### PR TITLE
Big code review

### DIFF
--- a/Games/Headless-Tests/src/Math/Tests/DefaultedCtor.cpp
+++ b/Games/Headless-Tests/src/Math/Tests/DefaultedCtor.cpp
@@ -11,21 +11,21 @@ namespace DefaultedCtor
         {
             const TRAP::Math::Vec2i a = TRAP::Math::Vec2i(76);
             TRAP::Math::Vec2i b;
-            std::memcpy(&b, &a, sizeof(TRAP::Math::Vec2i));
+            memcpy(&b, &a, sizeof(TRAP::Math::Vec2i));
             error += b == a ? 0 : 1;
         }
 
         {
             const TRAP::Math::Vec3i a = TRAP::Math::Vec3i(76);
             TRAP::Math::Vec3i b;
-            std::memcpy(&b, &a, sizeof(TRAP::Math::Vec3i));
+            memcpy(&b, &a, sizeof(TRAP::Math::Vec3i));
             error += b == a ? 0 : 1;
         }
 
         {
             const TRAP::Math::Vec4i a = TRAP::Math::Vec4i(76);
             TRAP::Math::Vec4i b;
-            std::memcpy(&b, &a, sizeof(TRAP::Math::Vec4i));
+            memcpy(&b, &a, sizeof(TRAP::Math::Vec4i));
             error += b == a ? 0 : 1;
         }
 
@@ -41,14 +41,14 @@ namespace DefaultedCtor
         {
             const TRAP::Math::Mat3 a = TRAP::Math::Mat3(76);
             TRAP::Math::Mat3 b;
-            std::memcpy(&b, &a, sizeof(TRAP::Math::Mat3));
+            memcpy(&b, &a, sizeof(TRAP::Math::Mat3));
             error += TRAP::Math::All(TRAP::Math::Equal(b, a, TRAP::Math::Epsilon<float>())) ? 0 : 1;
         }
 
         {
             const TRAP::Math::Mat4 a = TRAP::Math::Mat4(76);
             TRAP::Math::Mat4 b;
-            std::memcpy(&b, &a, sizeof(TRAP::Math::Mat4));
+            memcpy(&b, &a, sizeof(TRAP::Math::Mat4));
             error += TRAP::Math::All(TRAP::Math::Equal(b, a, TRAP::Math::Epsilon<float>())) ? 0 : 1;
         }
 
@@ -64,7 +64,7 @@ namespace DefaultedCtor
         {
             const TRAP::Math::Quat a = TRAP::Math::Quat(1, 0, 0, 0);
             TRAP::Math::Quat b;
-            std::memcpy(&b, &a, sizeof(TRAP::Math::Quat));
+            memcpy(&b, &a, sizeof(TRAP::Math::Quat));
             error += TRAP::Math::All(TRAP::Math::Equal(b, a, TRAP::Math::Epsilon<float>())) ? 0 : 1;
         }
 

--- a/Games/Tests/src/Controllers/ControllerTests.cpp
+++ b/Games/Tests/src/Controllers/ControllerTests.cpp
@@ -214,9 +214,9 @@ bool ControllerTests::OnWindowDrop(const TRAP::Events::WindowDropEvent& event)
 
 	for (const std::string_view path : paths)
 	{
-		std::string data = TRAP::FS::ReadTextFile(path);
-		if(!data.empty())
-			TRAP::Input::UpdateControllerMappings(data);
+		const auto data = TRAP::FS::ReadTextFile(path);
+		if(data)
+			TRAP::Input::UpdateControllerMappings(*data);
 	}
 
 	return true;

--- a/Games/Tests/src/Controllers/ControllerTests.cpp
+++ b/Games/Tests/src/Controllers/ControllerTests.cpp
@@ -214,7 +214,7 @@ bool ControllerTests::OnWindowDrop(const TRAP::Events::WindowDropEvent& event)
 
 	for (const std::string_view path : paths)
 	{
-		const auto data = TRAP::FS::ReadTextFile(path);
+		const auto data = TRAP::FileSystem::ReadTextFile(path);
 		if(data)
 			TRAP::Input::UpdateControllerMappings(*data);
 	}

--- a/Games/Tests/src/FileSystem/FileSystemTests.cpp
+++ b/Games/Tests/src/FileSystem/FileSystemTests.cpp
@@ -52,15 +52,15 @@ bool FileSystemTests::OnKeyPress(TRAP::Events::KeyPressEvent& event)
 		break;
 
 	case TRAP::Input::Key::O:
-		TRAP::FS::OpenFolderInFileBrowser(TRAP::FS::GetCurrentFolderPath());
+		TRAP::FileSystem::OpenFolderInFileBrowser(TRAP::FileSystem::GetCurrentFolderPath());
 		break;
 
 	case TRAP::Input::Key::F:
-		TRAP::FS::OpenFileInFileBrowser("Assets/Textures/vulkanlogo.png");
+		TRAP::FileSystem::OpenFileInFileBrowser("Assets/Textures/vulkanlogo.png");
 		break;
 
 	case TRAP::Input::Key::E:
-		TRAP::FS::OpenExternally("Assets/Textures/vulkanlogo.png");
+		TRAP::FileSystem::OpenExternally("Assets/Textures/vulkanlogo.png");
 		break;
 
 	default:

--- a/Games/Tests/src/FileSystem/FileSystemTests.cpp
+++ b/Games/Tests/src/FileSystem/FileSystemTests.cpp
@@ -52,8 +52,12 @@ bool FileSystemTests::OnKeyPress(TRAP::Events::KeyPressEvent& event)
 		break;
 
 	case TRAP::Input::Key::O:
-		TRAP::FileSystem::OpenFolderInFileBrowser(TRAP::FileSystem::GetCurrentFolderPath());
+	{
+		const auto currentFolder = TRAP::FileSystem::GetCurrentFolderPath();
+		if(currentFolder)
+			TRAP::FileSystem::OpenFolderInFileBrowser(*currentFolder);
 		break;
+	}
 
 	case TRAP::Input::Key::F:
 		TRAP::FileSystem::OpenFileInFileBrowser("Assets/Textures/vulkanlogo.png");

--- a/Games/TestsNetwork/src/FTP/FTPTests.cpp
+++ b/Games/TestsNetwork/src/FTP/FTPTests.cpp
@@ -90,7 +90,7 @@ void FTPTests::FTP()
 			//Print the current server directory
 			TRAP::Network::FTP::DirectoryResponse response = server.GetWorkingDirectory();
 			std::cout << "[Network][FTP] " << response << std::endl;
-			std::cout << "[Network][FTP] Current directory is " << response.GetDirectory().generic_u8string() << std::endl;
+			std::cout << "[Network][FTP] Current directory is " << response.GetDirectory().u8string() << std::endl;
 			break;
 		}
 
@@ -101,7 +101,7 @@ void FTPTests::FTP()
 			std::cout << "[Network][FTP] " << response << std::endl;
 			const std::vector<std::filesystem::path>& names = response.GetListing();
 			for (const std::filesystem::path& name : names)
-				std::cout << "[Network][FTP] " << name.generic_u8string() << std::endl;
+				std::cout << "[Network][FTP] " << name.u8string() << std::endl;
 			break;
 		}
 

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2914,3 +2914,4 @@ SITREP 07/16/2022|22w28b3
 SITREP 07/17/2022|22w28b4
     - Branch STL:
         - Replaced reinterpret_cast with Utils::BitCast in various files ~>15 mins
+        - Removed std:: from memcpy ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2917,3 +2917,4 @@ SITREP 07/17/2022|22w28b4
         - Removed std:: from memcpy ~<5 mins
         - Replaced memcpy with std::copy or std::copy_n ~>30 mins
         - Removed std:: from memset ~<5 mins
+        - Removed/Replaced memset where possible ~>15 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2927,3 +2927,7 @@ SITREP 07/18/2022|22w29a1
         - Renamed src/FS folder to src/FileSystem ~<5 mins
         - Replaced generic_u8string() with u8string() ~<10 mins
         - Utilize std::filesystem::file_size more ~<5 mins
+
+SITREP 07/19/2022|22w29a2
+    - Branch STL:
+        - Replaced const std::string& with const std::string_view where possible ~<15 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2915,3 +2915,4 @@ SITREP 07/17/2022|22w28b4
     - Branch STL:
         - Replaced reinterpret_cast with Utils::BitCast in various files ~>15 mins
         - Removed std:: from memcpy ~<5 mins
+        - Replaced memcpy with std::copy or std::copy_n ~>30 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2925,3 +2925,4 @@ SITREP 07/18/2022|22w29a1
         - Replaced TRAP::FS with TRAP::FileSystem ~<10 mins
         - Renamed FS.h/FS.cpp to FileSystem.h/FileSystem.cpp ~<5 mins
         - Renamed src/FS folder to src/FileSystem ~<5 mins
+        - Replaced generic_u8string() with u8string() ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2931,3 +2931,4 @@ SITREP 07/18/2022|22w29a1
 SITREP 07/19/2022|22w29a2
     - Branch STL:
         - Replaced const std::string& with const std::string_view where possible ~<15 mins
+        - Replaced const char* with const std::string_view where possible ~<20 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2852,7 +2852,7 @@ SITREP 07/14/2022|22w28b1
         - Events GetName() replaced const char* with std::string ~<15 mins
         - Events Made GetStaticType() constexpr ~<15 mins
         - EventDispatcher Made constructor and Dispatch() constexpr ~<5 mins
-        - EventCategory Made ^, ~, ^= operators constexpr ~<5 mins
+        - EventCategory Made operators constexpr ~<5 mins
         - FileChangeEvent FileStatusToString() now throws invalid_argument if enum value isn't valid ~<5 mins
         - Made some functions constexpr in
             - FileChangeEvent
@@ -2897,3 +2897,7 @@ SITREP 07/14/2022|22w28b1
         - Application Added fallback paths for engine.cfg and trap.log ~<5 mins
         - Updated Application ~<10 mins
         - Updated ControllerTests ~<5 mins
+
+SITREP 07/15/2022|22w28b2
+    - Branch STL:
+        - Replaced reinterpret_cast with static_cast where possible ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2844,3 +2844,56 @@ SITREP 07/12/2022|22w28a1
     - Base Added ENABLE_SINGLE_PROCESS_ONLY macro which makes the engine only run a single instance of itself ~<5 mins
         - Added error code 0x0012 "A TRAP Application is already running"
     - Application Implemented the checks for ENABLE_SINGLE_PROCESS_ONLY ~>20 mins
+
+SITREP 07/14/2022|22w28b1
+    - Changed TRAP Engine version to 22w28b1(0.8.12)
+    - Branch STL:
+        - Base Removed unnecessary static_casts ~<5 mins
+        - Events GetName() replaced const char* with std::string ~<15 mins
+        - Events Made GetStaticType() constexpr ~<15 mins
+        - EventDispatcher Made constructor and Dispatch() constexpr ~<5 mins
+        - EventCategory Made ^, ~, ^= operators constexpr ~<5 mins
+        - FileChangeEvent FileStatusToString() now throws invalid_argument if enum value isn't valid ~<5 mins
+        - Made some functions constexpr in
+            - FileChangeEvent
+            - TextureReloadEvent
+            - ShaderReloadEvent
+            - KeyEvent
+            - KeyPressEvent
+            - KeyReleaseEvent
+            - KeyTypeEvent
+            - MouseMoveEvent
+            - MouseScrollEvent
+            - MouseButtonEvent
+            - MouseButtonPressEvent
+            - MouseButtonReleaseEvent
+            - MouseEnterEvent
+            - MouseLeaveEvent
+            - WindowResizeEvent
+            - WindowMinimizeEvent
+            - WindowMaximizeEvent
+            - WindowRestoreEvent
+            - WindowCloseEvent
+            - WindowMoveEvent
+            - WindowFocusEvent
+            - WindowLostFocusEvent
+            - WindowDropEvent
+            - WindowContentScaleEvent
+            - FrameBufferResizeEvent
+        - FileSystem Made some functions constexpr ~<15 mins
+        - FileSystem Added std::optional to some functions ~<30 mins
+        - FileSystem Added GetGameLogFolderPath() function ~<5 mins
+        - FileWatcher unified WatchWindows() and WatchLinux into Watch() ~<10 mins
+        - FileWatcher Made m_run thread safe ~<5 mins
+        - FileWatcher Removed SkipNextFileChange() ~<5 mins
+        - Updated all files to support the aforementioned changes ~>45 mins
+        - VulkanRenderer replaced unordered_map inserts with try_emplace ~<10 mins
+        - ImGuiLayer Pipeline cache Added fallback path ~<5 mins
+        - Monitor::VideoMode Made constructor constexpr ~<5 mins
+        - Monitor Added rule of 5 ~<5 mins
+        - Monitor Made GetCurrentVideoMode(), IsInUse() and GetInternalMonitor() constexpr ~<5 mins
+        - AftermathTracker Replaced memcpy with std::copy_n ~<5 mins
+        - Application OnFileChange event now always returns false i.e. passes the event on to other callbacks ~<5 mins
+        - Application Added fallback paths for engine.cfg and trap.log ~<5 mins
+        - Updated Application ~<10 mins
+        - Updated ControllerTests ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2916,3 +2916,4 @@ SITREP 07/17/2022|22w28b4
         - Replaced reinterpret_cast with Utils::BitCast in various files ~>15 mins
         - Removed std:: from memcpy ~<5 mins
         - Replaced memcpy with std::copy or std::copy_n ~>30 mins
+        - Removed std:: from memset ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2926,3 +2926,4 @@ SITREP 07/18/2022|22w29a1
         - Renamed FS.h/FS.cpp to FileSystem.h/FileSystem.cpp ~<5 mins
         - Renamed src/FS folder to src/FileSystem ~<5 mins
         - Replaced generic_u8string() with u8string() ~<10 mins
+        - Utilize std::filesystem::file_size more ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2903,8 +2903,14 @@ SITREP 07/15/2022|22w28b2
         - Replaced reinterpret_cast with static_cast where possible ~<10 mins
 
 SITREP 07/16/2022|22w28b3
+    - Branch STL:
         - TRAP_Assert Removed type from macros ~<5 mins
         - TRAP_Assert Made path to file absolute ~<5 mins
         - Utils backported C++20s std::bitcast ~<10 mins
         - Application CheckSingleProcessLinux() now uses Utils::BitCast instead of reinterpret_cast ~<5 mins
         - Vulkan every VkSetObjectName() call now uses Utils::BitCast instead of reinterpret_cast ~<5 mins
+        - Renderer2D EndScene() Removed reinterpret_cast from vertex data size calculation ~<5 mins
+
+SITREP 07/17/2022|22w28b4
+    - Branch STL:
+        - Replaced reinterpret_cast with Utils::BitCast in various files ~>15 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2918,3 +2918,4 @@ SITREP 07/17/2022|22w28b4
         - Replaced memcpy with std::copy or std::copy_n ~>30 mins
         - Removed std:: from memset ~<5 mins
         - Removed/Replaced memset where possible ~>15 mins
+        - Replaced remaining memset calls with std::fill or std::fill_n ~<30 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2901,3 +2901,9 @@ SITREP 07/14/2022|22w28b1
 SITREP 07/15/2022|22w28b2
     - Branch STL:
         - Replaced reinterpret_cast with static_cast where possible ~<10 mins
+
+SITREP 07/16/2022|22w28b3
+        - TRAP_Assert Removed type from macros ~<5 mins
+        - TRAP_Assert Made path to file absolute ~<5 mins
+        - Utils backported C++20s std::bitcast ~<10 mins
+        - Application CheckSingleProcessLinux() now uses Utils::BitCast instead of reinterpret_cast ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2907,3 +2907,4 @@ SITREP 07/16/2022|22w28b3
         - TRAP_Assert Made path to file absolute ~<5 mins
         - Utils backported C++20s std::bitcast ~<10 mins
         - Application CheckSingleProcessLinux() now uses Utils::BitCast instead of reinterpret_cast ~<5 mins
+        - Vulkan every VkSetObjectName() call now uses Utils::BitCast instead of reinterpret_cast ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2919,3 +2919,9 @@ SITREP 07/17/2022|22w28b4
         - Removed std:: from memset ~<5 mins
         - Removed/Replaced memset where possible ~>15 mins
         - Replaced remaining memset calls with std::fill or std::fill_n ~<30 mins
+
+SITREP 07/18/2022|22w29a1
+    - Branch STL:
+        - Replaced TRAP::FS with TRAP::FileSystem ~<10 mins
+        - Renamed FS.h/FS.cpp to FileSystem.h/FileSystem.cpp ~<5 mins
+        - Renamed src/FS folder to src/FileSystem ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2932,3 +2932,5 @@ SITREP 07/19/2022|22w29a2
     - Branch STL:
         - Replaced const std::string& with const std::string_view where possible ~<15 mins
         - Replaced const char* with const std::string_view where possible ~<20 mins
+        - Removed String::FindToken() ~<5 mins
+        - Removed WindowingAPI::StringInExtensionString() ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -2934,3 +2934,12 @@ SITREP 07/19/2022|22w29a2
         - Replaced const char* with const std::string_view where possible ~<20 mins
         - Removed String::FindToken() ~<5 mins
         - Removed WindowingAPI::StringInExtensionString() ~<5 mins
+        - Removed std:: from getenv ~<5 mins
+
+SITREP 07/20/2022|22w29a3
+    - Branch STL:
+        - Checked for const correctness ~>240 mins
+        - Memory::SwapBytes() Added safety against const and non ref values ~<5 mins
+        - Moved Utils::GetStrError() to Utils::String::GetStrError() ~<5 mins
+        - Utils::String::ConvertToString() Added Utils::LinuxWindowManager overload ~<5 mins
+        - Utils::String::ConvertToType() Added Utils::LinuxWindowManager overload ~<5 mins

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -76,7 +76,8 @@ static bool CheckSingleProcessLinux()
 		if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 			TRAP::Utils::Memory::SwapBytes(name.sin_addr.s_addr);
 
-		rc = bind(socketFD, reinterpret_cast<sockaddr*>(&name), sizeof(name));
+		sockaddr convertedSock = TRAP::Utils::BitCast<sockaddr_in, sockaddr>(name); //Prevent usage of reinterpret_cast
+		rc = bind(socketFD, &convertedSock, sizeof(name));
 	}
 
 	return (socketFD != -1 && rc == 0);

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -2,8 +2,8 @@
 #include "Application.h"
 
 #include "Core/Base.h"
-#include "FS/FS.h"
-#include "FS/FileWatcher.h"
+#include "FileSystem/FileSystem.h"
+#include "FileSystem/FileWatcher.h"
 #include "Embed.h"
 #include "Graphics/RenderCommand.h"
 #include "Graphics/API/RendererAPI.h"
@@ -164,10 +164,10 @@ TRAP::Application::Application(std::string gameName)
 		exit(-1);
 	}
 
-	FS::Init();
+	FileSystem::Init();
 
 	//Set main log file path
-	const auto logFolder = FS::GetGameLogFolderPath();
+	const auto logFolder = FileSystem::GetGameLogFolderPath();
 	if(logFolder)
 		TRAP::TRAPLog.SetFilePath(*logFolder / "trap.log");
 	else //Fallback to current directory
@@ -175,7 +175,7 @@ TRAP::Application::Application(std::string gameName)
 
 	std::filesystem::path cfgPath = "engine.cfg";
 #ifndef TRAP_HEADLESS_MODE
-	const auto docsFolder = FS::GetGameDocumentsFolderPath();
+	const auto docsFolder = FileSystem::GetGameDocumentsFolderPath();
 	if(docsFolder)
 		cfgPath = *docsFolder / "engine.cfg";
 #endif
@@ -382,7 +382,7 @@ TRAP::Application::~Application()
 
 	std::filesystem::path cfgPath = "engine.cfg";
 #ifndef TRAP_HEADLESS_MODE
-	const auto docsFolder = FS::GetGameDocumentsFolderPath();
+	const auto docsFolder = FileSystem::GetGameDocumentsFolderPath();
 	if(docsFolder)
 		cfgPath = *docsFolder / "engine.cfg";
 #endif
@@ -401,7 +401,7 @@ TRAP::Application::~Application()
 		Graphics::RendererAPI::Shutdown();
 	}
 
-	FS::Shutdown();
+	FileSystem::Shutdown();
 
 	s_Instance = nullptr;
 
@@ -680,7 +680,7 @@ std::string TRAP::Application::GetGameName()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::FS::FileWatcher* TRAP::Application::GetHotReloadingFileWatcher()
+TRAP::FileSystem::FileWatcher* TRAP::Application::GetHotReloadingFileWatcher()
 {
 	if(s_Instance->m_hotReloadingFileWatcher)
 		return s_Instance->m_hotReloadingFileWatcher.get();
@@ -703,7 +703,7 @@ void TRAP::Application::SetHotReloading(const bool enable)
 
 	if(enable && !s_Instance->m_hotReloadingFileWatcher)
 	{
-		s_Instance->m_hotReloadingFileWatcher = std::make_unique<FS::FileWatcher>("", false);
+		s_Instance->m_hotReloadingFileWatcher = std::make_unique<FileSystem::FileWatcher>("", false);
 		s_Instance->m_hotReloadingFileWatcher->SetEventCallback([](Events::Event& e) {s_Instance->OnEvent(e); });
 	}
 	else if(s_Instance->m_hotReloadingFileWatcher)
@@ -855,10 +855,10 @@ void TRAP::Application::UpdateHotReloading()
 
 bool TRAP::Application::OnFileChangeEvent(const Events::FileChangeEvent& event)
 {
-	if(event.GetStatus() != FS::FileStatus::Modified)
+	if(event.GetStatus() != FileSystem::FileStatus::Modified)
 		return false; //Only handle modified files
 
-	const auto fileEnding = FS::GetFileEnding(event.GetPath());
+	const auto fileEnding = FileSystem::GetFileEnding(event.GetPath());
 	if(!fileEnding) //Ignore files without an extension
 		return false;
 
@@ -898,7 +898,7 @@ bool TRAP::Application::OnFileChangeEvent(const Events::FileChangeEvent& event)
 		//Don't add duplicates!
 		for(const auto& p : m_hotReloadingTexturePaths)
 		{
-			if(FS::IsPathEquivalent(p, event.GetPath()))
+			if(FileSystem::IsPathEquivalent(p, event.GetPath()))
 				return false;
 		}
 
@@ -911,7 +911,7 @@ bool TRAP::Application::OnFileChangeEvent(const Events::FileChangeEvent& event)
 		//Don't add duplicates!
 		for(const auto& p : m_hotReloadingShaderPaths)
 		{
-			if(FS::IsPathEquivalent(p, event.GetPath()))
+			if(FileSystem::IsPathEquivalent(p, event.GetPath()))
 				return false;
 		}
 

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -89,7 +89,7 @@ static bool CheckSingleProcessLinux()
 #if defined(ENABLE_SINGLE_PROCESS_ONLY) && defined(TRAP_PLATFORM_WINDOWS)
 static bool CheckSingleProcessWindows()
 {
-	HANDLE hMutex = CreateMutex(0, 0, L"TRAP-Engine");
+	const HANDLE hMutex = CreateMutex(0, 0, L"TRAP-Engine");
 	if(!hMutex) //Error creating mutex
 		return false;
 	if(hMutex && GetLastError() == ERROR_ALREADY_EXISTS)
@@ -294,8 +294,8 @@ TRAP::Application::Application(std::string gameName)
 	if(renderAPI != Graphics::RenderAPI::NONE)
 	{
 		//Set Anti aliasing
-		Graphics::AntiAliasing antiAliasing = m_config.Get<TRAP::Graphics::AntiAliasing>("AntiAliasing");
-		Graphics::SampleCount sampleCount = m_config.Get<TRAP::Graphics::SampleCount>("AntiAliasingQuality");
+		const Graphics::AntiAliasing antiAliasing = m_config.Get<TRAP::Graphics::AntiAliasing>("AntiAliasing");
+		const Graphics::SampleCount sampleCount = m_config.Get<TRAP::Graphics::SampleCount>("AntiAliasingQuality");
 		Graphics::RenderCommand::SetAntiAliasing(antiAliasing, sampleCount);
 
 		//Always added as a fallback shader
@@ -427,7 +427,7 @@ void TRAP::Application::Run()
 		if (!m_focused && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
 			nextFrame += std::chrono::milliseconds(1000 / 30); //30 FPS
 
-		Utils::Timer FrameTimeTimer;
+		const Utils::Timer FrameTimeTimer;
 		const float time = m_timer.Elapsed();
 		const Utils::TimeStep deltaTime{ (time - lastFrameTime) * m_timeScale };
 		lastFrameTime = time;
@@ -862,7 +862,7 @@ bool TRAP::Application::OnFileChangeEvent(const Events::FileChangeEvent& event)
 	if(!fileEnding) //Ignore files without an extension
 		return false;
 
-	std::string fEnding = Utils::String::ToLower(*fileEnding);
+	const std::string fEnding = Utils::String::ToLower(*fileEnding);
 
 	//Is it a texture?
 	bool texture = false;

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -299,8 +299,8 @@ TRAP::Application::Application(std::string gameName)
 		Graphics::RenderCommand::SetAntiAliasing(antiAliasing, sampleCount);
 
 		//Always added as a fallback shader
-		Graphics::ShaderManager::LoadSource("FallbackGraphics", Embed::FallbackGraphicsShader)->Use();
-		Graphics::ShaderManager::LoadSource("FallbackCompute", Embed::FallbackComputeShader)->Use();
+		Graphics::ShaderManager::LoadSource("FallbackGraphics", std::string(Embed::FallbackGraphicsShader))->Use();
+		Graphics::ShaderManager::LoadSource("FallbackCompute", std::string(Embed::FallbackComputeShader))->Use();
 
 		//Always added as a fallback texture
 		Graphics::TextureManager::Add(Graphics::Texture::CreateFallback2D());

--- a/TRAP/src/Application.h
+++ b/TRAP/src/Application.h
@@ -28,7 +28,7 @@ namespace TRAP
 		class FileChangeEvent;
 	}
 
-	namespace FS
+	namespace FileSystem
 	{
 		class FileWatcher;
 	}
@@ -173,8 +173,8 @@ namespace TRAP
 		/// <summary>
 		/// Get the hot reloading file watcher.
 		/// </summary>
-		/// <returns>TRAP::FS::FileWatcher* if file watcher is running, false otherwise.</returns>
-		static TRAP::FS::FileWatcher* GetHotReloadingFileWatcher();
+		/// <returns>TRAP::FileSystem::FileWatcher* if file watcher is running, false otherwise.</returns>
+		static TRAP::FileSystem::FileWatcher* GetHotReloadingFileWatcher();
 		/// <summary>
 		/// Get whether hot reloading is enabled or not.
 		/// </summary>
@@ -256,7 +256,7 @@ namespace TRAP
 		std::vector<std::filesystem::path> m_hotReloadingShaderPaths;
 		std::vector<std::filesystem::path> m_hotReloadingTexturePaths;
 		std::mutex m_hotReloadingMutex;
-		std::unique_ptr<FS::FileWatcher> m_hotReloadingFileWatcher;
+		std::unique_ptr<FileSystem::FileWatcher> m_hotReloadingFileWatcher;
 		bool m_hotReloadingEnabled;
 
 		std::unique_ptr<Window> m_window;

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -178,7 +178,6 @@ constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 12);
 #define TRAP_EXPAND_MACRO(x) x
 #define TRAP_STRINGIFY_MACRO(x) #x
 
-#include "TRAP_Assert.h"
 #include "Log/Log.h"
 
 /// <summary>

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -118,18 +118,18 @@ constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 12);
 
 #ifndef MAKE_ENUM_FLAG
 #define MAKE_ENUM_FLAG(ENUM_TYPE) \
-	static constexpr inline ENUM_TYPE operator|(ENUM_TYPE a, ENUM_TYPE b) \
+	static constexpr inline ENUM_TYPE operator|(const ENUM_TYPE a, const ENUM_TYPE b) \
 	{ \
 		return static_cast<ENUM_TYPE>(static_cast<std::underlying_type<ENUM_TYPE>::type>(a) | \
 		 							  static_cast<std::underlying_type<ENUM_TYPE>::type>(b)); \
 	} \
-	static constexpr inline ENUM_TYPE operator&(ENUM_TYPE a, ENUM_TYPE b) \
+	static constexpr inline ENUM_TYPE operator&(const ENUM_TYPE a, const ENUM_TYPE b) \
 	{ \
 		return static_cast<ENUM_TYPE>(static_cast<std::underlying_type<ENUM_TYPE>::type>(a) & \
 									  static_cast<std::underlying_type<ENUM_TYPE>::type>(b)); \
 	} \
-	static constexpr inline ENUM_TYPE operator|=(ENUM_TYPE& a, ENUM_TYPE b) { return a = (a | b); }\
-	static constexpr inline ENUM_TYPE operator&=(ENUM_TYPE& a, ENUM_TYPE b) { return a = (a & b); }
+	static constexpr inline ENUM_TYPE operator|=(ENUM_TYPE& a, const ENUM_TYPE b) { return a = (a | b); }\
+	static constexpr inline ENUM_TYPE operator&=(ENUM_TYPE& a, const ENUM_TYPE b) { return a = (a & b); }
 #endif
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -160,8 +160,7 @@ constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 12);
 		/// Note: Only works when TRAP_DEBUG or TRAP_RELWITHDEBINFO is set.
 		/// </summary>
 		constexpr void TRAP_DEBUG_BREAK()
-		{
-		}
+		{}
 	#endif
 #else
 		/// <summary>
@@ -169,8 +168,7 @@ constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 12);
 		/// Note: Only works when TRAP_DEBUG or TRAP_RELWITHDEBINFO is set.
 		/// </summary>
 		constexpr void TRAP_DEBUG_BREAK()
-		{
-		}
+		{}
 #endif
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -80,7 +80,7 @@ constexpr uint32_t TRAP_MAKE_VERSION(const uint32_t major, const uint32_t minor,
 /// <returns>Major version number.</returns>
 constexpr uint32_t TRAP_VERSION_MAJOR(const uint32_t version)
 {
-	return static_cast<uint32_t>(version) >> 22;
+	return version >> 22u;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -92,7 +92,7 @@ constexpr uint32_t TRAP_VERSION_MAJOR(const uint32_t version)
 /// <returns>Minor version number.</returns>
 constexpr uint32_t TRAP_VERSION_MINOR(const uint32_t version)
 {
-	return static_cast<uint32_t>(version) >> 12;
+	return version >> 12u;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -104,7 +104,7 @@ constexpr uint32_t TRAP_VERSION_MINOR(const uint32_t version)
 /// <returns>Patch version number.</returns>
 constexpr uint32_t TRAP_VERSION_PATCH(const uint32_t version)
 {
-	return static_cast<uint32_t>(version) & 0xFFF;
+	return version & 0xFFFu;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -112,7 +112,7 @@ constexpr uint32_t TRAP_VERSION_PATCH(const uint32_t version)
 /// <summary>
 /// TRAP version number created with TRAP_MAKE_VERSION
 /// </summary>
-constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 11);
+constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 12);
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -190,7 +190,7 @@ constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 11);
 template <typename T>
 constexpr T BIT(T x)
 {
-	return 1 << x;
+	return T(1) << x;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Embed.h
+++ b/TRAP/src/Embed.h
@@ -3,13 +3,14 @@
 
 #include <array>
 #include <cstdint>
+#include <string_view>
 
 namespace TRAP::Embed
 {
 	/// <summary>
 	/// Fallback Graphics shader
 	/// </summary>
-	inline static constexpr const char* FallbackGraphicsShader
+	inline static constexpr std::string_view FallbackGraphicsShader
 	{
 		R"(
 #shader vertex
@@ -43,7 +44,7 @@ namespace TRAP::Embed
 	/// <summary>
 	/// Fallback Compute shader
 	/// </summary>
-	inline static constexpr const char* FallbackComputeShader
+	inline static constexpr std::string_view FallbackComputeShader
 	{
 		R"(
 #shader compute
@@ -60,7 +61,7 @@ namespace TRAP::Embed
 	/// <summary>
 	/// 2D Renderer shader
 	/// </summary>
-	inline static constexpr const char* Renderer2DShader
+	inline static constexpr std::string_view Renderer2DShader
 	{
 		R"(
 #shader vertex

--- a/TRAP/src/Events/ControllerEvent.cpp
+++ b/TRAP/src/Events/ControllerEvent.cpp
@@ -1,13 +1,6 @@
 #include "TRAPPCH.h"
 #include "ControllerEvent.h"
 
-TRAP::Input::Controller TRAP::Events::ControllerEvent::GetController() const
-{
-	return m_controller;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Events::EventCategory TRAP::Events::ControllerEvent::GetCategoryFlags() const
 {
 	return EventCategory::Controller | EventCategory::Input;
@@ -17,8 +10,7 @@ TRAP::Events::EventCategory TRAP::Events::ControllerEvent::GetCategoryFlags() co
 
 TRAP::Events::ControllerEvent::ControllerEvent(const Input::Controller controller)
 	: m_controller(controller)
-{
-}
+{}
 
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
@@ -26,21 +18,13 @@ TRAP::Events::ControllerEvent::ControllerEvent(const Input::Controller controlle
 
 TRAP::Events::ControllerConnectEvent::ControllerConnectEvent(const Input::Controller controller)
 	: ControllerEvent(controller)
-{
-}
+{}
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 std::string TRAP::Events::ControllerConnectEvent::ToString() const
 {
 	return "ControllerConnectEvent: " + std::to_string(static_cast<uint32_t>(m_controller) + 1);
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::ControllerConnectEvent::GetStaticType()
-{
-	return EventType::ControllerConnect;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -52,7 +36,7 @@ TRAP::Events::EventType TRAP::Events::ControllerConnectEvent::GetEventType() con
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::ControllerConnectEvent::GetName() const
+std::string TRAP::Events::ControllerConnectEvent::GetName() const
 {
 	return "ControllerConnect";
 }
@@ -61,21 +45,13 @@ const char* TRAP::Events::ControllerConnectEvent::GetName() const
 
 TRAP::Events::ControllerDisconnectEvent::ControllerDisconnectEvent(const Input::Controller controller)
 	: ControllerEvent(controller)
-{
-}
+{}
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 std::string TRAP::Events::ControllerDisconnectEvent::ToString() const
 {
 	return "ControllerDisconnectEvent: " + std::to_string(static_cast<uint32_t>(m_controller) + 1);
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::ControllerDisconnectEvent::GetStaticType()
-{
-	return EventType::ControlledDisconnect;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -87,7 +63,7 @@ TRAP::Events::EventType TRAP::Events::ControllerDisconnectEvent::GetEventType() 
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::ControllerDisconnectEvent::GetName() const
+std::string TRAP::Events::ControllerDisconnectEvent::GetName() const
 {
 	return "ControllerDisconnect";
 }

--- a/TRAP/src/Events/ControllerEvent.cpp
+++ b/TRAP/src/Events/ControllerEvent.cpp
@@ -24,7 +24,7 @@ TRAP::Events::ControllerConnectEvent::ControllerConnectEvent(const Input::Contro
 
 std::string TRAP::Events::ControllerConnectEvent::ToString() const
 {
-	return "ControllerConnectEvent: " + std::to_string(static_cast<uint32_t>(m_controller) + 1);
+	return "ControllerConnectEvent: " + std::to_string(static_cast<uint32_t>(m_controller) + 1u);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -51,7 +51,7 @@ TRAP::Events::ControllerDisconnectEvent::ControllerDisconnectEvent(const Input::
 
 std::string TRAP::Events::ControllerDisconnectEvent::ToString() const
 {
-	return "ControllerDisconnectEvent: " + std::to_string(static_cast<uint32_t>(m_controller) + 1);
+	return "ControllerDisconnectEvent: " + std::to_string(static_cast<uint32_t>(m_controller) + 1u);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Events/ControllerEvent.h
+++ b/TRAP/src/Events/ControllerEvent.h
@@ -21,7 +21,7 @@ namespace TRAP::Events
 		/// Retrieve the affected controller.
 		/// </summary>
 		/// <returns>Controller.</returns>
-		Input::Controller GetController() const;
+		constexpr Input::Controller GetController() const;
 
 		/// <summary>
 		/// Retrieve the category flags of the event.
@@ -97,7 +97,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -107,7 +107,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 	};
 
 	/// <summary>
@@ -152,7 +152,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -162,8 +162,33 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 	};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Input::Controller TRAP::Events::ControllerEvent::GetController() const
+{
+	return m_controller;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::ControllerConnectEvent::GetStaticType()
+{
+	return EventType::ControllerConnect;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::ControllerDisconnectEvent::GetStaticType()
+{
+	return EventType::ControlledDisconnect;
 }
 
 #endif /*TRAP_CONTROLLEREVENT_H*/

--- a/TRAP/src/Events/Event.cpp
+++ b/TRAP/src/Events/Event.cpp
@@ -15,44 +15,7 @@ bool TRAP::Events::Event::IsInCategory(const EventCategory category) const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::EventDispatcher::EventDispatcher(Event& event)
-	: m_event(event)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::ostream& operator<<(std::ostream& os, const TRAP::Events::Event& e)
 {
 	return os << e.ToString();
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventCategory operator ^(TRAP::Events::EventCategory lhs, TRAP::Events::EventCategory rhs)
-{
-	return static_cast<TRAP::Events::EventCategory>
-		(
-			static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(lhs) ^
-			static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(rhs)
-		);
-}
-
-TRAP::Events::EventCategory operator ~(TRAP::Events::EventCategory rhs)
-{
-	return static_cast<TRAP::Events::EventCategory>
-		(
-			~static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(rhs)
-		);
-}
-
-TRAP::Events::EventCategory& operator ^=(TRAP::Events::EventCategory& lhs, TRAP::Events::EventCategory rhs)
-{
-	lhs = static_cast<TRAP::Events::EventCategory>
-		(
-			static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(lhs) ^
-			static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(rhs)
-		);
-
-	return lhs;
 }

--- a/TRAP/src/Events/Event.h
+++ b/TRAP/src/Events/Event.h
@@ -184,7 +184,8 @@ std::ostream& operator<<(std::ostream& os, const TRAP::Events::Event& e);
 
 MAKE_ENUM_FLAG(TRAP::Events::EventCategory)
 
-constexpr TRAP::Events::EventCategory operator ^(TRAP::Events::EventCategory lhs, TRAP::Events::EventCategory rhs)
+constexpr TRAP::Events::EventCategory operator ^(const TRAP::Events::EventCategory lhs,
+                                                 const TRAP::Events::EventCategory rhs)
 {
 	return static_cast<TRAP::Events::EventCategory>
 		(
@@ -192,14 +193,15 @@ constexpr TRAP::Events::EventCategory operator ^(TRAP::Events::EventCategory lhs
 			static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(rhs)
 		);
 }
-constexpr TRAP::Events::EventCategory operator ~(TRAP::Events::EventCategory rhs)
+constexpr TRAP::Events::EventCategory operator ~(const TRAP::Events::EventCategory rhs)
 {
 	return static_cast<TRAP::Events::EventCategory>
 		(
 			~static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(rhs)
 		);
 }
-constexpr TRAP::Events::EventCategory& operator ^=(TRAP::Events::EventCategory& lhs, TRAP::Events::EventCategory rhs)
+constexpr TRAP::Events::EventCategory& operator ^=(TRAP::Events::EventCategory& lhs,
+                                                   const TRAP::Events::EventCategory rhs)
 {
 	lhs = static_cast<TRAP::Events::EventCategory>
 		(

--- a/TRAP/src/Events/Event.h
+++ b/TRAP/src/Events/Event.h
@@ -97,7 +97,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		virtual const char* GetName() const = 0;
+		virtual std::string GetName() const = 0;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -122,7 +122,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="event">Event to dispatch.</param>
-		explicit EventDispatcher(Event& event);
+		explicit constexpr EventDispatcher(Event& event);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -152,31 +152,62 @@ namespace TRAP::Events
 		/// <param name="func">Function to call.</param>
 		/// <returns>True if the received event matches the event to dispatch, false otherwise.</returns>
 		template<typename T, typename F>
-		bool Dispatch(const F& func);
+		constexpr bool Dispatch(const F& func);
 
 	private:
 		Event& m_event;
 	};
-
-	template <typename T, typename F>
-	bool EventDispatcher::Dispatch(const F& func)
-	{
-		if (m_event.GetEventType() != T::GetStaticType() || m_event.Handled)
-			return false;
-
-		m_event.Handled = func(static_cast<T&>(m_event));
-
-		return true;
-	}
-
 }
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventDispatcher::EventDispatcher(Event& event)
+	: m_event(event)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+template <typename T, typename F>
+constexpr bool TRAP::Events::EventDispatcher::Dispatch(const F& func)
+{
+	if (m_event.GetEventType() != T::GetStaticType() || m_event.Handled)
+		return false;
+
+	m_event.Handled = func(static_cast<T&>(m_event));
+
+	return true;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
 
 std::ostream& operator<<(std::ostream& os, const TRAP::Events::Event& e);
 
 MAKE_ENUM_FLAG(TRAP::Events::EventCategory)
 
-TRAP::Events::EventCategory operator ^(TRAP::Events::EventCategory lhs, TRAP::Events::EventCategory rhs);
-TRAP::Events::EventCategory operator ~(TRAP::Events::EventCategory rhs);
-TRAP::Events::EventCategory& operator ^=(TRAP::Events::EventCategory& lhs, TRAP::Events::EventCategory rhs);
+constexpr TRAP::Events::EventCategory operator ^(TRAP::Events::EventCategory lhs, TRAP::Events::EventCategory rhs)
+{
+	return static_cast<TRAP::Events::EventCategory>
+		(
+			static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(lhs) ^
+			static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(rhs)
+		);
+}
+constexpr TRAP::Events::EventCategory operator ~(TRAP::Events::EventCategory rhs)
+{
+	return static_cast<TRAP::Events::EventCategory>
+		(
+			~static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(rhs)
+		);
+}
+constexpr TRAP::Events::EventCategory& operator ^=(TRAP::Events::EventCategory& lhs, TRAP::Events::EventCategory rhs)
+{
+	lhs = static_cast<TRAP::Events::EventCategory>
+		(
+			static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(lhs) ^
+			static_cast<std::underlying_type<TRAP::Events::EventCategory>::type>(rhs)
+		);
+
+	return lhs;
+}
 
 #endif /*TRAP_EVENT_H*/

--- a/TRAP/src/Events/FileEvent.cpp
+++ b/TRAP/src/Events/FileEvent.cpp
@@ -27,8 +27,8 @@ std::filesystem::path TRAP::Events::FileChangeEvent::GetOldName() const
 
 std::string TRAP::Events::FileChangeEvent::ToString() const
 {
-    return "FileChangeEvent: Path: " + m_path.generic_u8string() + " Status: " +
-           FileStatusToString(m_status) + (m_oldName.empty() ? "" : " OldName: " + m_oldName.generic_u8string());
+    return "FileChangeEvent: Path: " + m_path.u8string() + " Status: " +
+           FileStatusToString(m_status) + (m_oldName.empty() ? "" : " OldName: " + m_oldName.u8string());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Events/FileEvent.cpp
+++ b/TRAP/src/Events/FileEvent.cpp
@@ -1,10 +1,10 @@
 #include "TRAPPCH.h"
 #include "FileEvent.h"
 
-#include "FS/FileWatcher.h"
+#include "FileSystem/FileWatcher.h"
 #include <stdexcept>
 
-TRAP::Events::FileChangeEvent::FileChangeEvent(TRAP::FS::FileStatus status, std::filesystem::path path,
+TRAP::Events::FileChangeEvent::FileChangeEvent(TRAP::FileSystem::FileStatus status, std::filesystem::path path,
                                                std::filesystem::path oldName)
     : m_status(status), m_path(std::move(path)), m_oldName(std::move(oldName))
 {}
@@ -54,23 +54,23 @@ TRAP::Events::EventCategory TRAP::Events::FileChangeEvent::GetCategoryFlags() co
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::string TRAP::Events::FileChangeEvent::FileStatusToString(TRAP::FS::FileStatus status)
+std::string TRAP::Events::FileChangeEvent::FileStatusToString(TRAP::FileSystem::FileStatus status)
 {
     switch(status)
     {
-    case TRAP::FS::FileStatus::Created:
+    case TRAP::FileSystem::FileStatus::Created:
         return "Created";
 
-    case TRAP::FS::FileStatus::Renamed:
+    case TRAP::FileSystem::FileStatus::Renamed:
         return "Renamed";
 
-    case TRAP::FS::FileStatus::Modified:
+    case TRAP::FileSystem::FileStatus::Modified:
         return "Modified";
 
-    case TRAP::FS::FileStatus::Erased:
+    case TRAP::FileSystem::FileStatus::Erased:
         return "Erased";
 
     default:
-        throw std::invalid_argument("Unimplemented enum->string value for TRAP::FS::FileStatus");
+        throw std::invalid_argument("Unimplemented enum->string value for TRAP::FileSystem::FileStatus");
     }
 }

--- a/TRAP/src/Events/FileEvent.cpp
+++ b/TRAP/src/Events/FileEvent.cpp
@@ -2,19 +2,12 @@
 #include "FileEvent.h"
 
 #include "FS/FileWatcher.h"
+#include <stdexcept>
 
 TRAP::Events::FileChangeEvent::FileChangeEvent(TRAP::FS::FileStatus status, std::filesystem::path path,
                                                std::filesystem::path oldName)
     : m_status(status), m_path(std::move(path)), m_oldName(std::move(oldName))
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::FS::FileStatus TRAP::Events::FileChangeEvent::GetStatus() const
-{
-    return m_status;
-}
+{}
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -40,13 +33,6 @@ std::string TRAP::Events::FileChangeEvent::ToString() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::EventType TRAP::Events::FileChangeEvent::GetStaticType()
-{
-	return EventType::FileChange;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Events::EventType TRAP::Events::FileChangeEvent::GetEventType() const
 {
 	return GetStaticType();
@@ -54,7 +40,7 @@ TRAP::Events::EventType TRAP::Events::FileChangeEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::FileChangeEvent::GetName() const
+std::string TRAP::Events::FileChangeEvent::GetName() const
 {
 	return "FileChange";
 }
@@ -85,6 +71,6 @@ std::string TRAP::Events::FileChangeEvent::FileStatusToString(TRAP::FS::FileStat
         return "Erased";
 
     default:
-        return "";
+        throw std::invalid_argument("Unimplemented enum->string value for TRAP::FS::FileStatus");
     }
 }

--- a/TRAP/src/Events/FileEvent.cpp
+++ b/TRAP/src/Events/FileEvent.cpp
@@ -54,7 +54,7 @@ TRAP::Events::EventCategory TRAP::Events::FileChangeEvent::GetCategoryFlags() co
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::string TRAP::Events::FileChangeEvent::FileStatusToString(TRAP::FileSystem::FileStatus status)
+std::string TRAP::Events::FileChangeEvent::FileStatusToString(const TRAP::FileSystem::FileStatus status)
 {
     switch(status)
     {

--- a/TRAP/src/Events/FileEvent.h
+++ b/TRAP/src/Events/FileEvent.h
@@ -2,7 +2,7 @@
 #define TRAP_FILEEVENT_H
 
 #include "Event.h"
-#include "FS/FileWatcher.h"
+#include "FileSystem/FileWatcher.h"
 
 namespace TRAP::Events
 {
@@ -18,7 +18,7 @@ namespace TRAP::Events
         /// <param name="status">Status of the provided file or folder.</param>
         /// <param name="path">Path to a file or folder.</param>
         /// <param name="oldName">Old name of the file or folder. Only if FileStatus::Renamed.</param>
-		FileChangeEvent(TRAP::FS::FileStatus status, std::filesystem::path path,
+		FileChangeEvent(TRAP::FileSystem::FileStatus status, std::filesystem::path path,
                         std::filesystem::path oldName = "");
 		/// <summary>
 		/// Destructor.
@@ -45,7 +45,7 @@ namespace TRAP::Events
         /// Get the status of the file.
         /// </summary>
         /// <returns>The status of the file.</returns>
-        constexpr TRAP::FS::FileStatus GetStatus() const;
+        constexpr TRAP::FileSystem::FileStatus GetStatus() const;
         /// <summary>
         /// Get the path of the file.
         /// </summary>
@@ -87,13 +87,13 @@ namespace TRAP::Events
 
 	private:
 		/// <summary>
-		/// Convert TRAP::FS::FileStatus to string.
+		/// Convert TRAP::FileSystem::FileStatus to string.
 		/// </summary>
 		/// <param name="status">File status.</param>
 		/// <returns>File status as string.</returns>
-        static std::string FileStatusToString(TRAP::FS::FileStatus status);
+        static std::string FileStatusToString(TRAP::FileSystem::FileStatus status);
 
-        TRAP::FS::FileStatus m_status;
+        TRAP::FileSystem::FileStatus m_status;
         std::filesystem::path m_path;
         std::filesystem::path m_oldName;
 	};
@@ -101,7 +101,7 @@ namespace TRAP::Events
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr TRAP::FS::FileStatus TRAP::Events::FileChangeEvent::GetStatus() const
+constexpr TRAP::FileSystem::FileStatus TRAP::Events::FileChangeEvent::GetStatus() const
 {
 	return m_status;
 }

--- a/TRAP/src/Events/FileEvent.h
+++ b/TRAP/src/Events/FileEvent.h
@@ -45,7 +45,7 @@ namespace TRAP::Events
         /// Get the status of the file.
         /// </summary>
         /// <returns>The status of the file.</returns>
-        TRAP::FS::FileStatus GetStatus() const;
+        constexpr TRAP::FS::FileStatus GetStatus() const;
         /// <summary>
         /// Get the path of the file.
         /// </summary>
@@ -68,7 +68,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -78,7 +78,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -97,6 +97,20 @@ namespace TRAP::Events
         std::filesystem::path m_path;
         std::filesystem::path m_oldName;
 	};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::FS::FileStatus TRAP::Events::FileChangeEvent::GetStatus() const
+{
+	return m_status;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::FileChangeEvent::GetStaticType()
+{
+	return EventType::FileChange;
 }
 
 #endif /*TRAP_FILEEVENT_H*/

--- a/TRAP/src/Events/HotReloadEvent.cpp
+++ b/TRAP/src/Events/HotReloadEvent.cpp
@@ -4,30 +4,9 @@
 #include "Graphics/Textures/Texture.h"
 #include "Graphics/Shaders/Shader.h"
 
-TRAP::Events::TextureReloadEvent::TextureReloadEvent(TRAP::Graphics::Texture* texture)
-    : m_texture(texture)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Graphics::Texture* TRAP::Events::TextureReloadEvent::GetTexture() const
-{
-    return m_texture;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::TextureReloadEvent::ToString() const
 {
     return "TextureReloadEvent: " + m_texture->GetName();
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::TextureReloadEvent::GetStaticType()
-{
-	return EventType::TextureReload;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -39,7 +18,7 @@ TRAP::Events::EventType TRAP::Events::TextureReloadEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::TextureReloadEvent::GetName() const
+std::string TRAP::Events::TextureReloadEvent::GetName() const
 {
 	return "TextureReload";
 }
@@ -55,30 +34,9 @@ TRAP::Events::EventCategory TRAP::Events::TextureReloadEvent::GetCategoryFlags()
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::ShaderReloadEvent::ShaderReloadEvent(TRAP::Graphics::Shader* shader)
-    : m_shader(shader)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Graphics::Shader* TRAP::Events::ShaderReloadEvent::GetShader() const
-{
-    return m_shader;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::ShaderReloadEvent::ToString() const
 {
     return "ShaderReloadEvent: " + m_shader->GetName();
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::ShaderReloadEvent::GetStaticType()
-{
-	return EventType::ShaderReload;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -90,7 +48,7 @@ TRAP::Events::EventType TRAP::Events::ShaderReloadEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::ShaderReloadEvent::GetName() const
+std::string TRAP::Events::ShaderReloadEvent::GetName() const
 {
 	return "ShaderReload";
 }

--- a/TRAP/src/Events/HotReloadEvent.h
+++ b/TRAP/src/Events/HotReloadEvent.h
@@ -21,7 +21,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="texture">Pointer to the affected texture.</param>
-		TextureReloadEvent(TRAP::Graphics::Texture* texture);
+		constexpr TextureReloadEvent(TRAP::Graphics::Texture* texture);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -47,7 +47,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected texture.
 		/// </summary>
 		/// <returns>Texture pointer.</returns>
-		TRAP::Graphics::Texture* GetTexture() const;
+		constexpr TRAP::Graphics::Texture* GetTexture() const;
 
 		/// <summary>
 		/// Get a string representation of the TextureReloadEvent.
@@ -59,7 +59,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -69,7 +69,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -90,7 +90,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="shader">Pointer to the affected shader.</param>
-		ShaderReloadEvent(TRAP::Graphics::Shader* shader);
+		constexpr ShaderReloadEvent(TRAP::Graphics::Shader* shader);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -116,7 +116,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected shader.
 		/// </summary>
 		/// <returns>Shader pointer.</returns>
-		TRAP::Graphics::Shader* GetShader() const;
+		constexpr TRAP::Graphics::Shader* GetShader() const;
 
 		/// <summary>
 		/// Get a string representation of the ShaderReloadEvent.
@@ -128,7 +128,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -138,7 +138,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -148,6 +148,48 @@ namespace TRAP::Events
 	private:
         TRAP::Graphics::Shader* m_shader;
 	};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::TextureReloadEvent::TextureReloadEvent(TRAP::Graphics::Texture* texture)
+	: m_texture(texture)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Graphics::Texture* TRAP::Events::TextureReloadEvent::GetTexture() const
+{
+	return m_texture;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::TextureReloadEvent::GetStaticType()
+{
+	return EventType::TextureReload;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::ShaderReloadEvent::ShaderReloadEvent(TRAP::Graphics::Shader* shader)
+    : m_shader(shader)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Graphics::Shader* TRAP::Events::ShaderReloadEvent::GetShader() const
+{
+    return m_shader;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::ShaderReloadEvent::GetStaticType()
+{
+	return EventType::ShaderReload;
 }
 
 #endif /*TRAP_HOTRELOADEVENT_H*/

--- a/TRAP/src/Events/KeyEvent.cpp
+++ b/TRAP/src/Events/KeyEvent.cpp
@@ -3,63 +3,21 @@
 
 #include "Window/WindowingAPI.h"
 
-TRAP::Input::Key TRAP::Events::KeyEvent::GetKey() const
-{
-	return m_key;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Events::EventCategory TRAP::Events::KeyEvent::GetCategoryFlags() const
 {
 	return EventCategory::Keyboard | EventCategory::Input;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::KeyEvent::KeyEvent(const Input::Key key)
-	: m_key(key)
-{
-}
-
 //-------------------------------------------------------------------------------------------------------------------//
-//-------------------------------------------------------------------------------------------------------------------//
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::KeyPressEvent::KeyPressEvent(const Input::Key key, const uint32_t repeatCount, TRAP::Window* window)
-	: KeyEvent(key), m_repeatCount(repeatCount), m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-uint32_t TRAP::Events::KeyPressEvent::GetRepeatCount() const
-{
-	return m_repeatCount;
-}
-
 //-------------------------------------------------------------------------------------------------------------------//
 
 std::string TRAP::Events::KeyPressEvent::ToString() const
 {
-	std::string name = TRAP::Input::GetKeyName(m_key);
+	const std::string name = TRAP::Input::GetKeyName(m_key);
 
 	return "KeyPressEvent: " + name + "(" + std::to_string(static_cast<int32_t>(m_key)) + ") (" +
 	       std::to_string(m_repeatCount) + " repeats)";
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::KeyPressEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::KeyPressEvent::GetStaticType()
-{
-	return EventType::KeyPress;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -71,20 +29,13 @@ TRAP::Events::EventType TRAP::Events::KeyPressEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::KeyPressEvent::GetName() const
+std::string TRAP::Events::KeyPressEvent::GetName() const
 {
 	return "KeyPress";
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::KeyReleaseEvent::KeyReleaseEvent(const Input::Key key, TRAP::Window* window)
-	: KeyEvent(key), m_window(window)
-{
-}
-
 //-------------------------------------------------------------------------------------------------------------------//
 
 std::string TRAP::Events::KeyReleaseEvent::ToString() const
@@ -96,20 +47,6 @@ std::string TRAP::Events::KeyReleaseEvent::ToString() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Window* TRAP::Events::KeyReleaseEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::KeyReleaseEvent::GetStaticType()
-{
-	return EventType::KeyRelease;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Events::EventType TRAP::Events::KeyReleaseEvent::GetEventType() const
 {
 	return GetStaticType();
@@ -117,7 +54,7 @@ TRAP::Events::EventType TRAP::Events::KeyReleaseEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::KeyReleaseEvent::GetName() const
+std::string TRAP::Events::KeyReleaseEvent::GetName() const
 {
 	return "KeyRelease";
 }
@@ -126,37 +63,9 @@ const char* TRAP::Events::KeyReleaseEvent::GetName() const
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::KeyTypeEvent::KeyTypeEvent(const uint32_t codePoint, TRAP::Window* window)
-	: m_window(window), m_codePoint(codePoint)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::KeyTypeEvent::ToString() const
 {
 	return "KeyTypeEvent: " + EncodeUTF8(m_codePoint) + "(" + std::to_string(m_codePoint) + ")";
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::KeyTypeEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-uint32_t TRAP::Events::KeyTypeEvent::GetCodePoint() const
-{
-	return m_codePoint;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::KeyTypeEvent::GetStaticType()
-{
-	return EventType::KeyType;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -168,7 +77,7 @@ TRAP::Events::EventType TRAP::Events::KeyTypeEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::KeyTypeEvent::GetName() const
+std::string TRAP::Events::KeyTypeEvent::GetName() const
 {
 	return "KeyType";
 }
@@ -185,6 +94,7 @@ TRAP::Events::EventCategory TRAP::Events::KeyTypeEvent::GetCategoryFlags() const
 std::string TRAP::Events::KeyTypeEvent::EncodeUTF8(const uint32_t codePoint)
 {
 	std::string result{};
+	result.reserve(4);
 
 	if (codePoint < 0x80)
 		result.push_back(static_cast<char>(codePoint));
@@ -214,8 +124,7 @@ std::string TRAP::Events::KeyTypeEvent::EncodeUTF8(const uint32_t codePoint)
 
 TRAP::Events::KeyLayoutEvent::KeyLayoutEvent(std::string layout)
 	: m_layout(std::move(layout))
-{
-}
+{}
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -233,13 +142,6 @@ std::string TRAP::Events::KeyLayoutEvent::ToString() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::EventType TRAP::Events::KeyLayoutEvent::GetStaticType()
-{
-	return EventType::KeyLayout;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Events::EventType TRAP::Events::KeyLayoutEvent::GetEventType() const
 {
 	return GetStaticType();
@@ -247,7 +149,7 @@ TRAP::Events::EventType TRAP::Events::KeyLayoutEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::KeyLayoutEvent::GetName() const
+std::string TRAP::Events::KeyLayoutEvent::GetName() const
 {
 	return "KeyLayout";
 }

--- a/TRAP/src/Events/KeyEvent.cpp
+++ b/TRAP/src/Events/KeyEvent.cpp
@@ -128,7 +128,7 @@ TRAP::Events::KeyLayoutEvent::KeyLayoutEvent(std::string layout)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Events::KeyLayoutEvent::GetLayout() const
+std::string TRAP::Events::KeyLayoutEvent::GetLayout() const
 {
 	return m_layout;
 }

--- a/TRAP/src/Events/KeyEvent.cpp
+++ b/TRAP/src/Events/KeyEvent.cpp
@@ -40,7 +40,7 @@ std::string TRAP::Events::KeyPressEvent::GetName() const
 
 std::string TRAP::Events::KeyReleaseEvent::ToString() const
 {
-	std::string name = TRAP::Input::GetKeyName(m_key);
+	const std::string name = TRAP::Input::GetKeyName(m_key);
 
 	return "KeyReleaseEvent: " + name + "(" + std::to_string(static_cast<int32_t>(m_key)) + ")";
 }

--- a/TRAP/src/Events/KeyEvent.h
+++ b/TRAP/src/Events/KeyEvent.h
@@ -21,7 +21,7 @@ namespace TRAP::Events
 		/// Retrieve the affected key.
 		/// </summary>
 		/// <returns>Key.</returns>
-		Input::Key GetKey() const;
+		constexpr Input::Key GetKey() const;
 
 		/// <summary>
 		/// Retrieve the category flags of the event.
@@ -34,7 +34,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="key">Affected key.</param>
-		explicit KeyEvent(Input::Key key);
+		explicit constexpr KeyEvent(Input::Key key);
 		/// <summary>
 		/// Copy constructor.
 		/// </summary>
@@ -67,7 +67,7 @@ namespace TRAP::Events
 		/// <param name="key">Pressed key.</param>
 		/// <param name="repeatCount">Amount of key press repeats.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		KeyPressEvent(Input::Key key, uint32_t repeatCount, TRAP::Window* window);
+		constexpr KeyPressEvent(Input::Key key, uint32_t repeatCount, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -93,12 +93,12 @@ namespace TRAP::Events
 		/// Retrieve tha amount of key press repeats.
 		/// </summary>
 		/// <returns>Repeat count.</returns>
-		uint32_t GetRepeatCount() const;
+		constexpr uint32_t GetRepeatCount() const;
 		/// <summary>
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the KeyPressEvent.
@@ -110,7 +110,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -120,7 +120,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 
 	private:
 		uint32_t m_repeatCount;
@@ -138,7 +138,7 @@ namespace TRAP::Events
 		/// </summary>
 		/// <param name="key">Released key.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit KeyReleaseEvent(Input::Key key, TRAP::Window* window);
+		explicit constexpr KeyReleaseEvent(Input::Key key, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -164,7 +164,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the KeyReleaseEvent.
@@ -176,7 +176,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -186,7 +186,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 
 	private:
 		TRAP::Window* m_window;
@@ -203,7 +203,7 @@ namespace TRAP::Events
 		/// </summary>
 		/// <param name="codePoint">Unicode code point entered.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit KeyTypeEvent(uint32_t codePoint, TRAP::Window* window);
+		explicit constexpr KeyTypeEvent(uint32_t codePoint, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -229,12 +229,12 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 		/// <summary>
 		/// Retrieve the entered Unicode code point.
 		/// </summary>
 		/// <returns>Unicode code point.</returns>
-		uint32_t GetCodePoint() const;
+		constexpr uint32_t GetCodePoint() const;
 
 		/// <summary>
 		/// Get a string representation of the KeyTypeEvent.
@@ -246,7 +246,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -256,7 +256,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -323,7 +323,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -333,7 +333,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -343,6 +343,107 @@ namespace TRAP::Events
 	private:
 		std::string m_layout;
 	};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Input::Key TRAP::Events::KeyEvent::GetKey() const
+{
+	return m_key;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::KeyEvent::KeyEvent(const Input::Key key)
+	: m_key(key)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::KeyPressEvent::KeyPressEvent(const Input::Key key, const uint32_t repeatCount,
+                                                     TRAP::Window* window)
+	: KeyEvent(key), m_repeatCount(repeatCount), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr uint32_t TRAP::Events::KeyPressEvent::GetRepeatCount() const
+{
+	return m_repeatCount;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::KeyPressEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::KeyPressEvent::GetStaticType()
+{
+	return EventType::KeyPress;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::KeyReleaseEvent::KeyReleaseEvent(const Input::Key key, TRAP::Window* window)
+	: KeyEvent(key), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::KeyReleaseEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::KeyReleaseEvent::GetStaticType()
+{
+	return EventType::KeyRelease;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::KeyTypeEvent::KeyTypeEvent(const uint32_t codePoint, TRAP::Window* window)
+	: m_window(window), m_codePoint(codePoint)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::KeyTypeEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr uint32_t TRAP::Events::KeyTypeEvent::GetCodePoint() const
+{
+	return m_codePoint;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::KeyTypeEvent::GetStaticType()
+{
+	return EventType::KeyType;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::KeyLayoutEvent::GetStaticType()
+{
+	return EventType::KeyLayout;
 }
 
 #endif /*TRAP_KEYEVENT_H*/

--- a/TRAP/src/Events/KeyEvent.h
+++ b/TRAP/src/Events/KeyEvent.h
@@ -311,7 +311,7 @@ namespace TRAP::Events
 		/// Retrieve the human-readable name of the new keyboard layout.
 		/// </summary>
 		/// <returns>Name of new keyboard layout.</returns>
-		const std::string& GetLayout() const;
+		std::string GetLayout() const;
 
 		/// <summary>
 		/// Get a string representation of the KeyLayoutEvent.

--- a/TRAP/src/Events/MonitorEvent.cpp
+++ b/TRAP/src/Events/MonitorEvent.cpp
@@ -15,10 +15,9 @@ TRAP::Events::EventCategory TRAP::Events::MonitorEvent::GetCategoryFlags() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::MonitorEvent::MonitorEvent(const Monitor monitor)
-	: m_monitor(monitor)
-{
-}
+TRAP::Events::MonitorEvent::MonitorEvent(Monitor monitor)
+	: m_monitor(std::move(monitor))
+{}
 
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
@@ -26,21 +25,13 @@ TRAP::Events::MonitorEvent::MonitorEvent(const Monitor monitor)
 
 TRAP::Events::MonitorConnectEvent::MonitorConnectEvent(const Monitor monitor)
 	: MonitorEvent(monitor)
-{
-}
+{}
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 std::string TRAP::Events::MonitorConnectEvent::ToString() const
 {
 	return "MonitorConnectEvent: " + m_monitor.GetName() + " (" + std::to_string(m_monitor.GetID()) + ')';
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::MonitorConnectEvent::GetStaticType()
-{
-	return EventType::MonitorConnect;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -52,7 +43,7 @@ TRAP::Events::EventType TRAP::Events::MonitorConnectEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::MonitorConnectEvent::GetName() const
+std::string TRAP::Events::MonitorConnectEvent::GetName() const
 {
 	return "MonitorConnect";
 }
@@ -61,21 +52,13 @@ const char* TRAP::Events::MonitorConnectEvent::GetName() const
 
 TRAP::Events::MonitorDisconnectEvent::MonitorDisconnectEvent(const Monitor monitor)
 	: MonitorEvent(monitor)
-{
-}
+{}
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 std::string TRAP::Events::MonitorDisconnectEvent::ToString() const
 {
 	return "MonitorDisconnectEvent: " + m_monitor.GetName() + " (" + std::to_string(m_monitor.GetID()) + ')';
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::MonitorDisconnectEvent::GetStaticType()
-{
-	return EventType::MonitorDisconnect;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -87,7 +70,7 @@ TRAP::Events::EventType TRAP::Events::MonitorDisconnectEvent::GetEventType() con
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::MonitorDisconnectEvent::GetName() const
+std::string TRAP::Events::MonitorDisconnectEvent::GetName() const
 {
 	return "MonitorDisconnect";
 }

--- a/TRAP/src/Events/MonitorEvent.h
+++ b/TRAP/src/Events/MonitorEvent.h
@@ -97,7 +97,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -107,7 +107,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 	};
 
 	/// <summary>
@@ -152,7 +152,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -162,8 +162,24 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 	};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::MonitorConnectEvent::GetStaticType()
+{
+	return EventType::MonitorConnect;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::MonitorDisconnectEvent::GetStaticType()
+{
+	return EventType::MonitorDisconnect;
 }
 
 #endif /*TRAP_MONITOREVENT_H*/

--- a/TRAP/src/Events/MouseEvent.cpp
+++ b/TRAP/src/Events/MouseEvent.cpp
@@ -1,51 +1,9 @@
 #include "TRAPPCH.h"
 #include "MouseEvent.h"
 
-TRAP::Events::MouseMoveEvent::MouseMoveEvent(const float x, const float y, TRAP::Window* window)
-	: m_mouseX(x), m_mouseY(y), m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-float TRAP::Events::MouseMoveEvent::GetX() const
-{
-	return m_mouseX;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-float TRAP::Events::MouseMoveEvent::GetY() const
-{
-	return m_mouseY;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Math::Vec2 TRAP::Events::MouseMoveEvent::GetPosition() const
-{
-	return { m_mouseX, m_mouseY };
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::MouseMoveEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::MouseMoveEvent::ToString() const
 {
 	return "MouseMoveEvent: " + std::to_string(m_mouseX) + ", " + std::to_string(m_mouseY);
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::MouseMoveEvent::GetStaticType()
-{
-	return EventType::MouseMove;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -57,7 +15,7 @@ TRAP::Events::EventType TRAP::Events::MouseMoveEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::MouseMoveEvent::GetName() const
+std::string TRAP::Events::MouseMoveEvent::GetName() const
 {
 	return "MouseMove";
 }
@@ -73,51 +31,9 @@ TRAP::Events::EventCategory TRAP::Events::MouseMoveEvent::GetCategoryFlags() con
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::MouseScrollEvent::MouseScrollEvent(const float xOffset, const float yOffset, TRAP::Window* window)
-	: m_xOffset(xOffset), m_yOffset(yOffset), m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-float TRAP::Events::MouseScrollEvent::GetXOffset() const
-{
-	return m_xOffset;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-float TRAP::Events::MouseScrollEvent::GetYOffset() const
-{
-	return m_yOffset;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Math::Vec2 TRAP::Events::MouseScrollEvent::GetOffset() const
-{
-	return { m_xOffset, m_yOffset };
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::MouseScrollEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::MouseScrollEvent::ToString() const
 {
 	return "MouseScrollEvent: " + std::to_string(GetXOffset()) + ", " + std::to_string(GetYOffset());
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::MouseScrollEvent::GetStaticType()
-{
-	return EventType::MouseScroll;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -129,7 +45,7 @@ TRAP::Events::EventType TRAP::Events::MouseScrollEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::MouseScrollEvent::GetName() const
+std::string TRAP::Events::MouseScrollEvent::GetName() const
 {
 	return "MouseScroll";
 }
@@ -145,23 +61,9 @@ TRAP::Events::EventCategory TRAP::Events::MouseScrollEvent::GetCategoryFlags() c
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Input::MouseButton TRAP::Events::MouseButtonEvent::GetMouseButton() const
-{
-	return m_button;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Events::EventCategory TRAP::Events::MouseButtonEvent::GetCategoryFlags() const
 {
 	return EventCategory::Mouse | EventCategory::Input | EventCategory::MouseButton;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::MouseButtonEvent::MouseButtonEvent(const Input::MouseButton button)
-	: m_button(button)
-{
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -179,23 +81,8 @@ std::string TRAP::Events::MouseButtonEvent::MouseButtonToString(const Input::Mou
 	case Input::MouseButton::Three:
 		return "Middle";
 
-	case Input::MouseButton::Four:
-		return "4";
-
-	case Input::MouseButton::Five:
-		return "5";
-
-	case Input::MouseButton::Six:
-		return "6";
-
-	case Input::MouseButton::Seven:
-		return "7";
-
-	case Input::MouseButton::Eight:
-		return "8";
-
-	default:
-		return "";
+	default: //For every other value just return its numerical value as string
+		return std::to_string(static_cast<uint32_t>(button) + 1);
 	}
 }
 
@@ -203,31 +90,10 @@ std::string TRAP::Events::MouseButtonEvent::MouseButtonToString(const Input::Mou
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::MouseButtonPressEvent::MouseButtonPressEvent(const Input::MouseButton button, TRAP::Window* window)
-	: MouseButtonEvent(button), m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::MouseButtonPressEvent::ToString() const
 {
 	return "MouseButtonPressEvent: " + MouseButtonToString(m_button) +
 	       "(" + std::to_string(static_cast<int32_t>(m_button)) + ')';
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::MouseButtonPressEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::MouseButtonPressEvent::GetStaticType()
-{
-	return EventType::MouseButtonPress;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -239,7 +105,7 @@ TRAP::Events::EventType TRAP::Events::MouseButtonPressEvent::GetEventType() cons
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::MouseButtonPressEvent::GetName() const
+std::string TRAP::Events::MouseButtonPressEvent::GetName() const
 {
 	return "MouseButtonPress";
 }
@@ -248,31 +114,10 @@ const char* TRAP::Events::MouseButtonPressEvent::GetName() const
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::MouseButtonReleaseEvent::MouseButtonReleaseEvent(const Input::MouseButton button, TRAP::Window* window)
-	: MouseButtonEvent(button), m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::MouseButtonReleaseEvent::ToString() const
 {
 	return "MouseButtonReleaseEvent: " + MouseButtonToString(m_button) +
 	       "(" + std::to_string(static_cast<int32_t>(m_button)) + ')';
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::MouseButtonReleaseEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::MouseButtonReleaseEvent::GetStaticType()
-{
-	return EventType::MouseButtonRelease;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -284,34 +129,13 @@ TRAP::Events::EventType TRAP::Events::MouseButtonReleaseEvent::GetEventType() co
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::MouseButtonReleaseEvent::GetName() const
+std::string TRAP::Events::MouseButtonReleaseEvent::GetName() const
 {
 	return "MouseButtonRelease";
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::MouseEnterEvent::MouseEnterEvent(TRAP::Window* window)
-	: m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::MouseEnterEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::MouseEnterEvent::GetStaticType()
-{
-	return EventType::MouseEnter;
-}
-
 //-------------------------------------------------------------------------------------------------------------------//
 
 TRAP::Events::EventType TRAP::Events::MouseEnterEvent::GetEventType() const
@@ -321,7 +145,7 @@ TRAP::Events::EventType TRAP::Events::MouseEnterEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::MouseEnterEvent::GetName() const
+std::string TRAP::Events::MouseEnterEvent::GetName() const
 {
 	return "MouseEnter";
 }
@@ -337,27 +161,6 @@ TRAP::Events::EventCategory TRAP::Events::MouseEnterEvent::GetCategoryFlags() co
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::MouseLeaveEvent::MouseLeaveEvent(TRAP::Window* window)
-	: m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::MouseLeaveEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::MouseLeaveEvent::GetStaticType()
-{
-	return EventType::MouseLeave;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Events::EventType TRAP::Events::MouseLeaveEvent::GetEventType() const
 {
 	return GetStaticType();
@@ -365,7 +168,7 @@ TRAP::Events::EventType TRAP::Events::MouseLeaveEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::MouseLeaveEvent::GetName() const
+std::string TRAP::Events::MouseLeaveEvent::GetName() const
 {
 	return "MouseLeave";
 }

--- a/TRAP/src/Events/MouseEvent.h
+++ b/TRAP/src/Events/MouseEvent.h
@@ -18,7 +18,7 @@ namespace TRAP::Events
 		/// <param name="x">New mouse x position.</param>
 		/// <param name="y">New mouse y position.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		MouseMoveEvent(float x, float y, TRAP::Window* window);
+		constexpr MouseMoveEvent(float x, float y, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -44,22 +44,22 @@ namespace TRAP::Events
 		/// Retrieve the new mouse x position.
 		/// </summary>
 		/// <returns>Mouse x position.</returns>
-		float GetX() const;
+		constexpr float GetX() const;
 		/// <summary>
 		/// Retrieve the new mouse y position.
 		/// </summary>
 		/// <returns>Mouse y position.</returns>
-		float GetY() const;
+		constexpr float GetY() const;
 		/// <summary>
 		/// Retrieve the new mouse position.
 		/// </summary>
 		/// <returns>Mouse position.</returns>
-		Math::Vec2 GetPosition() const;
+		constexpr Math::Vec2 GetPosition() const;
 		/// <summary>
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the MouseMoveEvent.
@@ -71,7 +71,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -81,7 +81,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -105,7 +105,7 @@ namespace TRAP::Events
 		/// <param name="xOffset">New mouse scroll wheel x offset.</param>
 		/// <param name="yOffset">New mouse scroll wheel y offset.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		MouseScrollEvent(float xOffset, float yOffset, TRAP::Window* window);
+		constexpr MouseScrollEvent(float xOffset, float yOffset, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -131,22 +131,22 @@ namespace TRAP::Events
 		/// Retrieve the new mouse scroll wheel x offset.
 		/// </summary>
 		/// <returns>Mouse scroll wheel x offset.</returns>
-		float GetXOffset() const;
+		constexpr float GetXOffset() const;
 		/// <summary>
 		/// Retrieve the new mouse scroll wheel y offset.
 		/// </summary>
 		/// <returns>Mouse scroll wheel y offset.</returns>
-		float GetYOffset() const;
+		constexpr float GetYOffset() const;
 		/// <summary>
 		/// Retrieve the new mouse scroll wheel offset.
 		/// </summary>
 		/// <returns>Mouse scroll wheel offset.</returns>
-		Math::Vec2 GetOffset() const;
+		constexpr Math::Vec2 GetOffset() const;
 		/// <summary>
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the MouseScrollEvent.
@@ -158,7 +158,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -168,7 +168,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -195,7 +195,7 @@ namespace TRAP::Events
 		/// Retrieve the affected mouse button.
 		/// </summary>
 		/// <returns>Mouse button.</returns>
-		Input::MouseButton GetMouseButton() const;
+		constexpr Input::MouseButton GetMouseButton() const;
 
 		/// <summary>
 		/// Retrieve the category flags of the event.
@@ -208,7 +208,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="button">Affected mouse button.</param>
-		explicit MouseButtonEvent(Input::MouseButton button);
+		explicit constexpr MouseButtonEvent(Input::MouseButton button);
 		/// <summary>
 		/// Copy constructor.
 		/// </summary>
@@ -247,7 +247,7 @@ namespace TRAP::Events
 		/// </summary>
 		/// <param name="button">Pressed mouse button.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit MouseButtonPressEvent(Input::MouseButton button, TRAP::Window* window);
+		explicit constexpr MouseButtonPressEvent(Input::MouseButton button, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -273,7 +273,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the MouseButtonPressEvent.
@@ -285,7 +285,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -295,7 +295,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 
 	private:
 		TRAP::Window* m_window;
@@ -312,7 +312,7 @@ namespace TRAP::Events
 		/// </summary>
 		/// <param name="button">Released mouse button.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit MouseButtonReleaseEvent(Input::MouseButton button, TRAP::Window* window);
+		explicit constexpr MouseButtonReleaseEvent(Input::MouseButton button, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -338,7 +338,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the MouseButtonReleaseEvent.
@@ -350,7 +350,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -360,7 +360,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 
 	private:
 		TRAP::Window* m_window;
@@ -376,7 +376,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit MouseEnterEvent(TRAP::Window* window);
+		explicit constexpr MouseEnterEvent(TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -402,13 +402,13 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -418,7 +418,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -439,7 +439,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit MouseLeaveEvent(TRAP::Window* window);
+		explicit constexpr MouseLeaveEvent(TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -465,13 +465,13 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -481,7 +481,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -491,6 +491,198 @@ namespace TRAP::Events
 	private:
 		TRAP::Window* m_window;
 	};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::MouseMoveEvent::MouseMoveEvent(const float x, const float y, TRAP::Window* window)
+	: m_mouseX(x), m_mouseY(y), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+
+constexpr float TRAP::Events::MouseMoveEvent::GetX() const
+{
+	return m_mouseX;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr float TRAP::Events::MouseMoveEvent::GetY() const
+{
+	return m_mouseY;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Math::Vec2 TRAP::Events::MouseMoveEvent::GetPosition() const
+{
+	return { m_mouseX, m_mouseY };
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::MouseMoveEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::MouseMoveEvent::GetStaticType()
+{
+	return EventType::MouseMove;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::MouseScrollEvent::MouseScrollEvent(const float xOffset, const float yOffset,
+														   TRAP::Window* window)
+	: m_xOffset(xOffset), m_yOffset(yOffset), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr float TRAP::Events::MouseScrollEvent::GetXOffset() const
+{
+	return m_xOffset;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr float TRAP::Events::MouseScrollEvent::GetYOffset() const
+{
+	return m_yOffset;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Math::Vec2 TRAP::Events::MouseScrollEvent::GetOffset() const
+{
+	return { m_xOffset, m_yOffset };
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::MouseScrollEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::MouseScrollEvent::GetStaticType()
+{
+	return EventType::MouseScroll;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Input::MouseButton TRAP::Events::MouseButtonEvent::GetMouseButton() const
+{
+	return m_button;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::MouseButtonEvent::MouseButtonEvent(const Input::MouseButton button)
+	: m_button(button)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::MouseButtonPressEvent::MouseButtonPressEvent(const Input::MouseButton button,
+   																	 TRAP::Window* window)
+	: MouseButtonEvent(button), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::MouseButtonPressEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::MouseButtonPressEvent::GetStaticType()
+{
+	return EventType::MouseButtonPress;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::MouseButtonReleaseEvent::MouseButtonReleaseEvent(const Input::MouseButton button,
+																		 TRAP::Window* window)
+	: MouseButtonEvent(button), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::MouseButtonReleaseEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::MouseButtonReleaseEvent::GetStaticType()
+{
+	return EventType::MouseButtonRelease;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::MouseEnterEvent::MouseEnterEvent(TRAP::Window* window)
+	: m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::MouseEnterEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::MouseEnterEvent::GetStaticType()
+{
+	return EventType::MouseEnter;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::MouseLeaveEvent::MouseLeaveEvent(TRAP::Window* window)
+	: m_window(window)
+{
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::MouseLeaveEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::MouseLeaveEvent::GetStaticType()
+{
+	return EventType::MouseLeave;
 }
 
 #endif /*TRAP_MOUSEEVENT_H*/

--- a/TRAP/src/Events/WindowEvent.cpp
+++ b/TRAP/src/Events/WindowEvent.cpp
@@ -3,44 +3,9 @@
 
 #include "Window/Window.h"
 
-TRAP::Events::WindowResizeEvent::WindowResizeEvent(const uint32_t width, const uint32_t height, TRAP::Window* window)
-	: m_width(width), m_height(height), m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-uint32_t TRAP::Events::WindowResizeEvent::GetWidth() const
-{
-	return m_width;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-uint32_t TRAP::Events::WindowResizeEvent::GetHeight() const
-{
-	return m_height;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowResizeEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::WindowResizeEvent::ToString() const
 {
 	return "WindowResizeEvent: " + std::to_string(m_width) + "x" + std::to_string(m_height);
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::WindowResizeEvent::GetStaticType()
-{
-	return EventType::WindowResize;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -52,7 +17,7 @@ TRAP::Events::EventType TRAP::Events::WindowResizeEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowResizeEvent::GetName() const
+std::string TRAP::Events::WindowResizeEvent::GetName() const
 {
 	return "WindowResize";
 }
@@ -68,30 +33,9 @@ TRAP::Events::EventCategory TRAP::Events::WindowResizeEvent::GetCategoryFlags() 
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::WindowMinimizeEvent::WindowMinimizeEvent(TRAP::Window* window)
-	: m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowMinimizeEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::WindowMinimizeEvent::ToString() const
 {
 	return "WindowMinimizeEvent";
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::WindowMinimizeEvent::GetStaticType()
-{
-	return EventType::WindowMinimize;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -103,7 +47,7 @@ TRAP::Events::EventType TRAP::Events::WindowMinimizeEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowMinimizeEvent::GetName() const
+std::string TRAP::Events::WindowMinimizeEvent::GetName() const
 {
 	return "WindowMinimize";
 }
@@ -119,30 +63,9 @@ TRAP::Events::EventCategory TRAP::Events::WindowMinimizeEvent::GetCategoryFlags(
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::WindowMaximizeEvent::WindowMaximizeEvent(TRAP::Window* window)
-	: m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowMaximizeEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::WindowMaximizeEvent::ToString() const
 {
 	return "WindowMaximizeEvent";
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::WindowMaximizeEvent::GetStaticType()
-{
-	return EventType::WindowMaximize;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -154,7 +77,7 @@ TRAP::Events::EventType TRAP::Events::WindowMaximizeEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowMaximizeEvent::GetName() const
+std::string TRAP::Events::WindowMaximizeEvent::GetName() const
 {
 	return "WindowMaximize";
 }
@@ -170,30 +93,9 @@ TRAP::Events::EventCategory TRAP::Events::WindowMaximizeEvent::GetCategoryFlags(
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::WindowRestoreEvent::WindowRestoreEvent(TRAP::Window* window)
-	: m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowRestoreEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::WindowRestoreEvent::ToString() const
 {
 	return "WindowRestoreEvent";
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::WindowRestoreEvent::GetStaticType()
-{
-	return EventType::WindowRestore;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -205,7 +107,7 @@ TRAP::Events::EventType TRAP::Events::WindowRestoreEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowRestoreEvent::GetName() const
+std::string TRAP::Events::WindowRestoreEvent::GetName() const
 {
 	return "WindowRestore";
 }
@@ -221,30 +123,9 @@ TRAP::Events::EventCategory TRAP::Events::WindowRestoreEvent::GetCategoryFlags()
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::WindowCloseEvent::WindowCloseEvent(TRAP::Window* window)
-	: m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowCloseEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::WindowCloseEvent::ToString() const
 {
 	return "WindowCloseEvent: " + m_window->GetTitle();
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::WindowCloseEvent::GetStaticType()
-{
-	return EventType::WindowClose;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -256,7 +137,7 @@ TRAP::Events::EventType TRAP::Events::WindowCloseEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowCloseEvent::GetName() const
+std::string TRAP::Events::WindowCloseEvent::GetName() const
 {
 	return "WindowClose";
 }
@@ -272,51 +153,9 @@ TRAP::Events::EventCategory TRAP::Events::WindowCloseEvent::GetCategoryFlags() c
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::WindowMoveEvent::WindowMoveEvent(const int32_t x, const int32_t y, TRAP::Window* window)
-	: m_x(x), m_y(y), m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-int32_t TRAP::Events::WindowMoveEvent::GetX() const
-{
-	return m_x;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-int32_t TRAP::Events::WindowMoveEvent::GetY() const
-{
-	return m_y;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Math::Vec2i TRAP::Events::WindowMoveEvent::GetPosition() const
-{
-	return {m_x, m_y};
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowMoveEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::WindowMoveEvent::ToString() const
 {
 	return "WindowMoveEvent: " + std::to_string(m_x) + ", " + std::to_string(m_y);
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::WindowMoveEvent::GetStaticType()
-{
-	return EventType::WindowMove;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -328,7 +167,7 @@ TRAP::Events::EventType TRAP::Events::WindowMoveEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowMoveEvent::GetName() const
+std::string TRAP::Events::WindowMoveEvent::GetName() const
 {
 	return "WindowMove";
 }
@@ -344,30 +183,9 @@ TRAP::Events::EventCategory TRAP::Events::WindowMoveEvent::GetCategoryFlags() co
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::WindowFocusEvent::WindowFocusEvent(TRAP::Window* window)
-	: m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowFocusEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::WindowFocusEvent::ToString() const
 {
 	return "WindowFocusEvent: " + m_window->GetTitle();
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::WindowFocusEvent::GetStaticType()
-{
-	return EventType::WindowFocus;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -379,7 +197,7 @@ TRAP::Events::EventType TRAP::Events::WindowFocusEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowFocusEvent::GetName() const
+std::string TRAP::Events::WindowFocusEvent::GetName() const
 {
 	return "WindowFocus";
 }
@@ -395,30 +213,9 @@ TRAP::Events::EventCategory TRAP::Events::WindowFocusEvent::GetCategoryFlags() c
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::WindowLostFocusEvent::WindowLostFocusEvent(TRAP::Window* window)
-	: m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowLostFocusEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::WindowLostFocusEvent::ToString() const
 {
 	return "WindowLostFocusEvent: " + m_window->GetTitle();
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::WindowLostFocusEvent::GetStaticType()
-{
-	return EventType::WindowLostFocus;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -430,7 +227,7 @@ TRAP::Events::EventType TRAP::Events::WindowLostFocusEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowLostFocusEvent::GetName() const
+std::string TRAP::Events::WindowLostFocusEvent::GetName() const
 {
 	return "WindowLostFocus";
 }
@@ -448,21 +245,13 @@ TRAP::Events::EventCategory TRAP::Events::WindowLostFocusEvent::GetCategoryFlags
 
 TRAP::Events::WindowDropEvent::WindowDropEvent(std::vector<std::string> paths, TRAP::Window* window)
 	: m_paths(std::move(paths)), m_window(window)
-{
-}
+{}
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 const std::vector<std::string>& TRAP::Events::WindowDropEvent::GetPaths() const
 {
 	return m_paths;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowDropEvent::GetWindow() const
-{
-	return m_window;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -478,13 +267,6 @@ std::string TRAP::Events::WindowDropEvent::ToString() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::EventType TRAP::Events::WindowDropEvent::GetStaticType()
-{
-	return EventType::WindowDrop;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Events::EventType TRAP::Events::WindowDropEvent::GetEventType() const
 {
 	return GetStaticType();
@@ -492,7 +274,7 @@ TRAP::Events::EventType TRAP::Events::WindowDropEvent::GetEventType() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowDropEvent::GetName() const
+std::string TRAP::Events::WindowDropEvent::GetName() const
 {
 	return "WindowDrop";
 }
@@ -508,52 +290,9 @@ TRAP::Events::EventCategory TRAP::Events::WindowDropEvent::GetCategoryFlags() co
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::WindowContentScaleEvent::WindowContentScaleEvent(const float xScale, const float yScale,
-	TRAP::Window* window)
-	: m_XScale(xScale), m_YScale(yScale), m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-float TRAP::Events::WindowContentScaleEvent::GetXScale() const
-{
-	return m_XScale;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-float TRAP::Events::WindowContentScaleEvent::GetYScale() const
-{
-	return m_YScale;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Math::Vec2 TRAP::Events::WindowContentScaleEvent::GetScale() const
-{
-	return {m_XScale, m_YScale};
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::WindowContentScaleEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::WindowContentScaleEvent::ToString() const
 {
 	return "WindowContentScaleEvent: " + std::to_string(m_XScale) + "x" + std::to_string(m_YScale);
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::WindowContentScaleEvent::GetStaticType()
-{
-	return EventType::WindowContentScale;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -565,7 +304,7 @@ TRAP::Events::EventType TRAP::Events::WindowContentScaleEvent::GetEventType() co
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::WindowContentScaleEvent::GetName() const
+std::string TRAP::Events::WindowContentScaleEvent::GetName() const
 {
 	return "WindowContentScale";
 }
@@ -581,53 +320,9 @@ TRAP::Events::EventCategory TRAP::Events::WindowContentScaleEvent::GetCategoryFl
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Events::FrameBufferResizeEvent::FrameBufferResizeEvent(const uint32_t width, const uint32_t height,
-                                                             TRAP::Window* window)
-	: m_width(width), m_height(height), m_window(window)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-uint32_t TRAP::Events::FrameBufferResizeEvent::GetWidth() const
-{
-	return m_width;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-uint32_t TRAP::Events::FrameBufferResizeEvent::GetHeight() const
-{
-	return m_height;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Math::Vec2ui TRAP::Events::FrameBufferResizeEvent::GetSize() const
-{
-	return {m_width, m_height};
-}
-
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Window* TRAP::Events::FrameBufferResizeEvent::GetWindow() const
-{
-	return m_window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::Events::FrameBufferResizeEvent::ToString() const
 {
 	return "FrameBufferResizeEvent: " + std::to_string(m_width) + "x" + std::to_string(m_height);
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Events::EventType TRAP::Events::FrameBufferResizeEvent::GetStaticType()
-{
-	return EventType::FrameBufferResize;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -639,7 +334,7 @@ TRAP::Events::EventType TRAP::Events::FrameBufferResizeEvent::GetEventType() con
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Events::FrameBufferResizeEvent::GetName() const
+std::string TRAP::Events::FrameBufferResizeEvent::GetName() const
 {
 	return "FrameBufferResize";
 }

--- a/TRAP/src/Events/WindowEvent.h
+++ b/TRAP/src/Events/WindowEvent.h
@@ -1122,7 +1122,7 @@ constexpr TRAP::Events::EventType TRAP::Events::WindowContentScaleEvent::GetStat
 //-------------------------------------------------------------------------------------------------------------------//
 
 constexpr TRAP::Events::FrameBufferResizeEvent::FrameBufferResizeEvent(const uint32_t width, const uint32_t height,
-                                                             TRAP::Window* window)
+                                                                       TRAP::Window* window)
 	: m_width(width), m_height(height), m_window(window)
 {}
 

--- a/TRAP/src/Events/WindowEvent.h
+++ b/TRAP/src/Events/WindowEvent.h
@@ -23,7 +23,7 @@ namespace TRAP::Events
 		/// <param name="width">New Window width.</param>
 		/// <param name="height">New Window height.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		WindowResizeEvent(uint32_t width, uint32_t height, TRAP::Window* window);
+		constexpr WindowResizeEvent(uint32_t width, uint32_t height, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -49,17 +49,17 @@ namespace TRAP::Events
 		/// Retrieve the new window width.
 		/// </summary>
 		/// <returns>Width.</returns>
-		uint32_t GetWidth() const;
+		constexpr uint32_t GetWidth() const;
 		/// <summary>
 		/// Retrieve the new window height.
 		/// </summary>
 		/// <returns>Height.</returns>
-		uint32_t GetHeight() const;
+		constexpr uint32_t GetHeight() const;
 		/// <summary>
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the WindowResizeEvent.
@@ -71,7 +71,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -81,7 +81,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -103,7 +103,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit WindowMinimizeEvent(TRAP::Window* window);
+		explicit constexpr WindowMinimizeEvent(TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -129,7 +129,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the WindowMinimizeEvent.
@@ -141,7 +141,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -151,7 +151,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -172,7 +172,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit WindowMaximizeEvent(TRAP::Window* window);
+		explicit constexpr WindowMaximizeEvent(TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -198,7 +198,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 		/// <summary>
 		/// Get a string representation of the WindowMaximizeEvent.
 		/// </summary>
@@ -209,7 +209,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -219,7 +219,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -240,7 +240,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit WindowRestoreEvent(TRAP::Window* window);
+		explicit constexpr WindowRestoreEvent(TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -266,7 +266,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the WindowRestoreEvent.
@@ -278,7 +278,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -288,7 +288,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -309,7 +309,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit WindowCloseEvent(TRAP::Window* window);
+		explicit constexpr WindowCloseEvent(TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -335,7 +335,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the WindowCloseEvent.
@@ -347,7 +347,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -357,7 +357,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -380,7 +380,7 @@ namespace TRAP::Events
 		/// <param name="x">New x position.</param>
 		/// <param name="y">New y position.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		WindowMoveEvent(int32_t x, int32_t y, TRAP::Window* window);
+		constexpr WindowMoveEvent(int32_t x, int32_t y, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -406,22 +406,22 @@ namespace TRAP::Events
 		/// Retrieve the new window x position.
 		/// </summary>
 		/// <returns>Window x position.</returns>
-		int32_t GetX() const;
+		constexpr int32_t GetX() const;
 		/// <summary>
 		/// Retrieve the new window y position.
 		/// </summary>
 		/// <returns>Window y position.</returns>
-		int32_t GetY() const;
+		constexpr int32_t GetY() const;
 		/// <summary>
 		/// Retrieve the new window position.
 		/// </summary>
 		/// <returns>Window position</returns>
-		Math::Vec2i GetPosition() const;
+		constexpr Math::Vec2i GetPosition() const;
 		/// <summary>
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the WindowMoveEvent.
@@ -433,7 +433,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -443,7 +443,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -465,7 +465,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit WindowFocusEvent(TRAP::Window* window);
+		explicit constexpr WindowFocusEvent(TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -491,7 +491,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the WindowFocusEvent.
@@ -503,7 +503,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -513,7 +513,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -534,7 +534,7 @@ namespace TRAP::Events
 		/// Constructor.
 		/// </summary>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit WindowLostFocusEvent(TRAP::Window* window);
+		explicit constexpr WindowLostFocusEvent(TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -560,7 +560,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the WindowLostFocusEvent.
@@ -572,7 +572,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -582,7 +582,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -635,7 +635,7 @@ namespace TRAP::Events
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the WindowDropEvent.
@@ -647,7 +647,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -657,7 +657,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -681,7 +681,7 @@ namespace TRAP::Events
 		/// <param name="xScale">New x content scale.</param>
 		/// <param name="yScale">New y content scale.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		explicit WindowContentScaleEvent(float xScale, float yScale, TRAP::Window* window);
+		explicit constexpr WindowContentScaleEvent(float xScale, float yScale, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -707,22 +707,22 @@ namespace TRAP::Events
 		/// Retrieve the new x content scale.
 		/// </summary>
 		/// <returns>Window x content scale.</returns>
-		float GetXScale() const;
+		constexpr float GetXScale() const;
 		/// <summary>
 		/// Retrieve the new y content scale.
 		/// </summary>
 		/// <returns>Window y content scale.</returns>
-		float GetYScale() const;
+		constexpr float GetYScale() const;
 		/// <summary>
 		/// Retrieve the new content scale.
 		/// </summary>
 		/// <returns>Window content scale.</returns>
-		Math::Vec2 GetScale() const;
+		constexpr Math::Vec2 GetScale() const;
 		/// <summary>
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the WindowContentScaleEvent.
@@ -734,7 +734,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -744,7 +744,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -769,7 +769,7 @@ namespace TRAP::Events
 		/// <param name="width">New framebuffer width.</param>
 		/// <param name="height">New framebuffer height.</param>
 		/// <param name="window">Pointer to the affected window.</param>
-		FrameBufferResizeEvent(uint32_t width, uint32_t height, TRAP::Window* window);
+		constexpr FrameBufferResizeEvent(uint32_t width, uint32_t height, TRAP::Window* window);
 		/// <summary>
 		/// Destructor.
 		/// </summary>
@@ -795,22 +795,22 @@ namespace TRAP::Events
 		/// Retrieve the new framebuffer width.
 		/// </summary>
 		/// <returns>Framebuffer width.</returns>
-		uint32_t GetWidth() const;
+		constexpr uint32_t GetWidth() const;
 		/// <summary>
 		/// Retrieve the new framebuffer height.
 		/// </summary>
 		/// <returns>Framebuffer height.</returns>
-		uint32_t GetHeight() const;
+		constexpr uint32_t GetHeight() const;
 		/// <summary>
 		/// Retrieve the new framebuffer size.
 		/// </summary>
 		/// <returns>Framebuffer size.</returns>
-		Math::Vec2ui GetSize() const;
+		constexpr Math::Vec2ui GetSize() const;
 		/// <summary>
 		/// Retrieve a pointer to the affected window.
 		/// </summary>
 		/// <returns>Window pointer.</returns>
-		TRAP::Window* GetWindow() const;
+		constexpr TRAP::Window* GetWindow() const;
 
 		/// <summary>
 		/// Get a string representation of the FrameBufferResizeEvent.
@@ -822,7 +822,7 @@ namespace TRAP::Events
 		/// Retrieve the EventType of the event.
 		/// </summary>
 		/// <returns>EventType.</returns>
-		static EventType GetStaticType();
+		static constexpr EventType GetStaticType();
 		/// <summary>
 		/// Retrieve the EventType of the event.
 		/// </summary>
@@ -832,7 +832,7 @@ namespace TRAP::Events
 		/// Retrieve the name of the event.
 		/// </summary>
 		/// <returns>Name.</returns>
-		const char* GetName() const override;
+		std::string GetName() const override;
 		/// <summary>
 		/// Retrieve the category flags of the event.
 		/// </summary>
@@ -843,6 +843,322 @@ namespace TRAP::Events
 		uint32_t m_width, m_height;
 		TRAP::Window* m_window;
 	};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::WindowResizeEvent::WindowResizeEvent(const uint32_t width, const uint32_t height,
+   															 TRAP::Window* window)
+	: m_width(width), m_height(height), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr uint32_t TRAP::Events::WindowResizeEvent::GetWidth() const
+{
+	return m_width;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr uint32_t TRAP::Events::WindowResizeEvent::GetHeight() const
+{
+	return m_height;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowResizeEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowResizeEvent::GetStaticType()
+{
+	return EventType::WindowResize;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::WindowMinimizeEvent::WindowMinimizeEvent(TRAP::Window* window)
+	: m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowMinimizeEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowMinimizeEvent::GetStaticType()
+{
+	return EventType::WindowMinimize;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::WindowMaximizeEvent::WindowMaximizeEvent(TRAP::Window* window)
+	: m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowMaximizeEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowMaximizeEvent::GetStaticType()
+{
+	return EventType::WindowMaximize;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::WindowRestoreEvent::WindowRestoreEvent(TRAP::Window* window)
+	: m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowRestoreEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowRestoreEvent::GetStaticType()
+{
+	return EventType::WindowRestore;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::WindowCloseEvent::WindowCloseEvent(TRAP::Window* window)
+	: m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowCloseEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowCloseEvent::GetStaticType()
+{
+	return EventType::WindowClose;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::WindowMoveEvent::WindowMoveEvent(const int32_t x, const int32_t y, TRAP::Window* window)
+	: m_x(x), m_y(y), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr int32_t TRAP::Events::WindowMoveEvent::GetX() const
+{
+	return m_x;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr int32_t TRAP::Events::WindowMoveEvent::GetY() const
+{
+	return m_y;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Math::Vec2i TRAP::Events::WindowMoveEvent::GetPosition() const
+{
+	return {m_x, m_y};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowMoveEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowMoveEvent::GetStaticType()
+{
+	return EventType::WindowMove;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::WindowFocusEvent::WindowFocusEvent(TRAP::Window* window)
+	: m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowFocusEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowFocusEvent::GetStaticType()
+{
+	return EventType::WindowFocus;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::WindowLostFocusEvent::WindowLostFocusEvent(TRAP::Window* window)
+	: m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowLostFocusEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowLostFocusEvent::GetStaticType()
+{
+	return EventType::WindowLostFocus;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowDropEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowDropEvent::GetStaticType()
+{
+	return EventType::WindowDrop;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::WindowContentScaleEvent::WindowContentScaleEvent(const float xScale, const float yScale,
+	TRAP::Window* window)
+	: m_XScale(xScale), m_YScale(yScale), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr float TRAP::Events::WindowContentScaleEvent::GetXScale() const
+{
+	return m_XScale;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr float TRAP::Events::WindowContentScaleEvent::GetYScale() const
+{
+	return m_YScale;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Math::Vec2 TRAP::Events::WindowContentScaleEvent::GetScale() const
+{
+	return {m_XScale, m_YScale};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::WindowContentScaleEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::WindowContentScaleEvent::GetStaticType()
+{
+	return EventType::WindowContentScale;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::FrameBufferResizeEvent::FrameBufferResizeEvent(const uint32_t width, const uint32_t height,
+                                                             TRAP::Window* window)
+	: m_width(width), m_height(height), m_window(window)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr uint32_t TRAP::Events::FrameBufferResizeEvent::GetWidth() const
+{
+	return m_width;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr uint32_t TRAP::Events::FrameBufferResizeEvent::GetHeight() const
+{
+	return m_height;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Math::Vec2ui TRAP::Events::FrameBufferResizeEvent::GetSize() const
+{
+	return {m_width, m_height};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Window* TRAP::Events::FrameBufferResizeEvent::GetWindow() const
+{
+	return m_window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Events::EventType TRAP::Events::FrameBufferResizeEvent::GetStaticType()
+{
+	return EventType::FrameBufferResize;
 }
 
 #endif /*TRAP_WINDOWEVENT_H*/

--- a/TRAP/src/FS/FS.cpp
+++ b/TRAP/src/FS/FS.cpp
@@ -136,7 +136,7 @@ bool TRAP::FS::WriteTextFile(const std::filesystem::path& path, const std::strin
         return false;
     }
 
-    file.write(reinterpret_cast<const char*>(text.data()), static_cast<int64_t>(text.size()));
+    file.write(static_cast<const char*>(text.data()), static_cast<int64_t>(text.size()));
     file.close();
 
     return true;

--- a/TRAP/src/FS/FS.h
+++ b/TRAP/src/FS/FS.h
@@ -28,6 +28,8 @@
 #ifndef TRAP_FS_H
 #define TRAP_FS_H
 
+#include <optional>
+
 #include "Application.h"
 #include "FileWatcher.h"
 
@@ -53,7 +55,7 @@ namespace TRAP
 		/// <summary>
 		/// Shuts down the File System.
 		/// </summary>
-		void Shutdown();
+		constexpr void Shutdown();
 
         /// <summary>
 		/// Read the given binary file.
@@ -63,20 +65,21 @@ namespace TRAP
 		/// <param name="path">File path.</param>
 		/// <returns>
 		/// Vector with file content on success.
-		/// Empty vector if an error has occurred.
+		/// Empty optional if an error has occurred.
 		/// </returns>
-		std::vector<uint8_t> ReadFile(const std::filesystem::path& path);
+		std::optional<std::vector<uint8_t>> ReadFile(const std::filesystem::path& path);
         /// <summary>
 		/// Read the given text file.
+		/// Line endings are automatically converted to LF ('\n').
 		///
 		/// Prints an error if path is empty.
 		/// </summary>
 		/// <param name="path">File path.</param>
 		/// <returns>
 		/// String with file content on success.
-		/// Empty string if an error has occurred.
+		/// Empty optional if an error has occurred.
 		/// </returns>
-		std::string ReadTextFile(const std::filesystem::path& path);
+		std::optional<std::string> ReadTextFile(const std::filesystem::path& path);
 
         /// <summary>
 		/// Write the given data as binary to the given file path.
@@ -85,7 +88,7 @@ namespace TRAP
 		/// <param name="buffer">Data to be written.</param>
 		/// <param name="mode">Write mode to use.</param>
 		/// <returns>True if path could be resolved and data has been written, false otherwise.</returns>
-		bool WriteFile(const std::filesystem::path& path, std::vector<uint8_t>& buffer,
+		bool WriteFile(const std::filesystem::path& path, const std::vector<uint8_t>& buffer,
 		               WriteMode mode = WriteMode::Overwrite);
 		/// <summary>
 		/// Write the given text to the given file path.
@@ -164,77 +167,82 @@ namespace TRAP
 		/// <param name="path">Path to a file or folder.</param>
 		/// <returns>
 		/// File or folder size in bytes.
-		/// 0 if an error has occurred.
+		/// Empty optional if an error has occurred.
 		/// </returns>
-		uintmax_t GetFileOrFolderSize(const std::filesystem::path& path, bool recursive = true);
+		std::optional<uintmax_t> GetFileOrFolderSize(const std::filesystem::path& path, bool recursive = true);
         /// <summary>
 		/// Get the last write time of a file or folder.
 		/// </summary>
 		/// <param name="path">Path to a file or folder.</param>
 		/// <returns>
 		/// Last write time of the file or folder.
-		/// std::filesystem::file_time_type::min() if an error has occurred.
+		/// Empty optional if an error has occurred.
 		/// </returns>
-		std::filesystem::file_time_type GetLastWriteTime(const std::filesystem::path& path);
+		std::optional<std::filesystem::file_time_type> GetLastWriteTime(const std::filesystem::path& path);
 
         /// <summary>
 		/// Get only the filename without its folders from a file path.
 		/// </summary>
 		/// <param name="path">File path.</param>
-		/// <returns>String only containing the filename without its folders.</returns>
-		std::string GetFileNameWithEnding(const std::filesystem::path& path);
+		/// <returns>String only containing the filename without its folders on success, empty optional otherwise.</returns>
+		std::optional<std::string> GetFileNameWithEnding(const std::filesystem::path& path);
         /// <summary>
 		/// Get only the filename without its folders and ending/suffix from a file path.
 		/// </summary>
 		/// <param name="path">File path.</param>
-		/// <returns>String only containing the filename without its folders and file ending.</returns>
-		std::string GetFileName(const std::filesystem::path& path);
+		/// <returns>String only containing the filename without its folders and file ending on success, empty optional otherwise.</returns>
+		std::optional<std::string> GetFileName(const std::filesystem::path& path);
         /// <summary>
 		/// Get only the file ending without its name from a file path.
 		/// </summary>
 		/// <param name="path">File path.</param>
-		/// <returns>String only containing the file ending without its file name.</returns>
-		std::string GetFileEnding(const std::filesystem::path& path);
+		/// <returns>String only containing the file ending without its file name on success, empty optional otherwise.</returns>
+		std::optional<std::string> GetFileEnding(const std::filesystem::path& path);
 
 		/// <summary>
 		/// Get only the folder without the filename and its ending.
 		/// </summary>
 		/// <param name="filePath">File path.</param>
-		/// <returns>Folder path from file path.</returns>
-		std::filesystem::path GetFolderPath(const std::filesystem::path& filePath);
+		/// <returns>Folder path from file path on success, empty optional otherwise.</returns>
+		std::optional<std::filesystem::path> GetFolderPath(const std::filesystem::path& filePath);
 
         /// <summary>
-		/// Get the path to the temp folder.
+		/// Get the path to the temp folder of the engine.
 		/// </summary>
-		/// <returns>Path to the temp folder.</returns>
-		std::filesystem::path GetTempFolderPath();
+		/// <returns>Path to the temp folder on success, empty optional otherwise.</returns>
+		std::optional<std::filesystem::path> GetTempFolderPath();
         /// <summary>
 		/// Get the path to the temp folder of the game.
 		/// </summary>
-		/// <returns>Path to the temp folder.</returns>
-		std::filesystem::path GetGameTempFolderPath();
+		/// <returns>Path to the temp folder on success, empty optional otherwise.</returns>
+		std::optional<std::filesystem::path> GetGameTempFolderPath();
 		/// <summary>
 		/// Get the path to the current working folder.
 		/// </summary>
-		/// <returns>Path to the current working folder.</returns>
-		std::filesystem::path GetCurrentFolderPath();
+		/// <returns>Path to the current working folder on success, empty optional otherwise.</returns>
+		std::optional<std::filesystem::path> GetCurrentFolderPath();
 		/// <summary>
 		/// Get the path to the users documents folder.
 		/// </summary>
-		/// <returns>Path to the users documents folder.</returns>
-		std::filesystem::path GetDocumentsFolderPath();
+		/// <returns>Path to the users documents folder on success, empty optional otherwise.</returns>
+		std::optional<std::filesystem::path> GetDocumentsFolderPath();
 		/// <summary>
 		/// Get the path to the users documents folder for the game.
 		/// </summary>
-		/// <returns>Path to the users documents folder for the game.</returns>
-		std::filesystem::path GetGameDocumentsFolderPath();
+		/// <returns>Path to the users documents folder for the game on success, empty optional otherwise.</returns>
+		std::optional<std::filesystem::path> GetGameDocumentsFolderPath();
+		/// <summary>
+		/// Get the path to the log folder for the game.
+		/// </summary>
+		/// <returns>Path to the log folder for the game on success, empty optional otherwise.</returns>
+		std::optional<std::filesystem::path> GetGameLogFolderPath();
 
 		/// <summary>
 		/// Checks whether the paths p1 and p2 resolve to the same file system file/folder.
 		/// </summary>
 		/// <param name="p1">File/folder path.</param>
 		/// <param name="p2">File/folder path</param>
-		/// <returns>true if the p1 and p2 refer to the same file/folder, false otherwise.</returns>
+		/// <returns>True if p1 and p2 refer to the same file or folder, false otherwise.</returns>
 		bool IsPathEquivalent(const std::filesystem::path& p1, const std::filesystem::path& p2);
 		/// <summary>
 		/// Get whether the path p is an absolute path or not.
@@ -267,14 +275,14 @@ namespace TRAP
 		/// Converts a path to an absolute path.
 		/// </summary>
 		/// <param name="p">Path to convert.</param>
-		/// <returns>Absolute path on success, empty path otherwise.</returns>
-		std::filesystem::path ToAbsolutePath(const std::filesystem::path& p);
+		/// <returns>Absolute path on success, empty optional otherwise.</returns>
+		std::optional<std::filesystem::path> ToAbsolutePath(const std::filesystem::path& p);
 		/// <summary>
 		/// Converts a path to a relative path.
 		/// </summary>
 		/// <param name="p">Path to convert.</param>
-		/// <returns>Relative path on success, empty path otherwise.</returns>
-		std::filesystem::path ToRelativePath(const std::filesystem::path& p);
+		/// <returns>Relative path on success, empty optional otherwise.</returns>
+		std::optional<std::filesystem::path> ToRelativePath(const std::filesystem::path& p);
 
 		/// <summary>
 		/// Opens the file browser at the given path.
@@ -302,6 +310,15 @@ namespace TRAP
 		/// <returns>True on success, false otherwise.</returns>
 		bool OpenExternally(const std::filesystem::path& p);
     };
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr void TRAP::FS::Shutdown()
+{
+	TP_PROFILE_FUNCTION();
+
+	TP_DEBUG(Log::FileSystemPrefix, "Shutting down File System");
 }
 
 #endif /*TRAP_FS_H*/

--- a/TRAP/src/FS/FileWatcher.cpp
+++ b/TRAP/src/FS/FileWatcher.cpp
@@ -390,7 +390,7 @@ void TRAP::FS::FileWatcher::Watch()
         }
     }
 
-    std::array<char, 2048> buf{};
+    std::array<char, 2048> buf{}; //Can't be a inotify_event array because it includes a flexible array member.
     std::filesystem::path oldName;
 
     //Thread work loop
@@ -452,7 +452,7 @@ void TRAP::FS::FileWatcher::Watch()
         std::size_t offset = 0;
         while(offset < static_cast<std::size_t>(len)) //Process events
         {
-            const inotify_event* event = reinterpret_cast<const inotify_event*>(buf.data() + offset);
+            const inotify_event* event = reinterpret_cast<const inotify_event*>(buf.data() + offset); //Must use reinterpret_cast because of flexible array member
             if(!event->len)
             {
                 offset += sizeof(inotify_event) + event->len;

--- a/TRAP/src/FS/FileWatcher.h
+++ b/TRAP/src/FS/FileWatcher.h
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <functional>
 #include <thread>
+#include <atomic>
 
 namespace TRAP::Events
 {
@@ -65,7 +66,7 @@ namespace TRAP::FS
 		/// <summary>
 		/// Move constructor.
 		/// </summary>
-		FileWatcher(FileWatcher&&) = default;
+		FileWatcher(FileWatcher&&) = delete;
 		/// <summary>
 		/// Copy assignment operator.
 		/// </summary>
@@ -73,12 +74,7 @@ namespace TRAP::FS
 		/// <summary>
 		/// Move assignment operator.
 		/// </summary>
-		FileWatcher& operator=(FileWatcher&&) = default;
-
-        /// <summary>
-        /// Skip the next file event.
-        /// </summary>
-        void SkipNextFileChange();
+		FileWatcher& operator=(FileWatcher&&) = delete;
 
         /// <summary>
         /// Sets the callback function that is called when a file event occurs.
@@ -93,14 +89,14 @@ namespace TRAP::FS
 
         /// <summary>Adds a new folder path to the tracked paths.</summary>
         /// <param name="path">Folder path to track.</param>
-        void AddFolder(std::filesystem::path path);
+        void AddFolder(const std::filesystem::path& path);
         /// <summary>Adds new folder paths to the tracked paths.</summary>
         /// <param name="paths">Folder paths to track.</param>
         void AddFolders(const std::vector<std::filesystem::path>& paths);
 
         /// <summary>Removes a folder path from the tracked paths.</summary>
         /// <param name="path">Folder path to untrack.</param>
-        void RemoveFolder(std::filesystem::path path);
+        void RemoveFolder(const std::filesystem::path& path);
         /// <summary>Removes folder paths from the tracked paths.</summary>
         /// <param name="paths">Folder paths to untrack.</param>
         void RemoveFolders(const std::vector<std::filesystem::path>& paths);
@@ -123,21 +119,14 @@ namespace TRAP::FS
 
         /// <summary>
         /// Watch over files.
-        /// Used by Windows.
         /// </summary>
-        void WatchWindows();
-        /// <summary>
-        /// Watch over files.
-        /// Used by Linux.
-        /// </summary>
-        void WatchLinux();
+        void Watch();
 
         std::thread m_thread;
         EventCallbackFn m_callback;
-        std::vector<std::filesystem::path> m_paths;
+        std::vector<std::filesystem::path> m_paths; //No synchronization needed since it's only changed when m_thread is not running.
         bool m_recursive;
-        bool m_run;
-        bool m_skipNextFileChange;
+        std::atomic<bool> m_run;
 
 #ifdef TRAP_PLATFORM_WINDOWS
         HANDLE m_killEvent = nullptr;

--- a/TRAP/src/FileSystem/FileSystem.cpp
+++ b/TRAP/src/FileSystem/FileSystem.cpp
@@ -1,5 +1,5 @@
 #include "TRAPPCH.h"
-#include "FS.h"
+#include "FileSystem.h"
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -10,7 +10,7 @@ std::optional<std::filesystem::path> GetDocumentsFolderPathLinux();
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::FS::Init()
+void TRAP::FileSystem::Init()
 {
     TP_PROFILE_FUNCTION();
 
@@ -41,7 +41,7 @@ void TRAP::FS::Init()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::vector<uint8_t>> TRAP::FS::ReadFile(const std::filesystem::path& path)
+std::optional<std::vector<uint8_t>> TRAP::FileSystem::ReadFile(const std::filesystem::path& path)
 {
     TP_PROFILE_FUNCTION();
 
@@ -65,7 +65,7 @@ std::optional<std::vector<uint8_t>> TRAP::FS::ReadFile(const std::filesystem::pa
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::string> TRAP::FS::ReadTextFile(const std::filesystem::path& path)
+std::optional<std::string> TRAP::FileSystem::ReadTextFile(const std::filesystem::path& path)
 {
     TP_PROFILE_FUNCTION();
 
@@ -94,7 +94,7 @@ std::optional<std::string> TRAP::FS::ReadTextFile(const std::filesystem::path& p
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::WriteFile(const std::filesystem::path& path, const std::vector<uint8_t>& buffer, const WriteMode mode)
+bool TRAP::FileSystem::WriteFile(const std::filesystem::path& path, const std::vector<uint8_t>& buffer, const WriteMode mode)
 {
     TP_PROFILE_FUNCTION();
 
@@ -118,7 +118,7 @@ bool TRAP::FS::WriteFile(const std::filesystem::path& path, const std::vector<ui
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::WriteTextFile(const std::filesystem::path& path, const std::string_view text, const WriteMode mode)
+bool TRAP::FileSystem::WriteTextFile(const std::filesystem::path& path, const std::string_view text, const WriteMode mode)
 {
     TP_PROFILE_FUNCTION();
 
@@ -144,7 +144,7 @@ bool TRAP::FS::WriteTextFile(const std::filesystem::path& path, const std::strin
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::CreateFolder(const std::filesystem::path& path)
+bool TRAP::FileSystem::CreateFolder(const std::filesystem::path& path)
 {
     TP_PROFILE_FUNCTION();
 
@@ -165,7 +165,7 @@ bool TRAP::FS::CreateFolder(const std::filesystem::path& path)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::DeleteFileOrFolder(const std::filesystem::path& path)
+bool TRAP::FileSystem::DeleteFileOrFolder(const std::filesystem::path& path)
 {
     TP_PROFILE_FUNCTION();
 
@@ -211,7 +211,7 @@ bool TRAP::FS::DeleteFileOrFolder(const std::filesystem::path& path)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::MoveFolder(const std::filesystem::path& oldPath, const std::filesystem::path& newPath)
+bool TRAP::FileSystem::MoveFolder(const std::filesystem::path& oldPath, const std::filesystem::path& newPath)
 {
     if(FileOrFolderExists(newPath))
         return false;
@@ -231,28 +231,28 @@ bool TRAP::FS::MoveFolder(const std::filesystem::path& oldPath, const std::files
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::MoveFile(const std::filesystem::path& filePath, const std::filesystem::path& destFolder)
+bool TRAP::FileSystem::MoveFile(const std::filesystem::path& filePath, const std::filesystem::path& destFolder)
 {
     return MoveFolder(filePath, destFolder / filePath.filename());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::RenameFolder(const std::filesystem::path& oldPath, const std::filesystem::path& newPath)
+bool TRAP::FileSystem::RenameFolder(const std::filesystem::path& oldPath, const std::filesystem::path& newPath)
 {
     return MoveFolder(oldPath, newPath);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::RenameFile(const std::filesystem::path& oldPath, const std::string_view newName)
+bool TRAP::FileSystem::RenameFile(const std::filesystem::path& oldPath, const std::string_view newName)
 {
     return RenameFolder(oldPath, (oldPath.parent_path() / newName / oldPath.extension()));
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::FileOrFolderExists(const std::filesystem::path& path)
+bool TRAP::FileSystem::FileOrFolderExists(const std::filesystem::path& path)
 {
     TP_PROFILE_FUNCTION();
 
@@ -274,7 +274,7 @@ bool TRAP::FS::FileOrFolderExists(const std::filesystem::path& path)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<uintmax_t> TRAP::FS::GetFileOrFolderSize(const std::filesystem::path& path, const bool recursive)
+std::optional<uintmax_t> TRAP::FileSystem::GetFileOrFolderSize(const std::filesystem::path& path, const bool recursive)
 {
     TP_PROFILE_FUNCTION();
 
@@ -378,7 +378,7 @@ std::optional<uintmax_t> TRAP::FS::GetFileOrFolderSize(const std::filesystem::pa
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::file_time_type> TRAP::FS::GetLastWriteTime(const std::filesystem::path& path)
+std::optional<std::filesystem::file_time_type> TRAP::FileSystem::GetLastWriteTime(const std::filesystem::path& path)
 {
     TP_PROFILE_FUNCTION();
 
@@ -399,7 +399,7 @@ std::optional<std::filesystem::file_time_type> TRAP::FS::GetLastWriteTime(const 
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::string> TRAP::FS::GetFileNameWithEnding(const std::filesystem::path& path)
+std::optional<std::string> TRAP::FileSystem::GetFileNameWithEnding(const std::filesystem::path& path)
 {
     TP_PROFILE_FUNCTION();
 
@@ -411,7 +411,7 @@ std::optional<std::string> TRAP::FS::GetFileNameWithEnding(const std::filesystem
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::string> TRAP::FS::GetFileName(const std::filesystem::path& path)
+std::optional<std::string> TRAP::FileSystem::GetFileName(const std::filesystem::path& path)
 {
     TP_PROFILE_FUNCTION();
 
@@ -423,7 +423,7 @@ std::optional<std::string> TRAP::FS::GetFileName(const std::filesystem::path& pa
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::string> TRAP::FS::GetFileEnding(const std::filesystem::path& path)
+std::optional<std::string> TRAP::FileSystem::GetFileEnding(const std::filesystem::path& path)
 {
     TP_PROFILE_FUNCTION();
 
@@ -435,7 +435,7 @@ std::optional<std::string> TRAP::FS::GetFileEnding(const std::filesystem::path& 
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::path> TRAP::FS::GetFolderPath(const std::filesystem::path& filePath)
+std::optional<std::filesystem::path> TRAP::FileSystem::GetFolderPath(const std::filesystem::path& filePath)
 {
     TP_PROFILE_FUNCTION();
 
@@ -447,7 +447,7 @@ std::optional<std::filesystem::path> TRAP::FS::GetFolderPath(const std::filesyst
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::path> TRAP::FS::GetTempFolderPath()
+std::optional<std::filesystem::path> TRAP::FileSystem::GetTempFolderPath()
 {
     std::error_code ec;
     const std::filesystem::path path = std::filesystem::temp_directory_path(ec);
@@ -463,7 +463,7 @@ std::optional<std::filesystem::path> TRAP::FS::GetTempFolderPath()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::path> TRAP::FS::GetGameTempFolderPath()
+std::optional<std::filesystem::path> TRAP::FileSystem::GetGameTempFolderPath()
 {
     const auto tempFolder = GetTempFolderPath();
     if(!tempFolder)
@@ -474,7 +474,7 @@ std::optional<std::filesystem::path> TRAP::FS::GetGameTempFolderPath()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::path> TRAP::FS::GetCurrentFolderPath()
+std::optional<std::filesystem::path> TRAP::FileSystem::GetCurrentFolderPath()
 {
     std::error_code ec;
     const std::filesystem::path path = std::filesystem::current_path(ec);
@@ -490,7 +490,7 @@ std::optional<std::filesystem::path> TRAP::FS::GetCurrentFolderPath()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::path> TRAP::FS::GetDocumentsFolderPath()
+std::optional<std::filesystem::path> TRAP::FileSystem::GetDocumentsFolderPath()
 {
 #ifdef TRAP_PLATFORM_WINDOWS
     PWSTR path = nullptr;
@@ -522,7 +522,7 @@ std::optional<std::filesystem::path> TRAP::FS::GetDocumentsFolderPath()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::path> TRAP::FS::GetGameDocumentsFolderPath()
+std::optional<std::filesystem::path> TRAP::FileSystem::GetGameDocumentsFolderPath()
 {
 	const auto docsFolder = GetDocumentsFolderPath();
     if(!docsFolder)
@@ -533,7 +533,7 @@ std::optional<std::filesystem::path> TRAP::FS::GetGameDocumentsFolderPath()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::path> TRAP::FS::GetGameLogFolderPath()
+std::optional<std::filesystem::path> TRAP::FileSystem::GetGameLogFolderPath()
 {
 #ifndef TRAP_HEADLESS_MODE
     const auto docsFolder = GetGameDocumentsFolderPath();
@@ -548,7 +548,7 @@ std::optional<std::filesystem::path> TRAP::FS::GetGameLogFolderPath()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::IsPathEquivalent(const std::filesystem::path& p1, const std::filesystem::path& p2)
+bool TRAP::FileSystem::IsPathEquivalent(const std::filesystem::path& p1, const std::filesystem::path& p2)
 {
     std::error_code ec;
     const bool res = std::filesystem::equivalent(p1, p2, ec);
@@ -564,7 +564,7 @@ bool TRAP::FS::IsPathEquivalent(const std::filesystem::path& p1, const std::file
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::IsPathAbsolute(const std::filesystem::path& p)
+bool TRAP::FileSystem::IsPathAbsolute(const std::filesystem::path& p)
 {
     //is_absolute() may throw implementation-defined exception
     try
@@ -580,7 +580,7 @@ bool TRAP::FS::IsPathAbsolute(const std::filesystem::path& p)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::IsPathRelative(const std::filesystem::path& p)
+bool TRAP::FileSystem::IsPathRelative(const std::filesystem::path& p)
 {
     //is_relative() may throw implementation-defined exception
     try
@@ -596,7 +596,7 @@ bool TRAP::FS::IsPathRelative(const std::filesystem::path& p)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::IsFolder(const std::filesystem::path& p)
+bool TRAP::FileSystem::IsFolder(const std::filesystem::path& p)
 {
     std::error_code ec;
     const bool res = std::filesystem::is_directory(p, ec);
@@ -612,7 +612,7 @@ bool TRAP::FS::IsFolder(const std::filesystem::path& p)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::IsFile(const std::filesystem::path& p)
+bool TRAP::FileSystem::IsFile(const std::filesystem::path& p)
 {
     std::error_code ec;
     const bool res = std::filesystem::is_regular_file(p, ec);
@@ -628,7 +628,7 @@ bool TRAP::FS::IsFile(const std::filesystem::path& p)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::path> TRAP::FS::ToAbsolutePath(const std::filesystem::path& p)
+std::optional<std::filesystem::path> TRAP::FileSystem::ToAbsolutePath(const std::filesystem::path& p)
 {
     if(p.is_absolute())
         return p;
@@ -647,7 +647,7 @@ std::optional<std::filesystem::path> TRAP::FS::ToAbsolutePath(const std::filesys
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::optional<std::filesystem::path> TRAP::FS::ToRelativePath(const std::filesystem::path& p)
+std::optional<std::filesystem::path> TRAP::FileSystem::ToRelativePath(const std::filesystem::path& p)
 {
     if(p.is_relative())
         return p;
@@ -666,7 +666,7 @@ std::optional<std::filesystem::path> TRAP::FS::ToRelativePath(const std::filesys
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::OpenFolderInFileBrowser(const std::filesystem::path& p)
+bool TRAP::FileSystem::OpenFolderInFileBrowser(const std::filesystem::path& p)
 {
     if(!FileOrFolderExists(p) || !IsFolder(p))
         return false;
@@ -702,7 +702,7 @@ bool TRAP::FS::OpenFolderInFileBrowser(const std::filesystem::path& p)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::OpenFileInFileBrowser(const std::filesystem::path& p)
+bool TRAP::FileSystem::OpenFileInFileBrowser(const std::filesystem::path& p)
 {
     if(!FileOrFolderExists(p) || !IsFile(p))
         return false;
@@ -742,7 +742,7 @@ bool TRAP::FS::OpenFileInFileBrowser(const std::filesystem::path& p)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::FS::OpenExternally(const std::filesystem::path& p)
+bool TRAP::FileSystem::OpenExternally(const std::filesystem::path& p)
 {
     if(!FileOrFolderExists(p))
         return false;

--- a/TRAP/src/FileSystem/FileSystem.cpp
+++ b/TRAP/src/FileSystem/FileSystem.cpp
@@ -48,15 +48,25 @@ std::optional<std::vector<uint8_t>> TRAP::FileSystem::ReadFile(const std::filesy
     if(!FileOrFolderExists(path))
         return std::nullopt;
 
-    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    const auto fileSize = TRAP::FileSystem::GetFileOrFolderSize(path);
+
+    std::ifstream file(path, std::ios::binary);
     if(!file.is_open() || !file.good())
     {
 		TP_ERROR(Log::FileSystemPrefix, "Couldn't open file: \"", path.u8string(), "\"");
         return std::nullopt;
     }
 
-    std::vector<uint8_t> buffer(file.tellg());
-    file.seekg(0);
+    std::vector<uint8_t> buffer;
+    if(fileSize)
+        buffer.resize(*fileSize);
+    else //Fallback
+    {
+        file.seekg(0, std::ios::end);
+        buffer.resize(file.tellg());
+        file.seekg(0);
+    }
+
     file.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
     file.close();
 

--- a/TRAP/src/FileSystem/FileSystem.cpp
+++ b/TRAP/src/FileSystem/FileSystem.cpp
@@ -51,7 +51,7 @@ std::optional<std::vector<uint8_t>> TRAP::FileSystem::ReadFile(const std::filesy
     std::ifstream file(path, std::ios::binary | std::ios::ate);
     if(!file.is_open() || !file.good())
     {
-		TP_ERROR(Log::FileSystemPrefix, "Couldn't open file: \"", path.generic_u8string(), "\"");
+		TP_ERROR(Log::FileSystemPrefix, "Couldn't open file: \"", path.u8string(), "\"");
         return std::nullopt;
     }
 
@@ -75,7 +75,7 @@ std::optional<std::string> TRAP::FileSystem::ReadTextFile(const std::filesystem:
     std::ifstream file(path);
     if(!file.is_open() || !file.good())
     {
-		TP_ERROR(Log::FileSystemPrefix, "Couldn't open file: \"", path.generic_u8string(), "\"");
+		TP_ERROR(Log::FileSystemPrefix, "Couldn't open file: \"", path.u8string(), "\"");
         return std::nullopt;
     }
 
@@ -106,7 +106,7 @@ bool TRAP::FileSystem::WriteFile(const std::filesystem::path& path, const std::v
     std::ofstream file(path, modeFlags);
     if(!file.is_open() || !file.good())
     {
-	    TP_ERROR(Log::FileSystemPrefix, "Couldn't write file: \"", path.generic_u8string(), "\"");
+	    TP_ERROR(Log::FileSystemPrefix, "Couldn't write file: \"", path.u8string(), "\"");
         return false;
     }
 
@@ -132,7 +132,7 @@ bool TRAP::FileSystem::WriteTextFile(const std::filesystem::path& path, const st
         file.open(path, std::ios::trunc);
     if(!file.is_open() || !file.good())
     {
-        TP_ERROR(Log::FileSystemPrefix, "Couldn't write file: \"", path.generic_u8string(), "\"");
+        TP_ERROR(Log::FileSystemPrefix, "Couldn't write file: \"", path.u8string(), "\"");
         return false;
     }
 
@@ -156,7 +156,7 @@ bool TRAP::FileSystem::CreateFolder(const std::filesystem::path& path)
 
     if(ec)
     {
-        TP_ERROR(Log::FileSystemPrefix, "Couldn't create folder: \"", path.generic_u8string(), "\" (", ec.message(), ")");
+        TP_ERROR(Log::FileSystemPrefix, "Couldn't create folder: \"", path.u8string(), "\" (", ec.message(), ")");
         return false;
     }
 
@@ -180,7 +180,7 @@ bool TRAP::FileSystem::DeleteFileOrFolder(const std::filesystem::path& path)
     {
         if(ec)
         {
-            TP_ERROR(Log::FileSystemPrefix, "Couldn't delete file or folder: \"", path.generic_u8string(),
+            TP_ERROR(Log::FileSystemPrefix, "Couldn't delete file or folder: \"", path.u8string(),
                      "\" (", ec.message(), ")");
             return false;
         }
@@ -189,7 +189,7 @@ bool TRAP::FileSystem::DeleteFileOrFolder(const std::filesystem::path& path)
 
         if(ec)
         {
-            TP_ERROR(Log::FileSystemPrefix, "Couldn't delete file or folder: \"", path.generic_u8string(),
+            TP_ERROR(Log::FileSystemPrefix, "Couldn't delete file or folder: \"", path.u8string(),
                      "\" (", ec.message(), ")");
             return false;
         }
@@ -201,7 +201,7 @@ bool TRAP::FileSystem::DeleteFileOrFolder(const std::filesystem::path& path)
     const bool res = std::filesystem::remove(path, ec);
     if(ec)
     {
-        TP_ERROR(Log::FileSystemPrefix, "Couldn't delete file or folder: \"", path.generic_u8string(),
+        TP_ERROR(Log::FileSystemPrefix, "Couldn't delete file or folder: \"", path.u8string(),
                  "\" (", ec.message(), ")");
         return false;
     }
@@ -221,8 +221,8 @@ bool TRAP::FileSystem::MoveFolder(const std::filesystem::path& oldPath, const st
 
     if(ec)
     {
-        TP_ERROR(Log::FileSystemPrefix, "Couldn't move from: \"", oldPath.generic_u8string(),
-                 "\" to \"", newPath.generic_u8string(), "\"(", ec.message(), ")");
+        TP_ERROR(Log::FileSystemPrefix, "Couldn't move from: \"", oldPath.u8string(),
+                 "\" to \"", newPath.u8string(), "\"(", ec.message(), ")");
         return false;
     }
 
@@ -264,7 +264,7 @@ bool TRAP::FileSystem::FileOrFolderExists(const std::filesystem::path& path)
 
     if(ec)
     {
-        TP_ERROR(Log::FileSystemPrefix, "Couldn't check if file or folder exists: \"", path.generic_u8string(),
+        TP_ERROR(Log::FileSystemPrefix, "Couldn't check if file or folder exists: \"", path.u8string(),
                  "\" (", ec.message(), ")");
         return false;
     }
@@ -286,7 +286,7 @@ std::optional<uintmax_t> TRAP::FileSystem::GetFileOrFolderSize(const std::filesy
 
     if(ec)
     {
-        TP_ERROR(Log::FileSystemPrefix, "Couldn't check if path is a directory: \"", path.generic_u8string(),
+        TP_ERROR(Log::FileSystemPrefix, "Couldn't check if path is a directory: \"", path.u8string(),
                  "\" (", ec.message(), ")");
         return std::nullopt;
     }
@@ -298,7 +298,7 @@ std::optional<uintmax_t> TRAP::FileSystem::GetFileOrFolderSize(const std::filesy
 
         if(ec)
         {
-            TP_ERROR(Log::FileSystemPrefix, "Couldn't check file size of: \"", path.generic_u8string(),
+            TP_ERROR(Log::FileSystemPrefix, "Couldn't check file size of: \"", path.u8string(),
                     "\" (", ec.message(), ")");
             return std::nullopt;
         }
@@ -313,7 +313,7 @@ std::optional<uintmax_t> TRAP::FileSystem::GetFileOrFolderSize(const std::filesy
         const std::filesystem::recursive_directory_iterator rDIt(path, ec);
         if(ec)
         {
-            TP_ERROR(Log::FileSystemPrefix, "Couldn't create recursive directory iterator: \"", path.generic_u8string(),
+            TP_ERROR(Log::FileSystemPrefix, "Couldn't create recursive directory iterator: \"", path.u8string(),
                     "\" (", ec.message(), ")");
             return std::nullopt;
         }
@@ -323,7 +323,7 @@ std::optional<uintmax_t> TRAP::FileSystem::GetFileOrFolderSize(const std::filesy
             res = entry.is_regular_file(ec);
             if(ec)
             {
-                TP_ERROR(Log::FileSystemPrefix, "Couldn't check if path is a regular file: \"", entry.path().generic_u8string(),
+                TP_ERROR(Log::FileSystemPrefix, "Couldn't check if path is a regular file: \"", entry.path().u8string(),
                          "\" (", ec.message(), ")");
                 return std::nullopt;
             }
@@ -332,7 +332,7 @@ std::optional<uintmax_t> TRAP::FileSystem::GetFileOrFolderSize(const std::filesy
                 const uintmax_t fileSize = entry.file_size(ec);
                 if(ec)
                 {
-                    TP_ERROR(Log::FileSystemPrefix, "Couldn't get file size: \"", entry.path().generic_u8string(),
+                    TP_ERROR(Log::FileSystemPrefix, "Couldn't get file size: \"", entry.path().u8string(),
                             "\" (", ec.message(), ")");
                     return std::nullopt;
                 }
@@ -345,7 +345,7 @@ std::optional<uintmax_t> TRAP::FileSystem::GetFileOrFolderSize(const std::filesy
         const std::filesystem::directory_iterator dIt(path, ec);
         if(ec)
         {
-            TP_ERROR(Log::FileSystemPrefix, "Couldn't create directory iterator: \"", path.generic_u8string(),
+            TP_ERROR(Log::FileSystemPrefix, "Couldn't create directory iterator: \"", path.u8string(),
                     "\" (", ec.message(), ")");
             return std::nullopt;
         }
@@ -355,7 +355,7 @@ std::optional<uintmax_t> TRAP::FileSystem::GetFileOrFolderSize(const std::filesy
             res = entry.is_regular_file(ec);
             if(ec)
             {
-                TP_ERROR(Log::FileSystemPrefix, "Couldn't check if path is a regular file: \"", entry.path().generic_u8string(),
+                TP_ERROR(Log::FileSystemPrefix, "Couldn't check if path is a regular file: \"", entry.path().u8string(),
                          "\" (", ec.message(), ")");
                 return std::nullopt;
             }
@@ -364,7 +364,7 @@ std::optional<uintmax_t> TRAP::FileSystem::GetFileOrFolderSize(const std::filesy
                 const uintmax_t fileSize = entry.file_size(ec);
                 if(ec)
                 {
-                    TP_ERROR(Log::FileSystemPrefix, "Couldn't get file size: \"", entry.path().generic_u8string(),
+                    TP_ERROR(Log::FileSystemPrefix, "Couldn't get file size: \"", entry.path().u8string(),
                             "\" (", ec.message(), ")");
                     return std::nullopt;
                 }
@@ -389,7 +389,7 @@ std::optional<std::filesystem::file_time_type> TRAP::FileSystem::GetLastWriteTim
     const auto res = std::filesystem::last_write_time(path, ec);
     if(ec)
     {
-        TP_ERROR(Log::FileSystemPrefix, "Couldn't get last write time: \"", path.generic_u8string(),
+        TP_ERROR(Log::FileSystemPrefix, "Couldn't get last write time: \"", path.u8string(),
                  "\" (", ec.message(), ")");
         return std::nullopt;
     }
@@ -406,7 +406,7 @@ std::optional<std::string> TRAP::FileSystem::GetFileNameWithEnding(const std::fi
     if(path.empty() || !path.has_filename())
         return std::nullopt;
 
-    return path.filename().generic_u8string();
+    return path.filename().u8string();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -418,7 +418,7 @@ std::optional<std::string> TRAP::FileSystem::GetFileName(const std::filesystem::
     if(path.empty() || !path.has_stem())
         return std::nullopt;
 
-    return path.stem().generic_u8string();
+    return path.stem().u8string();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -430,7 +430,7 @@ std::optional<std::string> TRAP::FileSystem::GetFileEnding(const std::filesystem
     if(path.empty() || !path.has_extension())
         return std::nullopt;
 
-    return path.extension().generic_u8string();
+    return path.extension().u8string();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -442,7 +442,7 @@ std::optional<std::filesystem::path> TRAP::FileSystem::GetFolderPath(const std::
     if (filePath.empty())
         return std::nullopt;
 
-    return filePath.parent_path().generic_u8string();
+    return filePath.parent_path();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -458,7 +458,7 @@ std::optional<std::filesystem::path> TRAP::FileSystem::GetTempFolderPath()
         return std::nullopt;
     }
 
-    return (path / "TRAP").generic_u8string();
+    return (path / "TRAP");
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -469,7 +469,7 @@ std::optional<std::filesystem::path> TRAP::FileSystem::GetGameTempFolderPath()
     if(!tempFolder)
         return std::nullopt;
 
-    return (*tempFolder / TRAP::Application::GetGameName()).generic_u8string();
+    return (*tempFolder / TRAP::Application::GetGameName());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -481,11 +481,11 @@ std::optional<std::filesystem::path> TRAP::FileSystem::GetCurrentFolderPath()
 
     if(ec)
     {
-        TP_ERROR(Log::FileSystemPrefix, "Couldn't get current directory path: \"", path, "\" (", ec.message(), ")");
+        TP_ERROR(Log::FileSystemPrefix, "Couldn't get current directory path (", ec.message(), ")");
         return std::nullopt;
     }
 
-    return path.generic_u8string();
+    return path;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -514,7 +514,7 @@ std::optional<std::filesystem::path> TRAP::FileSystem::GetDocumentsFolderPath()
     const auto docsFolder = GetDocumentsFolderPathLinux();
     if(!docsFolder)
         return std::nullopt;
-    return (*docsFolder).generic_u8string();
+    return *docsFolder;
 #else
     return std::nullopt;
 #endif
@@ -528,7 +528,7 @@ std::optional<std::filesystem::path> TRAP::FileSystem::GetGameDocumentsFolderPat
     if(!docsFolder)
         return std::nullopt;
 
-    return (*docsFolder / "TRAP" / TRAP::Application::GetGameName()).generic_u8string();
+    return (*docsFolder / "TRAP" / TRAP::Application::GetGameName());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -540,7 +540,7 @@ std::optional<std::filesystem::path> TRAP::FileSystem::GetGameLogFolderPath()
     if(!docsFolder)
         return std::nullopt;
 
-    return (*docsFolder / "logs").generic_u8string();
+    return (*docsFolder / "logs");
 #else
     return "logs";
 #endif
@@ -688,7 +688,7 @@ bool TRAP::FileSystem::OpenFolderInFileBrowser(const std::filesystem::path& p)
     return reinterpret_cast<const INT_PTR>(res) > 32;
 #elif defined(TRAP_PLATFORM_LINUX)
     std::string cmd = "xdg-open ";
-    cmd += (*absPath).generic_u8string();
+    cmd += (*absPath).u8string();
     FILE* xdg = popen(cmd.c_str(), "r");
     if(!xdg)
         return false;
@@ -728,7 +728,7 @@ bool TRAP::FileSystem::OpenFileInFileBrowser(const std::filesystem::path& p)
     return res == S_OK;
 #elif defined(TRAP_PLATFORM_LINUX)
     std::string cmd = "xdg-open ";
-    cmd += (*absPath).parent_path().generic_u8string();
+    cmd += (*absPath).parent_path().u8string();
     FILE* xdg = popen(cmd.c_str(), "r");
     if(!xdg)
         return false;
@@ -764,7 +764,7 @@ bool TRAP::FileSystem::OpenExternally(const std::filesystem::path& p)
     return reinterpret_cast<const INT_PTR>(res) > 32;
 #elif defined(TRAP_PLATFORM_LINUX)
     std::string cmd = "xdg-open ";
-    cmd += (*absPath).generic_u8string();
+    cmd += (*absPath).u8string();
     FILE* xdg = popen(cmd.c_str(), "r");
     if(!xdg)
         return false;
@@ -903,12 +903,12 @@ std::optional<std::filesystem::path> GetDocumentsFolderPathLinux()
     }
     file.close();
 
-    if(documentsDir.generic_u8string().compare(0, 5, "$HOME") == 0)
+    if(documentsDir.u8string().compare(0, 5, "$HOME") == 0)
     {
         const auto homeFolder = GetHomeFolderPathLinux();
         if(!homeFolder)
             return std::nullopt;
-        documentsDir = (*homeFolder).generic_u8string() + documentsDir.generic_u8string().substr(5, std::string::npos);
+        documentsDir = (*homeFolder).u8string() + documentsDir.u8string().substr(5, std::string::npos);
     }
 
     return documentsDir;

--- a/TRAP/src/FileSystem/FileSystem.cpp
+++ b/TRAP/src/FileSystem/FileSystem.cpp
@@ -195,7 +195,7 @@ bool TRAP::FileSystem::DeleteFileOrFolder(const std::filesystem::path& path)
             return false;
         }
 
-        bool res = std::filesystem::remove_all(path, ec) > 1;
+        const bool res = std::filesystem::remove_all(path, ec) > 1;
 
         if(ec)
         {
@@ -809,8 +809,8 @@ std::optional<std::filesystem::path> GetHomeFolderPathLinux()
     if(!homeDir.empty())
         return homeDir;
 
-    uid_t uid = getuid();
-    const char* homeEnv = std::getenv("HOME");
+    const uid_t uid = getuid();
+    const char* homeEnv = getenv("HOME");
     if(uid != 0 && homeEnv)
     {
         //We only acknowledge HOME if not root.
@@ -824,7 +824,7 @@ std::optional<std::filesystem::path> GetHomeFolderPathLinux()
     if(bufSize < 0)
         bufSize = 16384;
     std::vector<char> buffer(bufSize, '\0');
-    int32_t errorCode = getpwuid_r(uid, &pwd, buffer.data(), buffer.size(), &pw);
+    const int32_t errorCode = getpwuid_r(uid, &pwd, buffer.data(), buffer.size(), &pw);
     if(errorCode)
     {
         TP_ERROR(TRAP::Log::FileSystemPrefix, "Failed to get home folder path (", errorCode, ")");
@@ -867,7 +867,7 @@ std::optional<std::filesystem::path> GetDocumentsFolderPathLinux()
     documentsDir = "$HOME/Documents";
 
     //Get config folder
-    const char* tempRes = std::getenv("XDG_CONFIG_HOME");
+    const char* tempRes = getenv("XDG_CONFIG_HOME");
     std::filesystem::path configPath{};
     if(tempRes)
         configPath = tempRes;

--- a/TRAP/src/FileSystem/FileSystem.h
+++ b/TRAP/src/FileSystem/FileSystem.h
@@ -35,9 +35,7 @@
 
 namespace TRAP
 {
-	namespace FileSystem = FS;
-
-	namespace FS
+	namespace FileSystem
     {
         /// <summary>
 		/// Write mode to be used by writing operations.
@@ -314,7 +312,7 @@ namespace TRAP
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr void TRAP::FS::Shutdown()
+constexpr void TRAP::FileSystem::Shutdown()
 {
 	TP_PROFILE_FUNCTION();
 

--- a/TRAP/src/FileSystem/FileWatcher.cpp
+++ b/TRAP/src/FileSystem/FileWatcher.cpp
@@ -106,7 +106,7 @@ void TRAP::FileSystem::FileWatcher::RemoveFolder(const std::filesystem::path& pa
     if(std::find(m_paths.begin(), m_paths.end(), *absPath) != m_paths.end())
     {
         Shutdown();
-        m_paths.erase(std::remove(m_paths.begin(), m_paths.end(), (*absPath).generic_u8string()),
+        m_paths.erase(std::remove(m_paths.begin(), m_paths.end(), (*absPath)),
                         m_paths.end());
         Init();
     }
@@ -128,7 +128,7 @@ void TRAP::FileSystem::FileWatcher::RemoveFolders(const std::vector<std::filesys
         if(!absPath) //Skip empty path
             continue;
 
-        m_paths.erase(std::remove(m_paths.begin(), m_paths.end(), (*absPath).generic_u8string()),
+        m_paths.erase(std::remove(m_paths.begin(), m_paths.end(), (*absPath).u8string()),
                       m_paths.end());
     }
 
@@ -263,7 +263,7 @@ void TRAP::FileSystem::FileWatcher::Watch()
                 }
                const std::size_t filenameLength = notify->FileNameLength / sizeof(wchar_t);
 
-                std::filesystem::path filePath = (m_paths[i] / std::filesystem::path(std::wstring(notify->FileName, filenameLength))).generic_u8string();
+                std::filesystem::path filePath = (m_paths[i] / std::filesystem::path(std::wstring(notify->FileName, filenameLength)));
                 FileStatus status;
                 std::filesystem::path oldFileName = "";
 
@@ -355,7 +355,7 @@ void TRAP::FileSystem::FileWatcher::Watch()
 
     for(const auto& path : m_paths)
     {
-        const int32_t wd = inotify_add_watch(fileDescriptors[0].fd, path.generic_u8string().c_str(),
+        const int32_t wd = inotify_add_watch(fileDescriptors[0].fd, path.u8string().c_str(),
                                              IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO);
 
         if(wd < 0)
@@ -376,7 +376,7 @@ void TRAP::FileSystem::FileWatcher::Watch()
 
             for(const auto& p : it)
             {
-                const int32_t wd = inotify_add_watch(fileDescriptors[0].fd, p.path().generic_u8string().c_str(),
+                const int32_t wd = inotify_add_watch(fileDescriptors[0].fd, p.path().u8string().c_str(),
                                                     IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO);
 
                 if(wd < 0)
@@ -385,7 +385,7 @@ void TRAP::FileSystem::FileWatcher::Watch()
                     continue; //Skip failed entry
                 }
 
-                watchDescriptors[wd] = p.path().generic_u8string();
+                watchDescriptors[wd] = p.path();
             }
         }
     }
@@ -460,7 +460,7 @@ void TRAP::FileSystem::FileWatcher::Watch()
             }
 
             FileStatus status = FileStatus::Created;
-            std::filesystem::path filePath = watchDescriptors[event->wd] / std::filesystem::path(event->name).generic_u8string();
+            std::filesystem::path filePath = watchDescriptors[event->wd] / std::filesystem::path(event->name);
             bool isDir = std::filesystem::is_directory(filePath);
             std::filesystem::path oldFileName = "";
 
@@ -468,7 +468,7 @@ void TRAP::FileSystem::FileWatcher::Watch()
             {
                 if(isDir && m_recursive) //Add to tracking list
                 {
-                    const int32_t wd = inotify_add_watch(fileDescriptors[0].fd, filePath.generic_u8string().c_str(),
+                    const int32_t wd = inotify_add_watch(fileDescriptors[0].fd, filePath.u8string().c_str(),
                                                             IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO);
 
                     if(wd < 0)

--- a/TRAP/src/FileSystem/FileWatcher.cpp
+++ b/TRAP/src/FileSystem/FileWatcher.cpp
@@ -1,11 +1,11 @@
 #include "TRAPPCH.h"
 #include "FileWatcher.h"
 
-#include "FS.h"
+#include "FileSystem.h"
 #include "Events/FileEvent.h"
 #include "Utils/Utils.h"
 
-TRAP::FS::FileWatcher::FileWatcher(const std::vector<std::filesystem::path>& paths, const bool recursive)
+TRAP::FileSystem::FileWatcher::FileWatcher(const std::vector<std::filesystem::path>& paths, const bool recursive)
     : m_recursive(recursive), m_run(true)
 {
     if(paths.empty())
@@ -17,7 +17,7 @@ TRAP::FS::FileWatcher::FileWatcher(const std::vector<std::filesystem::path>& pat
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::FS::FileWatcher::FileWatcher(const std::filesystem::path& path, const bool recursive)
+TRAP::FileSystem::FileWatcher::FileWatcher(const std::filesystem::path& path, const bool recursive)
     : m_recursive(recursive), m_run(true)
 {
     if(path.empty())
@@ -29,34 +29,34 @@ TRAP::FS::FileWatcher::FileWatcher(const std::filesystem::path& path, const bool
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::FS::FileWatcher::~FileWatcher()
+TRAP::FileSystem::FileWatcher::~FileWatcher()
 {
     Shutdown();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::FS::FileWatcher::SetEventCallback(const EventCallbackFn& callback)
+void TRAP::FileSystem::FileWatcher::SetEventCallback(const EventCallbackFn& callback)
 {
     m_callback = callback;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::FS::FileWatcher::EventCallbackFn TRAP::FS::FileWatcher::GetEventCallback()
+TRAP::FileSystem::FileWatcher::EventCallbackFn TRAP::FileSystem::FileWatcher::GetEventCallback()
 {
     return m_callback;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::FS::FileWatcher::AddFolder(const std::filesystem::path& path)
+void TRAP::FileSystem::FileWatcher::AddFolder(const std::filesystem::path& path)
 {
     if(path.empty())
         return;
 
     //Always use absolute paths
-    const auto absPath = FS::ToAbsolutePath(path);
+    const auto absPath = FileSystem::ToAbsolutePath(path);
     if(!absPath)
         return;
 
@@ -71,7 +71,7 @@ void TRAP::FS::FileWatcher::AddFolder(const std::filesystem::path& path)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::FS::FileWatcher::AddFolders(const std::vector<std::filesystem::path>& paths)
+void TRAP::FileSystem::FileWatcher::AddFolders(const std::vector<std::filesystem::path>& paths)
 {
     if(paths.empty())
         return;
@@ -81,7 +81,7 @@ void TRAP::FS::FileWatcher::AddFolders(const std::vector<std::filesystem::path>&
     for (const auto& path : paths)
     {
         //Always use absolute paths
-        const auto absPath = FS::ToAbsolutePath(path);
+        const auto absPath = FileSystem::ToAbsolutePath(path);
         if(!absPath) //Skip invalid paths
             continue;
 
@@ -95,10 +95,10 @@ void TRAP::FS::FileWatcher::AddFolders(const std::vector<std::filesystem::path>&
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::FS::FileWatcher::RemoveFolder(const std::filesystem::path& path)
+void TRAP::FileSystem::FileWatcher::RemoveFolder(const std::filesystem::path& path)
 {
     //Always use absolute paths
-    const auto absPath = FS::ToAbsolutePath(path);
+    const auto absPath = FileSystem::ToAbsolutePath(path);
     if(!absPath)
         return;
 
@@ -114,7 +114,7 @@ void TRAP::FS::FileWatcher::RemoveFolder(const std::filesystem::path& path)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::FS::FileWatcher::RemoveFolders(const std::vector<std::filesystem::path>& paths)
+void TRAP::FileSystem::FileWatcher::RemoveFolders(const std::vector<std::filesystem::path>& paths)
 {
     if(paths.empty())
         return;
@@ -124,7 +124,7 @@ void TRAP::FS::FileWatcher::RemoveFolders(const std::vector<std::filesystem::pat
     for(const auto& path : paths)
     {
         //Always use absolute paths
-        const auto& absPath = FS::ToAbsolutePath(path);
+        const auto& absPath = FileSystem::ToAbsolutePath(path);
         if(!absPath) //Skip empty path
             continue;
 
@@ -137,14 +137,14 @@ void TRAP::FS::FileWatcher::RemoveFolders(const std::vector<std::filesystem::pat
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::vector<std::filesystem::path> TRAP::FS::FileWatcher::GetFolders() const
+std::vector<std::filesystem::path> TRAP::FileSystem::FileWatcher::GetFolders() const
 {
     return m_paths;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::FS::FileWatcher::Init()
+void TRAP::FileSystem::FileWatcher::Init()
 {
     if(m_paths.empty())
         return;
@@ -156,12 +156,12 @@ void TRAP::FS::FileWatcher::Init()
 #elif defined(TRAP_PLATFORM_LINUX)
     m_killEvent = eventfd(0, 0);
 #endif
-    m_thread = std::thread(&TRAP::FS::FileWatcher::Watch, this);
+    m_thread = std::thread(&TRAP::FileSystem::FileWatcher::Watch, this);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::FS::FileWatcher::Shutdown()
+void TRAP::FileSystem::FileWatcher::Shutdown()
 {
     if(!m_run)
         return;
@@ -193,7 +193,7 @@ void TRAP::FS::FileWatcher::Shutdown()
 //-------------------------------------------------------------------------------------------------------------------//
 
 #ifdef TRAP_PLATFORM_WINDOWS
-void TRAP::FS::FileWatcher::Watch()
+void TRAP::FileSystem::FileWatcher::Watch()
 {
     //Thread init
     std::vector<Events::FileChangeEvent> events;
@@ -323,7 +323,7 @@ void TRAP::FS::FileWatcher::Watch()
 //-------------------------------------------------------------------------------------------------------------------//
 
 #elif defined(TRAP_PLATFORM_LINUX)
-void TRAP::FS::FileWatcher::Watch()
+void TRAP::FileSystem::FileWatcher::Watch()
 {
     //Thread init
     std::vector<Events::FileChangeEvent> events;

--- a/TRAP/src/FileSystem/FileWatcher.h
+++ b/TRAP/src/FileSystem/FileWatcher.h
@@ -11,7 +11,7 @@ namespace TRAP::Events
     class Event;
 }
 
-namespace TRAP::FS
+namespace TRAP::FileSystem
 {
     /// <summary>
     /// Specifies the status of a file.

--- a/TRAP/src/FileSystem/FileWatcher.h
+++ b/TRAP/src/FileSystem/FileWatcher.h
@@ -85,7 +85,7 @@ namespace TRAP::FileSystem
 		/// Get the function to call when an file event occurred.
 		/// </summary>
 		/// <returns>EventCallbackFn.</returns>
-		EventCallbackFn GetEventCallback();
+		EventCallbackFn GetEventCallback() const;
 
         /// <summary>Adds a new folder path to the tracked paths.</summary>
         /// <param name="path">Folder path to track.</param>

--- a/TRAP/src/Graphics/API/CommonShaderReflection.cpp
+++ b/TRAP/src/Graphics/API/CommonShaderReflection.cpp
@@ -1,8 +1,8 @@
 #include "TRAPPCH.h"
 #include "ShaderReflection.h"
 
-bool ShaderResourceCmp(TRAP::Graphics::API::ShaderReflection::ShaderResource& a,
-                       TRAP::Graphics::API::ShaderReflection::ShaderResource& b)
+constexpr bool ShaderResourceCmp(const TRAP::Graphics::API::ShaderReflection::ShaderResource& a,
+                                 const TRAP::Graphics::API::ShaderReflection::ShaderResource& b)
 {
 	bool isSame = true;
 
@@ -15,8 +15,8 @@ bool ShaderResourceCmp(TRAP::Graphics::API::ShaderReflection::ShaderResource& a,
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool ShaderVariableCmp(TRAP::Graphics::API::ShaderReflection::ShaderVariable& a,
-                       TRAP::Graphics::API::ShaderReflection::ShaderVariable& b)
+constexpr bool ShaderVariableCmp(const TRAP::Graphics::API::ShaderReflection::ShaderVariable& a,
+                                 const TRAP::Graphics::API::ShaderReflection::ShaderVariable& b)
 {
 	bool isSame = true;
 
@@ -71,7 +71,7 @@ TRAP::Ref<TRAP::Graphics::API::ShaderReflection::PipelineReflection> TRAP::Graph
 	std::vector<ShaderVariable> variables;
 	std::size_t variableCount = 0;
 
-	TRAP::Ref<PipelineReflection> out = TRAP::MakeRef<PipelineReflection>();
+	const TRAP::Ref<PipelineReflection> out = TRAP::MakeRef<PipelineReflection>();
 
 	std::array<ShaderResource*, 512> uniqueResources{};
 	std::array<RendererAPI::ShaderStage, 512> shaderUsage{};
@@ -166,7 +166,7 @@ TRAP::Ref<TRAP::Graphics::API::ShaderReflection::PipelineReflection> TRAP::Graph
 		for(std::size_t i = 0; i < variableCount; ++i)
 		{
 			variables[i] = *uniqueVariable[i];
-			ShaderResource* parentResource = uniqueVariableParent[i];
+			const ShaderResource* parentResource = uniqueVariableParent[i];
 			//Look for parent
 			for(std::size_t j = 0; j < resourceCount; ++j)
 			{

--- a/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
+++ b/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
@@ -191,12 +191,12 @@ void TRAP::Graphics::AftermathTracker::Shutdown()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::AftermathTracker::SetAftermathMarker([[maybe_unused]] const std::string& name)
+void TRAP::Graphics::AftermathTracker::SetAftermathMarker([[maybe_unused]] const std::string_view name)
 {
 #ifdef ENABLE_NSIGHT_AFTERMATH
     /*if(TRAP::Graphics::RendererAPI::GetRenderAPI() == TRAP::Graphics::RenderAPI::D3D12 && context)
     {
-        AftermathCall(setEventMarker(aftermathHandle, name.c_str(), name.size()));
+        AftermathCall(setEventMarker(aftermathHandle, name.data(), name.size()));
     }*/
 #endif
 }

--- a/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
+++ b/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
@@ -44,7 +44,7 @@ void OnCrashDump([[maybe_unused]] const void* gpuCrashDump,
     std::filesystem::path filePath = folderPath / ("crash_" + dateTimeStamp + ".dump");
     std::lock_guard lock(mutex);
     std::vector<uint8_t> buffer(gpuCrashDumpSize);
-    std::copy_n(reinterpret_cast<const uint8_t*>(gpuCrashDump), gpuCrashDumpSize, buffer.begin());
+    std::copy_n(static_cast<const uint8_t*>(gpuCrashDump), gpuCrashDumpSize, buffer.begin());
     if(!TRAP::FS::FileOrFolderExists(folderPath))
         TRAP::FS::CreateFolder(folderPath);
     TRAP::FS::WriteFile(filePath, buffer);

--- a/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
+++ b/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
@@ -40,8 +40,8 @@ void OnCrashDump([[maybe_unused]] const void* gpuCrashDump,
     std::string dateTimeStamp = TRAP::Utils::String::GetDateTimeStamp(std::chrono::system_clock::now());
     std::replace(dateTimeStamp.begin(), dateTimeStamp.end(), ':', '-');
 
-    std::filesystem::path folderPath = *docsFolder / "TRAP" / TRAP::Application::GetGameName() / "crash-dumps";
-    std::filesystem::path filePath = folderPath / ("crash_" + dateTimeStamp + ".dump");
+    const std::filesystem::path folderPath = *docsFolder / "TRAP" / TRAP::Application::GetGameName() / "crash-dumps";
+    const std::filesystem::path filePath = folderPath / ("crash_" + dateTimeStamp + ".dump");
     std::lock_guard lock(mutex);
     std::vector<uint8_t> buffer(gpuCrashDumpSize);
     std::copy_n(static_cast<const uint8_t*>(gpuCrashDump), gpuCrashDumpSize, buffer.begin());

--- a/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
+++ b/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
@@ -1,7 +1,7 @@
 #include "TRAPPCH.h"
 #include "AftermathTracker.h"
 
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Application.h"
 #include "Utils/DynamicLoading/DynamicLoading.h"
 
@@ -33,7 +33,7 @@ void OnCrashDump([[maybe_unused]] const void* gpuCrashDump,
                  void* /*userData*/)
 {
 #ifdef ENABLE_NSIGHT_AFTERMATH
-    const auto docsFolder = TRAP::FS::GetDocumentsFolderPath();
+    const auto docsFolder = TRAP::FileSystem::GetDocumentsFolderPath();
     if(!docsFolder)
         return;
 
@@ -45,9 +45,9 @@ void OnCrashDump([[maybe_unused]] const void* gpuCrashDump,
     std::lock_guard lock(mutex);
     std::vector<uint8_t> buffer(gpuCrashDumpSize);
     std::copy_n(static_cast<const uint8_t*>(gpuCrashDump), gpuCrashDumpSize, buffer.begin());
-    if(!TRAP::FS::FileOrFolderExists(folderPath))
-        TRAP::FS::CreateFolder(folderPath);
-    TRAP::FS::WriteFile(filePath, buffer);
+    if(!TRAP::FileSystem::FileOrFolderExists(folderPath))
+        TRAP::FileSystem::CreateFolder(folderPath);
+    TRAP::FileSystem::WriteFile(filePath, buffer);
 #endif
 }
 

--- a/TRAP/src/Graphics/API/Objects/AftermathTracker.h
+++ b/TRAP/src/Graphics/API/Objects/AftermathTracker.h
@@ -19,7 +19,7 @@ namespace TRAP::Graphics::AftermathTracker
 	/// Set a marker.
 	/// </summary>
 	/// <param name="name">Name of the marker.</param>
-	void SetAftermathMarker(const std::string& name);
+	void SetAftermathMarker(const std::string_view name);
 
 #ifdef ENABLE_NSIGHT_AFTERMATH
 	/// <summary>

--- a/TRAP/src/Graphics/API/Objects/CommandBuffer.h
+++ b/TRAP/src/Graphics/API/Objects/CommandBuffer.h
@@ -106,8 +106,8 @@ namespace TRAP::Graphics
 		virtual void BindRenderTargets(const std::vector<TRAP::Ref<RenderTarget>>& renderTargets,
 			                           const TRAP::Ref<RenderTarget>& depthStencil,
 			                           const RendererAPI::LoadActionsDesc* loadActions,
-			                           std::vector<uint32_t>* colorArraySlices,
-			                           std::vector<uint32_t>* colorMipSlices,
+			                           const std::vector<uint32_t>* colorArraySlices,
+			                           const std::vector<uint32_t>* colorMipSlices,
 			                           uint32_t depthArraySlice, uint32_t depthMipSlice) = 0;
 
 		/// <summary>
@@ -307,7 +307,7 @@ namespace TRAP::Graphics
 		/// <param name="color">Color to clear the color attachment with.</param>
 		/// <param name="width">Width of the area to clear.</param>
 		/// <param name="height">Height of the area to clear.</param>
-		virtual void Clear(TRAP::Math::Vec4 color, uint32_t width, uint32_t height) = 0;
+		virtual void Clear(TRAP::Math::Vec4 color, uint32_t width, uint32_t height) const = 0;
 		/// <summary>
 		/// Clear the currently used depth and stencil attachment.
 		/// </summary>
@@ -315,21 +315,21 @@ namespace TRAP::Graphics
 		/// <param name="stencil">Stencil value to clear the stencil attachment with.</param>
 		/// <param name="width">Width of the area to clear.</param>
 		/// <param name="height">Height of the area to clear.</param>
-		virtual void Clear(float depth, uint32_t stencil, uint32_t width, uint32_t height) = 0;
+		virtual void Clear(float depth, uint32_t stencil, uint32_t width, uint32_t height) const = 0;
 		/// <summary>
 		/// Clear the currently used depth attachment.
 		/// </summary>
 		/// <param name="depth">Depth value to clear the depth attachment with.</param>
 		/// <param name="width">Width of the area to clear.</param>
 		/// <param name="height">Height of the area to clear.</param>
-		virtual void Clear(float depth, uint32_t width, uint32_t height) = 0;
+		virtual void Clear(float depth, uint32_t width, uint32_t height) const = 0;
 		/// <summary>
 		/// Clear the currently used stencil attachment.
 		/// </summary>
 		/// <param name="stencil">Stencil value to clear the stencil attachment with.</param>
 		/// <param name="width">Width of the area to clear.</param>
 		/// <param name="height">Height of the area to clear.</param>
-		virtual void Clear(uint32_t stencil, uint32_t width, uint32_t height) = 0;
+		virtual void Clear(uint32_t stencil, uint32_t width, uint32_t height) const = 0;
 
 	protected:
 		/// <summary>

--- a/TRAP/src/Graphics/API/Objects/CommandBuffer.h
+++ b/TRAP/src/Graphics/API/Objects/CommandBuffer.h
@@ -115,13 +115,13 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <param name="color">Color for the debug marker.</param>
 		/// <param name="name">Name of the marker.</param>
-		virtual void AddDebugMarker(const TRAP::Math::Vec3& color, const char* name) const = 0;
+		virtual void AddDebugMarker(const TRAP::Math::Vec3& color, std::string_view name) const = 0;
 		/// <summary>
 		/// Start a debug marker region.
 		/// </summary>
 		/// <param name="color">Color for the debug marker.</param>
 		/// <param name="name">Name of the marker.</param>
-		virtual void BeginDebugMarker(const TRAP::Math::Vec3& color, const char* name) const = 0;
+		virtual void BeginDebugMarker(const TRAP::Math::Vec3& color, std::string_view name) const = 0;
 		/// <summary>
 		/// End the currently running debug marker region.
 		/// </summary>

--- a/TRAP/src/Graphics/API/Objects/DescriptorPool.cpp
+++ b/TRAP/src/Graphics/API/Objects/DescriptorPool.cpp
@@ -3,7 +3,7 @@
 
 #include "Graphics/API/Vulkan/Objects/VulkanDescriptorPool.h"
 
-TRAP::Ref<TRAP::Graphics::DescriptorPool> TRAP::Graphics::DescriptorPool::Create(uint32_t numDescriptorSets)
+TRAP::Ref<TRAP::Graphics::DescriptorPool> TRAP::Graphics::DescriptorPool::Create(const uint32_t numDescriptorSets)
 {
 	switch(RendererAPI::GetRenderAPI())
 	{

--- a/TRAP/src/Graphics/API/Objects/Fence.h
+++ b/TRAP/src/Graphics/API/Objects/Fence.h
@@ -38,7 +38,11 @@ namespace TRAP::Graphics
 		/// </summary>
 		Fence& operator=(Fence&&) = default;
 
-		virtual bool IsSubmitted() const;
+		/// <summary>
+		/// Retrieve whether the Fence was submitted or not.
+		/// </summary>
+		/// <returns>True if Fence was submitted, false otherwise.</returns>
+		bool IsSubmitted() const;
 
 		/// <summary>
 		/// Retrieve the current status of the fence.

--- a/TRAP/src/Graphics/API/Objects/PipelineCache.cpp
+++ b/TRAP/src/Graphics/API/Objects/PipelineCache.cpp
@@ -2,7 +2,7 @@
 #include "PipelineCache.h"
 
 #include "Graphics/API/Vulkan/Objects/VulkanPipelineCache.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 TRAP::Graphics::PipelineCache::PipelineCache()
 {
@@ -51,7 +51,7 @@ TRAP::Ref<TRAP::Graphics::PipelineCache> TRAP::Graphics::PipelineCache::Create(c
 		if(!std::filesystem::exists(desc.Path))
 			return TRAP::Graphics::PipelineCache::Create(cacheDesc); //Empty cache
 
-		const auto data = TRAP::FS::ReadFile(desc.Path);
+		const auto data = TRAP::FileSystem::ReadFile(desc.Path);
 		if(!data)
 			return TRAP::Graphics::PipelineCache::Create(cacheDesc); //Empty cache
 

--- a/TRAP/src/Graphics/API/Objects/PipelineCache.cpp
+++ b/TRAP/src/Graphics/API/Objects/PipelineCache.cpp
@@ -46,12 +46,18 @@ TRAP::Ref<TRAP::Graphics::PipelineCache> TRAP::Graphics::PipelineCache::Create(c
 	{
 	case RenderAPI::Vulkan:
 	{
-		TRAP::Graphics::RendererAPI::PipelineCacheDesc cacheDesc;
+		TRAP::Graphics::RendererAPI::PipelineCacheDesc cacheDesc{};
 		cacheDesc.Flags = desc.Flags;
-		if(std::filesystem::exists(desc.Path))
-			cacheDesc.Data = TRAP::FS::ReadFile(desc.Path);
+		if(!std::filesystem::exists(desc.Path))
+			return TRAP::Graphics::PipelineCache::Create(cacheDesc); //Empty cache
 
-		return TRAP::Graphics::PipelineCache::Create(cacheDesc);
+		const auto data = TRAP::FS::ReadFile(desc.Path);
+		if(!data)
+			return TRAP::Graphics::PipelineCache::Create(cacheDesc); //Empty cache
+
+		cacheDesc.Data = *data;
+
+		return TRAP::Graphics::PipelineCache::Create(cacheDesc); //Cache with data
 	}
 
 	case RenderAPI::NONE:

--- a/TRAP/src/Graphics/API/Objects/RenderTarget.cpp
+++ b/TRAP/src/Graphics/API/Objects/RenderTarget.cpp
@@ -5,18 +5,8 @@
 #include "Graphics/API/Vulkan/Objects/VulkanRenderTarget.h"
 
 TRAP::Graphics::RenderTarget::RenderTarget()
-	: m_texture(nullptr),
-	  m_clearColor(),
-	  m_clearDepth(1.0f),
-	  m_clearStencil(0),
-	  m_arraySize(),
-	  m_depth(),
-	  m_width(),
-	  m_height(),
-	  m_descriptors(),
-	  m_mipLevels(),
-	  m_sampleQuality(),
-	  m_format(),
+	: m_texture(nullptr), m_clearColor(), m_clearDepth(1.0f), m_clearStencil(0), m_arraySize(),
+	  m_depth(), m_width(), m_height(), m_descriptors(), m_mipLevels(), m_sampleQuality(), m_format(),
 	  m_sampleCount()
 {
 #ifdef ENABLE_GRAPHICS_DEBUG

--- a/TRAP/src/Graphics/API/Objects/Sampler.cpp
+++ b/TRAP/src/Graphics/API/Objects/Sampler.cpp
@@ -42,7 +42,7 @@ TRAP::Ref<TRAP::Graphics::Sampler> TRAP::Graphics::Sampler::Create(const Sampler
 	{
 	case RenderAPI::Vulkan:
 	{
-		TRAP::Ref<Sampler> result = TRAP::MakeRef<API::VulkanSampler>(desc);
+		const TRAP::Ref<Sampler> result = TRAP::MakeRef<API::VulkanSampler>(desc);
 
 #ifdef ENABLE_GRAPHICS_DEBUG
 		TP_DEBUG(Log::RendererSamplerPrefix, "Caching Sampler");

--- a/TRAP/src/Graphics/API/Objects/Semaphore.h
+++ b/TRAP/src/Graphics/API/Objects/Semaphore.h
@@ -41,7 +41,7 @@ namespace TRAP::Graphics
 		/// Is the semaphore signaled?
 		/// </summary>
 		/// <returns>True if the semaphore is signaled, false otherwise.</returns>
-		virtual bool IsSignaled() const;
+		bool IsSignaled() const;
 
 	protected:
 		/// <summary>

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -369,8 +369,8 @@ bool TRAP::Graphics::RendererAPI::IsVulkanCapable()
 		for (uint32_t i = 0; i < instanceExtensions.size(); i++)
 			extensions[i] = instanceExtensions[i].c_str();
 		const VkApplicationInfo appInfo = API::VulkanInits::ApplicationInfo("Vulkan Capability Tester");
-		VkInstanceCreateInfo instanceCreateInfo = API::VulkanInits::InstanceCreateInfo(appInfo, {}, extensions);
-		VkResult res = vkCreateInstance(&instanceCreateInfo, nullptr, &instance);
+		const VkInstanceCreateInfo instanceCreateInfo = API::VulkanInits::InstanceCreateInfo(appInfo, {}, extensions);
+		const VkResult res = vkCreateInstance(&instanceCreateInfo, nullptr, &instance);
 		if (res == VK_SUCCESS && instance)
 		{
 			VkLoadInstance(instance);
@@ -435,28 +435,6 @@ TRAP::Graphics::RendererAPI::PerWindowData::~PerWindowData()
 		ComputeCommandBuffers[i] = nullptr;
 		ComputeCommandPools[i].reset();
 	}
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-bool TRAP::Graphics::RendererAPI::SamplerDesc::operator==(const SamplerDesc& s) const
-{
-	//Deep equality
-	return this->MinFilter == s.MinFilter && this->MagFilter == s.MagFilter && this->MipMapMode == s.MipMapMode &&
-		   this->AddressU == s.AddressU && this->AddressV == s.AddressV && this->AddressW == s.AddressW &&
-		   this->MipLodBias == s.MipLodBias && this->MaxAnisotropy == s.MaxAnisotropy &&
-		   this->CompareFunc == s.CompareFunc && this->SamplerConversionDesc == s.SamplerConversionDesc;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-bool TRAP::Graphics::RendererAPI::SamplerDesc::SamplerConversionDesc::operator==(const SamplerConversionDesc& s) const
-{
-	//Deep equality
-	return this->Format == s.Format && this->Model == s.Model && this->Range == s.Range &&
-	       this->ChromaOffsetX == s.ChromaOffsetX && this->ChromaOffsetY == s.ChromaOffsetY &&
-		   this->ChromaFilter == s.ChromaFilter &&
-		   this->ForceExplicitReconstruction == s.ForceExplicitReconstruction;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -575,7 +575,7 @@ namespace TRAP::Graphics
 		/// Example title: "[Vulkan 1.3.0]".
 		/// </summary>
 		/// <returns>Renderer title.</returns>
-		virtual const std::string& GetTitle() const = 0;
+		virtual std::string GetTitle() const = 0;
 
 		/// <summary>
 		/// Retrieve the currently used GPUs UUID.

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -1895,7 +1895,7 @@ namespace TRAP::Graphics
 			uint32_t PipelineExtensionCount{};
 
 			//Name for the pipeline
-			const char* Name{};
+			std::string Name{};
 		};
 
 		/// <summary>
@@ -1971,7 +1971,7 @@ namespace TRAP::Graphics
 			//Type of indirect argument
 			IndirectArgumentType Type{};
 			//Name of descriptor
-			const char* Name{};
+			std::string Name{};
 			//Index of descriptor
 			uint32_t Index{};
 		};
@@ -2112,7 +2112,7 @@ namespace TRAP::Graphics
 		{
 			//User can either set name of descriptor or index (index in RootSignature->Descriptors array)
 			//Name of descriptor
-			const char* Name{};
+			std::string Name{};
 			/// <summary>
 			/// Range(s) to bind (buffer, offset, size)
 			/// </summary>

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -158,7 +158,7 @@ namespace TRAP::Graphics
 		/// Present to the given window.
 		/// </summary>
 		/// <param name="window">Window to present.</param>
-		virtual void Present(Window* window) = 0;
+		virtual void Present(Window* window) const = 0;
 
 		/// <summary>
 		/// Dispatch to the given window.
@@ -168,20 +168,20 @@ namespace TRAP::Graphics
 		/// The elements are automatically divided by the number of threads in the work group and rounded up.
 		/// </param>
 		/// <param name="window">Window to Dispatch.</param>
-		virtual void Dispatch(std::array<uint32_t, 3> workGroupElements, Window* window) = 0;
+		virtual void Dispatch(std::array<uint32_t, 3> workGroupElements, Window* window) const = 0;
 
 		/// <summary>
 		/// Set the VSync state for the given window.
 		/// </summary>
 		/// <param name="vsync">Enable or disable VSync.</param>
 		/// <param name="window">Window to set VSync for. Default: Main Window.</param>
-		virtual void SetVSync(bool vsync, Window* window = nullptr) = 0;
+		virtual void SetVSync(bool vsync, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Retrieve whether VSync is enabled or not for the given window.
 		/// </summary>
 		/// <param name="window">Window to retrieve VSync for. Default: Main Window.</param>
 		/// <returns>True if VSync is enabled, false otherwise.</returns>
-		virtual bool GetVSync(Window* window = nullptr) = 0;
+		virtual bool GetVSync(Window* window = nullptr) const = 0;
 
 		//RenderTarget Stuff
 
@@ -191,19 +191,19 @@ namespace TRAP::Graphics
 		/// <param name="color">New clear color.</param>
 		/// <param name="window">Window to set clear color for. Default: Main Window.</param>
 		virtual void SetClearColor(const Math::Vec4& color = { 0.1f, 0.1f, 0.1f, 1.0f },
-		                           Window* window = nullptr) = 0;
+		                           Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the clear depth value to be used by the given window.
 		/// </summary>
 		/// <param name="depth">New clear depth value. Must be between 0.0f and 1.0f</param>
 		/// <param name="window">Window to set clear depth value for. Default: Main Window.</param>
-		virtual void SetClearDepth(float depth = 1.0f, Window* window = nullptr) = 0;
+		virtual void SetClearDepth(float depth = 1.0f, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the clear stencil value to be used by the given window.
 		/// </summary>
 		/// <param name="stencil">New clear stencil value.</param>
 		/// <param name="window">Window to set clear stencil value for. Default: Main Window.</param>
-		virtual void SetClearStencil(uint32_t stencil = 0, Window* window = nullptr) = 0;
+		virtual void SetClearStencil(uint32_t stencil = 0, Window* window = nullptr) const = 0;
 #ifdef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the resolution of the render targets used by the given window.
@@ -213,7 +213,7 @@ namespace TRAP::Graphics
 		/// <param name="width">New width.</param>
 		/// <param name="height">New height.</param>
 		/// <param name="window">Window to set resolution for. Default: Main Window.</param>
-		virtual void SetResolution(uint32_t width, uint32_t height, Window* window = nullptr) = 0;
+		virtual void SetResolution(uint32_t width, uint32_t height, Window* window = nullptr) const = 0;
 #endif
 
 		//Pipeline Stuff
@@ -223,103 +223,103 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth testing.</param>
 		/// <param name="window">Window to set depth testing for. Default: Main Window.</param>
-		virtual void SetDepthTesting(bool enabled, Window* window = nullptr) = 0;
+		virtual void SetDepthTesting(bool enabled, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Enable or disable depth writing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth writing.</param>
 		/// <param name="window">Window to set depth writing for. Default: Main Window.</param>
-		virtual void SetDepthWriting(bool enabled, Window* window = nullptr) = 0;
+		virtual void SetDepthWriting(bool enabled, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the depth function for the given window.
 		/// </summary>
 		/// <param name="function">Function to use for depth testing.</param>
 		/// <param name="window">Window to set depth function for. Default: Main Window.</param>
-		virtual void SetDepthFunction(CompareMode function, Window* window = nullptr) = 0;
+		virtual void SetDepthFunction(CompareMode function, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the depth action to perform when depth testing fails for the given window.
 		/// </summary>
 		/// <param name="front">Depth action to perform when depth testing fails.</param>
 		/// <param name="back">Depth action to perform when depth testing fails.</param>
 		/// <param name="window">Window to set the depth fail action for. Default: Main Window.</param>
-		virtual void SetDepthFail(StencilOp front, StencilOp back, Window* window = nullptr) = 0;
+		virtual void SetDepthFail(StencilOp front, StencilOp back, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the depth bias (scalar factor to add to each fragments depth value) for the given window.
 		/// </summary>
 		/// <param name="depthBias">Depth bias.</param>
 		/// <param name="window">Window to set the depth bias for. Default: Main Window.</param>
-		virtual void SetDepthBias(int32_t depthBias, Window* window = nullptr) = 0;
+		virtual void SetDepthBias(int32_t depthBias, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the depth bias slope factor (scalar factor applied to fragment's slope in depth bias calculation) for the given window.
 		/// </summary>
 		/// <param name="factor">Depth bias slope factor.</param>
 		/// <param name="window">Window to set the depth bias slope factor for. Default: Main Window.</param>
-		virtual void SetDepthBiasSlopeFactor(float factor, Window* window = nullptr) = 0;
+		virtual void SetDepthBiasSlopeFactor(float factor, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Enable or disable stencil testing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable stencil testing.</param>
 		/// <param name="window">Window to set stencil testing for. Default: Main Window.</param>
-		virtual void SetStencilTesting(bool enabled, Window* window = nullptr) = 0;
+		virtual void SetStencilTesting(bool enabled, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the stencil action to perform when stencil testing fails for the given window.
 		/// </summary>
 		/// <param name="front">Stencil action to perform when stencil testing fails.</param>
 		/// <param name="back">Stencil action to perform when stencil testing fails.</param>
 		/// <param name="window">Window to set the stencil fail action for. Default: Main Window.</param>
-		virtual void SetStencilFail(StencilOp front, StencilOp back, Window* window = nullptr) = 0;
+		virtual void SetStencilFail(StencilOp front, StencilOp back, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the stencil action to perform when stencil testing and depth testing passes for the given window.
 		/// </summary>
 		/// <param name="front">Stencil action to perform when passed.</param>
 		/// <param name="back">Stencil action to perform when passed.</param>
 		/// <param name="window">Window to set the stencil pass action for. Default: Main Window.</param>
-		virtual void SetStencilPass(StencilOp front, StencilOp back, Window* window = nullptr) = 0;
+		virtual void SetStencilPass(StencilOp front, StencilOp back, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the stencil functions for the given window.
 		/// </summary>
 		/// <param name="front">Function to use on the front for stencil testing.</param>
 		/// <param name="back">Function to use on the back for stencil testing.</param>
 		/// <param name="window">Window to set stencil functions for. Default: Main Window.</param>
-		virtual void SetStencilFunction(CompareMode front, CompareMode back, Window* window = nullptr) = 0;
+		virtual void SetStencilFunction(CompareMode front, CompareMode back, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the stencil mask for the given window.
 		/// </summary>
 		/// <param name="read">Select the bits of the stencil values to test.</param>
 		/// <param name="write">Select the bits of the stencil values updated by the stencil test.</param>
 		/// <param name="window">Window to set stencil mask for. Default: Main Window.</param>
-		virtual void SetStencilMask(uint8_t read, uint8_t write, Window* window = nullptr) = 0;
+		virtual void SetStencilMask(uint8_t read, uint8_t write, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the cull mode for the given window.
 		/// </summary>
 		/// <param name="mode">Cull mode to use.</param>
 		/// <param name="window">Window to set cull mode for. Default: Main Window.</param>
-		virtual void SetCullMode(CullMode mode, Window* window = nullptr) = 0;
+		virtual void SetCullMode(CullMode mode, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the fill mode for the given window.
 		/// </summary>
 		/// <param name="mode">Fill mode to use.</param>
 		/// <param name="window">Window to set fill mode for. Default: Main Window.</param>
-		virtual void SetFillMode(FillMode mode, Window* window = nullptr) = 0;
+		virtual void SetFillMode(FillMode mode, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the primitive topology for the given window.
 		/// </summary>
 		/// <param name="topology">Primitive topology to use.</param>
 		/// <param name="window">Window to set primitive topology for. Default: Main Window.</param>
-		virtual void SetPrimitiveTopology(PrimitiveTopology topology, Window* window = nullptr) = 0;
+		virtual void SetPrimitiveTopology(PrimitiveTopology topology, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the front face winding order for the given window.
 		/// </summary>
 		/// <param name="face">Front face winding order to use.</param>
 		/// <param name="window">Window to set front face winding order for. Default: Main Window.</param>
-		virtual void SetFrontFace(FrontFace face, Window* window = nullptr) = 0;
+		virtual void SetFrontFace(FrontFace face, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the blend mode for the given window.
 		/// </summary>
 		/// <param name="modeRGB">Blend mode to use for the RGB channels.</param>
 		/// <param name="modeAlpha">Blend mode to use for the alpha channel.</param>
 		/// <param name="window">Window to set the blend mode for. Default: Main Window.</param>
-		virtual void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha, Window* window = nullptr) = 0;
+		virtual void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the blend constants/factors for the given window.
 		/// </summary>
@@ -330,7 +330,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to set the blend constants for. Default: Main Window.</param>
 		virtual void SetBlendConstant(BlendConstant sourceRGB, BlendConstant sourceAlpha,
 			                          BlendConstant destinationRGB, BlendConstant destinationAlpha,
-									  Window* window = nullptr) = 0;
+									  Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the pipeline fragment shading rate and combiner operation for the command buffer.
 		/// </summary>
@@ -342,7 +342,7 @@ namespace TRAP::Graphics
 		virtual void SetShadingRate(ShadingRate shadingRate,
 						            TRAP::Graphics::Texture* texture,
 		                            ShadingRateCombiner postRasterizerRate,
-							        ShadingRateCombiner finalRate, Window* window = nullptr) = 0;
+							        ShadingRateCombiner finalRate, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set the anti aliasing method and the sample count for the window.
 		/// Use AntiAliasing::Off and SampleCount::One to disable anti aliasing.
@@ -350,21 +350,21 @@ namespace TRAP::Graphics
 		/// <param name="antiAliasing">Anti aliasing method to use.</param>
 		/// <param name="sampleCount">Sample count to use.</param>
 		/// <param name="window">Window to set anti aliasing for. Default: Main Window.</param>
-		virtual void SetAntiAliasing(AntiAliasing antiAliasing, SampleCount sampleCount, Window* window = nullptr) = 0;
+		virtual void SetAntiAliasing(AntiAliasing antiAliasing, SampleCount sampleCount, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Retrieve the anti aliasing method and the sample count of the window.
 		/// </summary>
 		/// <param name="outAntiAliasing">Output: Used anti aliasing method.</param>
 		/// <param name="outSampleCount">Output: Used sample count.</param>
 		/// <param name="window">Window to get anti aliasing from. Default: Main Window.</param>
-		virtual void GetAntiAliasing(AntiAliasing& outAntiAliasing, SampleCount& outSampleCount, Window* window = nullptr) = 0;
+		virtual void GetAntiAliasing(AntiAliasing& outAntiAliasing, SampleCount& outSampleCount, Window* window = nullptr) const = 0;
 
 		/// <summary>
 		/// Clear the given window's render target.
 		/// </summary>
 		/// <param name="clearType">Type of buffer to clear.</param>
 		/// <param name="window">Window to clear. Default: Main Window.</param>
-		virtual void Clear(ClearBufferType clearType, Window* window = nullptr) = 0;
+		virtual void Clear(ClearBufferType clearType, Window* window = nullptr) const = 0;
 
 		//CommandBuffer Stuff
 
@@ -379,7 +379,7 @@ namespace TRAP::Graphics
 		/// <param name="maxDepth">New max depth value. Default: 1.0f.</param>
 		/// <param name="window">Window to set viewport for. Default: Main Window.</param>
 		virtual void SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height, float minDepth = 0.0f,
-		                         float maxDepth = 1.0f, Window* window = nullptr) = 0;
+		                         float maxDepth = 1.0f, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Set scissor size for the given window.
 		/// </summary>
@@ -389,7 +389,7 @@ namespace TRAP::Graphics
 		/// <param name="height">New scissor height.</param>
 		/// <param name="window">Window to set scissor size for. Default: Main Window.</param>
 		virtual void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height,
-		                        Window* window = nullptr) = 0;
+		                        Window* window = nullptr) const = 0;
 
 		/// <summary>
 		/// Draw non-indexed, non-instanced geometry for the given window.
@@ -397,7 +397,7 @@ namespace TRAP::Graphics
 		/// <param name="vertexCount">Number of vertices to draw.</param>
 		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
-		virtual void Draw(uint32_t vertexCount, uint32_t firstVertex = 0, Window* window = nullptr) = 0;
+		virtual void Draw(uint32_t vertexCount, uint32_t firstVertex = 0, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Draw indexed, non-instanced geometry for the given window.
 		/// </summary>
@@ -406,7 +406,7 @@ namespace TRAP::Graphics
 		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		virtual void DrawIndexed(uint32_t indexCount, uint32_t firstIndex = 0, uint32_t firstVertex = 0,
-		                         Window* window = nullptr) = 0;
+		                         Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Draw non-indexed, instanced geometry for the given window.
 		/// </summary>
@@ -416,7 +416,7 @@ namespace TRAP::Graphics
 		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		virtual void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex = 0,
-		                           uint32_t firstInstance = 0, Window* window = nullptr) = 0;
+		                           uint32_t firstInstance = 0, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Draw indexed, instanced geometry for the given window.
 		/// </summary>
@@ -428,7 +428,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		virtual void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
 		                                  uint32_t firstIndex = 0, uint32_t firstInstance = 0,
-										  uint32_t firstVertex = 0, Window* window = nullptr) = 0;
+										  uint32_t firstVertex = 0, Window* window = nullptr) const = 0;
 
 		/// <summary>
 		/// Bind vertex buffer on the given window.
@@ -437,7 +437,7 @@ namespace TRAP::Graphics
 		/// <param name="layout">Layout of the vertex buffer.</param>
 		/// <param name="window">Window to bind the vertex buffer for. Default: Main Window.</param>
 		virtual void BindVertexBuffer(const TRAP::Ref<Buffer>& vBuffer, const VertexBufferLayout& layout,
-		                              Window* window = nullptr) = 0;
+		                              Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Bind an index buffer on the given window.
 		/// </summary>
@@ -445,7 +445,7 @@ namespace TRAP::Graphics
 		/// <param name="indexType">Data type used by the index buffer.</param>
 		/// <param name="window">Window to bind the vertex buffer for. Default: Main Window.</param>
 		virtual void BindIndexBuffer(const TRAP::Ref<Buffer>& iBuffer, IndexType indexType,
-		                             Window* window = nullptr) = 0;
+		                             Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Bind a descriptor set on the given window.
 		/// </summary>
@@ -455,7 +455,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to bind the descriptor set for. Default: Main Window.</param>
 		virtual void BindDescriptorSet(DescriptorSet& dSet, uint32_t index,
 		                               QueueType queueType = QueueType::Graphics,
-									   Window* window = nullptr) = 0;
+									   Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Bind push constant buffer data on the given window.
 		/// Note: There is an optimized function which uses the index into the RootSignature
@@ -467,7 +467,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to bind the push constants for. Default: Main Window.</param>
 		virtual void BindPushConstants(const char* name, const void* constantsData,
 		                               QueueType queueType = QueueType::Graphics,
-									   Window* window = nullptr) = 0;
+									   Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Bind push constant buffer data on the given window.
 		/// </summary>
@@ -477,7 +477,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to bind the push constants for. Default: Main Window.</param>
 		virtual void BindPushConstantsByIndex(uint32_t paramIndex, const void* constantsData,
 											  QueueType queueType = QueueType::Graphics,
-											  Window* window = nullptr) = 0;
+											  Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Bind render target(s) on the given window.
 		///
@@ -497,7 +497,7 @@ namespace TRAP::Graphics
 									  std::vector<uint32_t>* colorArraySlices = nullptr,
 									  std::vector<uint32_t>* colorMipSlices = nullptr,
 									  uint32_t depthArraySlice = -1, uint32_t depthMipSlice = -1,
-									  Window* window = nullptr) = 0;
+									  Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Bind render target(s) on the given window.
 		///
@@ -517,7 +517,7 @@ namespace TRAP::Graphics
 									   std::vector<uint32_t>* colorArraySlices = nullptr,
 									   std::vector<uint32_t>* colorMipSlices = nullptr,
 									   uint32_t depthArraySlice = -1, uint32_t depthMipSlice = -1,
-									   Window* window = nullptr) = 0;
+									   Window* window = nullptr) const = 0;
 
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
@@ -527,7 +527,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to add the barrier for. Default: Main Window.</param>
 		virtual void ResourceBufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
 										   QueueType queueType = QueueType::Graphics,
-								           Window* window = nullptr) = 0;
+								           Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
@@ -536,7 +536,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to add the barriers for. Default: Main Window.</param>
 		virtual void ResourceBufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
 											QueueType queueType = QueueType::Graphics,
-									        Window* window = nullptr) = 0;
+									        Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
@@ -545,7 +545,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to add the barrier for. Default: Main Window.</param>
 		virtual void ResourceTextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
 											QueueType queueType = QueueType::Graphics,
-									        Window* window = nullptr) = 0;
+									        Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
@@ -554,21 +554,21 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to add the barriers for. Default: Main Window.</param>
 		virtual void ResourceTextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
 											 QueueType queueType = QueueType::Graphics,
-									         Window* window = nullptr) = 0;
+									         Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
 		/// <param name="renderTargetBarrier">Render target barrier.</param>
 		/// <param name="window">Window to add the barrier for. Default: Main Window.</param>
 		virtual void ResourceRenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier,
-									             Window* window = nullptr) = 0;
+									             Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
 		/// <param name="renderTargetBarriers">Render target barriers.</param>
 		/// <param name="window">Window to add the barriers for. Default: Main Window.</param>
 		virtual void ResourceRenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers,
-									              Window* window = nullptr) = 0;
+									              Window* window = nullptr) const = 0;
 
 		/// <summary>
 		/// Retrieve the renderer title.
@@ -581,25 +581,25 @@ namespace TRAP::Graphics
 		/// Retrieve the currently used GPUs UUID.
 		/// </summary>
 		/// <returns>GPU's UUID.</returns>
-		virtual std::array<uint8_t, 16> GetCurrentGPUUUID() = 0;
+		virtual std::array<uint8_t, 16> GetCurrentGPUUUID() const = 0;
 		/// <summary>
 		/// Retrieve the name of the currently used GPU.
 		/// </summary>
 		/// <returns>GPU's name.</returns>
-		virtual std::string GetCurrentGPUName() = 0;
+		virtual std::string GetCurrentGPUName() const = 0;
 		/// <summary>
 		/// Retrieve a list of all supported GPUs.
 		/// The list contains the GPUs name and UUID.
 		/// </summary>
 		/// <returns>List of all supported GPUs.</returns>
-		virtual std::vector<std::pair<std::string, std::array<uint8_t, 16>>> GetAllGPUs() = 0;
+		virtual std::vector<std::pair<std::string, std::array<uint8_t, 16>>> GetAllGPUs() const = 0;
 
 		/// <summary>
 		/// Capture a screenshot of the last presented frame.
 		/// </summary>
 		/// <param name="window">Window to capture screenshot on. Default: Main Window.</param>
 		/// <returns>Captured screenshot as TRAP::Image on success, Black 1x1 TRAP::Image otherwise.</returns>
-		virtual TRAP::Scope<TRAP::Image> CaptureScreenshot(Window* window = nullptr) = 0;
+		virtual TRAP::Scope<TRAP::Image> CaptureScreenshot(Window* window = nullptr) const = 0;
 
 		/// <summary>
 		/// Retrieve the used descriptor pool.
@@ -666,17 +666,17 @@ namespace TRAP::Graphics
 		/// Initialize the internal rendering data of the given window.
 		/// </summary>
 		/// <param name="window">Window to initialize the internal rendering data for.</param>
-		virtual void InitPerWindowData(Window* window) = 0;
+		virtual void InitPerWindowData(Window* window) const = 0;
 		/// <summary>
 		/// Remove the internal rendering data of the given window.
 		/// </summary>
 		/// <param name="window">Window to remove the internal rendering data from.</param>
-		virtual void RemovePerWindowData(Window* window) = 0;
+		virtual void RemovePerWindowData(Window* window) const = 0;
 
 		/// <summary>
 		/// Wait for the GPU to idle.
 		/// </summary>
-		virtual void WaitIdle() = 0;
+		virtual void WaitIdle() const = 0;
 
 		/// <summary>
 		/// Check if the system is Vulkan API capable.
@@ -1547,10 +1547,10 @@ namespace TRAP::Graphics
 				//Explicitly force the reconstruction
 				bool ForceExplicitReconstruction;
 
-				bool operator==(const SamplerConversionDesc& s) const;
+				constexpr bool operator==(const SamplerConversionDesc& s) const;
 			} SamplerConversionDesc{};
 
-			bool operator==(const SamplerDesc& s) const;
+			constexpr bool operator==(const SamplerDesc& s) const;
 		};
 
 		/// <summary>
@@ -2453,6 +2453,30 @@ namespace TRAP::Graphics
 		static bool s_isVulkanCapableFirstTest;
 	};
 }
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr bool TRAP::Graphics::RendererAPI::SamplerDesc::operator==(const SamplerDesc& s) const
+{
+	//Deep equality
+	return this->MinFilter == s.MinFilter && this->MagFilter == s.MagFilter && this->MipMapMode == s.MipMapMode &&
+		   this->AddressU == s.AddressU && this->AddressV == s.AddressV && this->AddressW == s.AddressW &&
+		   this->MipLodBias == s.MipLodBias && this->MaxAnisotropy == s.MaxAnisotropy &&
+		   this->CompareFunc == s.CompareFunc && this->SamplerConversionDesc == s.SamplerConversionDesc;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr bool TRAP::Graphics::RendererAPI::SamplerDesc::SamplerConversionDesc::operator==(const SamplerConversionDesc& s) const
+{
+	//Deep equality
+	return this->Format == s.Format && this->Model == s.Model && this->Range == s.Range &&
+	       this->ChromaOffsetX == s.ChromaOffsetX && this->ChromaOffsetY == s.ChromaOffsetY &&
+		   this->ChromaFilter == s.ChromaFilter &&
+		   this->ForceExplicitReconstruction == s.ForceExplicitReconstruction;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
 
 MAKE_ENUM_FLAG(TRAP::Graphics::RendererAPI::WaveOpsSupportFlags)
 MAKE_ENUM_FLAG(TRAP::Graphics::RendererAPI::TextureCreationFlags);

--- a/TRAP/src/Graphics/API/ResourceLoader.cpp
+++ b/TRAP/src/Graphics/API/ResourceLoader.cpp
@@ -364,7 +364,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 				else
 				{
 					TRAP_ASSERT(data);
-					memcpy(updateDesc.MappedData, static_cast<const uint8_t*>(data) + offset, chunkSize);
+					std::copy_n(static_cast<const uint8_t*>(data) + offset, chunkSize, static_cast<uint8_t*>(updateDesc.MappedData));
 				}
 				EndUpdateResource(updateDesc, token);
 			}
@@ -380,7 +380,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 			{
 				TRAP_ASSERT(!desc.Desc.Size || desc.Data);
 				if(desc.Data)
-					memcpy(updateDesc.MappedData, desc.Data, desc.Desc.Size);
+					std::copy_n(static_cast<const uint8_t*>(desc.Data), desc.Desc.Size, static_cast<uint8_t*>(updateDesc.MappedData));
 			}
 			EndUpdateResource(updateDesc, token);
 		}
@@ -1085,7 +1085,7 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 
 					uint8_t* dstData = data + subSlicePitch * z;
 					for(uint32_t r = 0; r < subNumRows; ++r)
-						memcpy(dstData + r * subRowPitch, pixelData + r * subRowSize, subRowSize);
+						std::copy_n(pixelData + r * subRowSize, subRowSize, dstData + r * subRowPitch);
 				}
 			}
 

--- a/TRAP/src/Graphics/API/ResourceLoader.cpp
+++ b/TRAP/src/Graphics/API/ResourceLoader.cpp
@@ -360,7 +360,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 				updateDesc.DstOffset = offset;
 				BeginUpdateResource(updateDesc);
 				if (desc.ForceReset)
-					std::fill_n(static_cast<uint8_t*>(updateDesc.MappedData), chunkSize, 0u);
+					std::fill_n(static_cast<uint8_t*>(updateDesc.MappedData), chunkSize, static_cast<uint8_t>(0u));
 				else
 				{
 					TRAP_ASSERT(data);
@@ -375,7 +375,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 			updateDesc.Buffer = desc.Buffer;
 			BeginUpdateResource(updateDesc);
 			if (desc.ForceReset)
-				std::fill_n(static_cast<uint8_t*>(updateDesc.MappedData), desc.Desc.Size, 0u);
+				std::fill_n(static_cast<uint8_t*>(updateDesc.MappedData), desc.Desc.Size, static_cast<uint8_t>(0u));
 			else
 			{
 				TRAP_ASSERT(!desc.Desc.Size || desc.Data);

--- a/TRAP/src/Graphics/API/ResourceLoader.cpp
+++ b/TRAP/src/Graphics/API/ResourceLoader.cpp
@@ -1170,7 +1170,11 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 	//https://github.com/GPUOpen-Effects/FidelityFX-SPD/blob/master/sample/src/VK/CSDownsampler.glsl
 	if(!textureLoadDesc.Filepaths[0].empty() && supported)
 	{
-		textureDesc.Name = FS::GetFileNameWithEnding(textureLoadDesc.Filepaths[0]);
+		const auto fileName = FS::GetFileNameWithEnding(textureLoadDesc.Filepaths[0]);
+		if(fileName)
+			textureDesc.Name = *fileName;
+		else
+			textureDesc.Name = "Unknown";
 
 		if(textureLoadDesc.IsCubemap && textureLoadDesc.Type == RendererAPI::TextureCubeType::MultiFile)
 		{

--- a/TRAP/src/Graphics/API/ResourceLoader.cpp
+++ b/TRAP/src/Graphics/API/ResourceLoader.cpp
@@ -20,7 +20,7 @@ TRAP::Graphics::RendererAPI::ResourceLoaderDesc TRAP::Graphics::API::ResourceLoa
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-static constexpr uint32_t MIP_REDUCE(uint32_t size, uint32_t mip)
+static constexpr uint32_t MIP_REDUCE(const uint32_t size, const uint32_t mip)
 {
 	return TRAP::Math::Max(1u, size >> mip);
 }
@@ -97,7 +97,7 @@ void TRAP::Graphics::API::ResourceLoader::StreamerThreadFunc(ResourceLoader* loa
 
 			case UpdateRequestType::BufferBarrier:
 			{
-				RendererAPI::BufferBarrier barrier = std::get<RendererAPI::BufferBarrier>(updateState.Desc);
+				const RendererAPI::BufferBarrier barrier = std::get<RendererAPI::BufferBarrier>(updateState.Desc);
 				loader->AcquireCmd(loader->m_nextSet)->ResourceBarrier(&barrier, nullptr, nullptr);
 				result = UploadFunctionResult::Completed;
 				break;
@@ -105,7 +105,7 @@ void TRAP::Graphics::API::ResourceLoader::StreamerThreadFunc(ResourceLoader* loa
 
 			case UpdateRequestType::TextureBarrier:
 			{
-				RendererAPI::TextureBarrier barrier = std::get<RendererAPI::TextureBarrier>(updateState.Desc);
+				const RendererAPI::TextureBarrier barrier = std::get<RendererAPI::TextureBarrier>(updateState.Desc);
 				loader->AcquireCmd(loader->m_nextSet)->ResourceBarrier(nullptr, &barrier, nullptr);
 				result = UploadFunctionResult::Completed;
 				break;
@@ -533,7 +533,7 @@ bool TRAP::Graphics::API::ResourceLoader::AllResourceLoadsCompleted() const
 
 void TRAP::Graphics::API::ResourceLoader::WaitForAllResourceLoads()
 {
-	SyncToken token = m_tokenCounter;
+	const SyncToken token = m_tokenCounter;
 	WaitForToken(&token);
 }
 
@@ -571,7 +571,7 @@ TRAP::Graphics::RendererAPI::MappedMemoryRange TRAP::Graphics::API::ResourceLoad
 	desc.Alignment = alignment;
 	desc.MemoryUsage = RendererAPI::ResourceMemoryUsage::CPUOnly;
 	desc.Flags = RendererAPI::BufferCreationFlags::PersistentMap;
-	TRAP::Ref<Buffer> buffer = Buffer::Create(desc);
+	const TRAP::Ref<Buffer> buffer = Buffer::Create(desc);
 
 	return RendererAPI::MappedMemoryRange{static_cast<uint8_t*>(buffer->GetCPUMappedAddress()), std::move(buffer),
 	                                      0, memoryRequirement };
@@ -711,7 +711,7 @@ TRAP::Graphics::RendererAPI::MappedMemoryRange TRAP::Graphics::API::ResourceLoad
 	const bool memoryAvailable = (offset < size) && (memoryRequirement <= size - offset);
 	if(memoryAvailable && resSet.Buffer->GetCPUMappedAddress())
 	{
-		TRAP::Ref<Buffer> buffer = resSet.Buffer;
+		const TRAP::Ref<Buffer> buffer = resSet.Buffer;
 		TRAP_ASSERT(buffer->GetCPUMappedAddress());
 		uint8_t* dstData = static_cast<uint8_t*>(buffer->GetCPUMappedAddress()) + offset;
 		m_copyEngine.ResourceSets[m_nextSet].AllocatedSpace = offset + memoryRequirement;
@@ -720,12 +720,12 @@ TRAP::Graphics::RendererAPI::MappedMemoryRange TRAP::Graphics::API::ResourceLoad
 
 	if(m_copyEngine.BufferSize < memoryRequirement)
 	{
-		RendererAPI::MappedMemoryRange range = AllocateUploadMemory(memoryRequirement, alignment);
+		const RendererAPI::MappedMemoryRange range = AllocateUploadMemory(memoryRequirement, alignment);
 		resSet.TempBuffers.emplace_back(range.Buffer);
 		return range;
 	}
 
-	RendererAPI::MappedMemoryRange range = AllocateUploadMemory(memoryRequirement, alignment);
+	const RendererAPI::MappedMemoryRange range = AllocateUploadMemory(memoryRequirement, alignment);
 	resSet.TempBuffers.emplace_back(range.Buffer);
 	return range;
 }
@@ -804,10 +804,10 @@ void TRAP::Graphics::API::ResourceLoader::CleanupCopyEngine()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::ResourceLoader::WaitCopyEngineSet(const std::size_t activeSet)
+void TRAP::Graphics::API::ResourceLoader::WaitCopyEngineSet(const std::size_t activeSet) const
 {
 	TRAP_ASSERT(!m_copyEngine.IsRecording);
-	CopyEngine::CopyResourceSet& resSet = m_copyEngine.ResourceSets[activeSet];
+	const CopyEngine::CopyResourceSet& resSet = m_copyEngine.ResourceSets[activeSet];
 
 	if (resSet.Fence->GetStatus() == RendererAPI::FenceStatus::Incomplete)
 		resSet.Fence->Wait();
@@ -828,7 +828,7 @@ void TRAP::Graphics::API::ResourceLoader::ResetCopyEngineSet(const std::size_t a
 
 TRAP::Graphics::CommandBuffer* TRAP::Graphics::API::ResourceLoader::AcquireCmd(const std::size_t activeSet)
 {
-	CopyEngine::CopyResourceSet& resSet = m_copyEngine.ResourceSets[activeSet];
+	const CopyEngine::CopyResourceSet& resSet = m_copyEngine.ResourceSets[activeSet];
 	if(!m_copyEngine.IsRecording)
 	{
 		resSet.CommandPool->Reset();
@@ -846,7 +846,7 @@ void TRAP::Graphics::API::ResourceLoader::StreamerFlush(const std::size_t active
 	if(!m_copyEngine.IsRecording)
 		return;
 
-	CopyEngine::CopyResourceSet& resSet = m_copyEngine.ResourceSets[activeSet];
+	const CopyEngine::CopyResourceSet& resSet = m_copyEngine.ResourceSets[activeSet];
 	resSet.Cmd->End();
 	RendererAPI::QueueSubmitDesc submitDesc{};
 	submitDesc.Cmds.push_back(resSet.Cmd);
@@ -868,54 +868,12 @@ bool TRAP::Graphics::API::ResourceLoader::AreTasksAvailable() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Graphics::RendererAPI::ResourceState TRAP::Graphics::API::ResourceLoader::UtilDetermineResourceStartState(const bool uav)
-{
-	if(uav)
-		return RendererAPI::ResourceState::UnorderedAccess;
-
-	return RendererAPI::ResourceState::ShaderResource;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Graphics::RendererAPI::ResourceState TRAP::Graphics::API::ResourceLoader::UtilDetermineResourceStartState(const RendererAPI::BufferDesc& desc)
-{
-	//Host visible (Upload Heap)
-	if (desc.MemoryUsage == RendererAPI::ResourceMemoryUsage::CPUOnly ||
-	    desc.MemoryUsage == RendererAPI::ResourceMemoryUsage::CPUToGPU)
-		return RendererAPI::ResourceState::GenericRead;
-
-	//Device Local (Default Heap)
-	if (desc.MemoryUsage == RendererAPI::ResourceMemoryUsage::GPUOnly)
-	{
-		const RendererAPI::DescriptorType usage = desc.Descriptors;
-
-		//Try to limit number of states used overall to avoid sync complexities
-		if (static_cast<uint32_t>(usage & RendererAPI::DescriptorType::RWBuffer))
-			return RendererAPI::ResourceState::UnorderedAccess;
-		if ((static_cast<uint32_t>(usage & RendererAPI::DescriptorType::VertexBuffer) ||
-			 static_cast<uint32_t>(usage & RendererAPI::DescriptorType::UniformBuffer)))
-			return RendererAPI::ResourceState::VertexAndConstantBuffer;
-		if (static_cast<uint32_t>(usage & RendererAPI::DescriptorType::IndexBuffer))
-			return RendererAPI::ResourceState::IndexBuffer;
-		if (static_cast<uint32_t>(usage & RendererAPI::DescriptorType::Buffer))
-			return RendererAPI::ResourceState::ShaderResource;
-
-		return RendererAPI::ResourceState::Common;
-	}
-
-	//Host Cached (Readback Heap)
-	return RendererAPI::ResourceState::CopyDestination;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 void TRAP::Graphics::API::ResourceLoader::VulkanGenerateMipMaps(TRAP::Graphics::Texture* texture,
                                                                 CommandBuffer* cmd)
 {
 	//Check if image format supports linear blitting
 	VkFormatProperties formatProperties;
-	TRAP::Graphics::API::VulkanRenderer* vkRenderer = dynamic_cast<TRAP::Graphics::API::VulkanRenderer*>
+	const TRAP::Graphics::API::VulkanRenderer* vkRenderer = dynamic_cast<TRAP::Graphics::API::VulkanRenderer*>
 		(
 			RendererAPI::GetRenderer()
 		);
@@ -960,7 +918,7 @@ void TRAP::Graphics::API::ResourceLoader::VulkanGenerateMipMaps(TRAP::Graphics::
 		blit.dstSubresource.baseArrayLayer = 0;
 		blit.dstSubresource.layerCount = 1;
 
-		auto* vkTexture = dynamic_cast<TRAP::Graphics::API::VulkanTexture*>(texture);
+		const auto* vkTexture = dynamic_cast<TRAP::Graphics::API::VulkanTexture*>(texture);
 
 		vkCmdBlitImage(dynamic_cast<TRAP::Graphics::API::VulkanCommandBuffer*>(cmd)->GetVkCommandBuffer(),
 			           vkTexture->GetVkImage(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
@@ -989,7 +947,7 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 	TRAP_ASSERT(buffer->GetMemoryUsage() == RendererAPI::ResourceMemoryUsage::GPUOnly ||
 		        buffer->GetMemoryUsage() == RendererAPI::ResourceMemoryUsage::GPUToCPU);
 
-	CommandBuffer* cmd = AcquireCmd(activeSet);
+	const CommandBuffer* cmd = AcquireCmd(activeSet);
 
 	const RendererAPI::MappedMemoryRange range = bufferUpdateDesc.Internal.MappedRange;
 	cmd->UpdateBuffer(buffer, bufferUpdateDesc.DstOffset, range.Buffer, range.Offset, range.Size);
@@ -1019,7 +977,7 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 
 	if(RendererAPI::GetRenderAPI() == RenderAPI::Vulkan)
 	{
-		RendererAPI::TextureBarrier barrier{texture, RendererAPI::ResourceState::Undefined,
+		const RendererAPI::TextureBarrier barrier{texture, RendererAPI::ResourceState::Undefined,
 		                                    RendererAPI::ResourceState::CopyDestination};
 		cmd->ResourceBarrier(nullptr, &barrier, nullptr);
 	}
@@ -1077,7 +1035,7 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 					const uint8_t* pixelData = nullptr;
 					if((*images)[layer]->GetColorFormat() == TRAP::Image::ColorFormat::RGB) //Convert RGB to RGBA
 					{
-						TRAP::Scope<TRAP::Image> RGBAImage = TRAP::Image::ConvertRGBToRGBA((*images)[layer].get());
+						const TRAP::Scope<TRAP::Image> RGBAImage = TRAP::Image::ConvertRGBToRGBA((*images)[layer].get());
 						pixelData = static_cast<const uint8_t*>(RGBAImage->GetPixelData());
 					}
 					else
@@ -1110,9 +1068,9 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 
 	if(RendererAPI::GetRenderAPI() == RenderAPI::Vulkan)
 	{
-		RendererAPI::ResourceState finalLayout = UtilDetermineResourceStartState(static_cast<bool>(texture->GetDescriptorTypes() & RendererAPI::DescriptorType::RWTexture));
-		RendererAPI::TextureBarrier barrier{texture, RendererAPI::ResourceState::CopyDestination,
-		                                    finalLayout};
+		const RendererAPI::ResourceState finalLayout = UtilDetermineResourceStartState(static_cast<bool>(texture->GetDescriptorTypes() & RendererAPI::DescriptorType::RWTexture));
+		const RendererAPI::TextureBarrier barrier{texture, RendererAPI::ResourceState::CopyDestination,
+		                                          finalLayout};
 		cmd->ResourceBarrier(nullptr, &barrier, nullptr);
 	}
 
@@ -1124,7 +1082,7 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::ResourceLoader::LoadTexture(const std::size_t activeSet,
 																										   TRAP::Graphics::API::ResourceLoader::UpdateRequest& textureUpdate)
 {
-	TRAP::Graphics::RendererAPI::TextureLoadDesc& textureLoadDesc = std::get<TRAP::Graphics::RendererAPI::TextureLoadDesc>
+	const TRAP::Graphics::RendererAPI::TextureLoadDesc& textureLoadDesc = std::get<TRAP::Graphics::RendererAPI::TextureLoadDesc>
 		(
 			textureUpdate.Desc
 		);
@@ -1236,7 +1194,7 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 		}*/
 		else if(textureLoadDesc.IsCubemap && textureLoadDesc.Type == RendererAPI::TextureCubeType::Cross)
 		{
-			TRAP::Scope<TRAP::Image> baseImg = TRAP::Image::LoadFromFile(textureLoadDesc.Filepaths[0]);
+			const TRAP::Scope<TRAP::Image> baseImg = TRAP::Image::LoadFromFile(textureLoadDesc.Filepaths[0]);
 
 			bool valid = true;
 			if(baseImg->GetWidth() > baseImg->GetHeight()) //Horizontal

--- a/TRAP/src/Graphics/API/ResourceLoader.cpp
+++ b/TRAP/src/Graphics/API/ResourceLoader.cpp
@@ -360,7 +360,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 				updateDesc.DstOffset = offset;
 				BeginUpdateResource(updateDesc);
 				if (desc.ForceReset)
-					memset(updateDesc.MappedData, 0, chunkSize);
+					std::fill_n(static_cast<uint8_t*>(updateDesc.MappedData), chunkSize, 0u);
 				else
 				{
 					TRAP_ASSERT(data);
@@ -375,7 +375,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 			updateDesc.Buffer = desc.Buffer;
 			BeginUpdateResource(updateDesc);
 			if (desc.ForceReset)
-				memset(updateDesc.MappedData, 0, desc.Desc.Size);
+				std::fill_n(static_cast<uint8_t*>(updateDesc.MappedData), desc.Desc.Size, 0u);
 			else
 			{
 				TRAP_ASSERT(!desc.Desc.Size || desc.Data);

--- a/TRAP/src/Graphics/API/ResourceLoader.cpp
+++ b/TRAP/src/Graphics/API/ResourceLoader.cpp
@@ -364,7 +364,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 				else
 				{
 					TRAP_ASSERT(data);
-					std::memcpy(updateDesc.MappedData, static_cast<const uint8_t*>(data) + offset, chunkSize);
+					memcpy(updateDesc.MappedData, static_cast<const uint8_t*>(data) + offset, chunkSize);
 				}
 				EndUpdateResource(updateDesc, token);
 			}
@@ -380,7 +380,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 			{
 				TRAP_ASSERT(!desc.Desc.Size || desc.Data);
 				if(desc.Data)
-					std::memcpy(updateDesc.MappedData, desc.Data, desc.Desc.Size);
+					memcpy(updateDesc.MappedData, desc.Data, desc.Desc.Size);
 			}
 			EndUpdateResource(updateDesc, token);
 		}

--- a/TRAP/src/Graphics/API/ResourceLoader.cpp
+++ b/TRAP/src/Graphics/API/ResourceLoader.cpp
@@ -8,7 +8,7 @@
 #include "Graphics/Textures/Texture.h"
 #include "Vulkan/VulkanRenderer.h"
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 #include "Vulkan/VulkanCommon.h"
 #include "Vulkan/Objects/VulkanDevice.h"
@@ -1132,7 +1132,7 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 	bool validMultiFileCubemap = true;
 	for(const std::filesystem::path& str : textureLoadDesc.Filepaths)
 	{
-		if(str.empty() || !TRAP::FS::FileOrFolderExists(str) || !TRAP::Image::IsSupportedImageFile(str))
+		if(str.empty() || !TRAP::FileSystem::FileOrFolderExists(str) || !TRAP::Image::IsSupportedImageFile(str))
 		{
 			validMultiFileCubemap = false;
 			break;
@@ -1141,7 +1141,7 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 
 	bool supported = true;
 	if((textureLoadDesc.Filepaths[0].empty() ||
-	    !TRAP::FS::FileOrFolderExists(textureLoadDesc.Filepaths[0]) ||
+	    !TRAP::FileSystem::FileOrFolderExists(textureLoadDesc.Filepaths[0]) ||
 	    !TRAP::Image::IsSupportedImageFile(textureLoadDesc.Filepaths[0])))
 		supported = false;
 	else if(textureLoadDesc.IsCubemap && textureLoadDesc.Type == RendererAPI::TextureCubeType::MultiFile &&
@@ -1170,7 +1170,7 @@ TRAP::Graphics::API::ResourceLoader::UploadFunctionResult TRAP::Graphics::API::R
 	//https://github.com/GPUOpen-Effects/FidelityFX-SPD/blob/master/sample/src/VK/CSDownsampler.glsl
 	if(!textureLoadDesc.Filepaths[0].empty() && supported)
 	{
-		const auto fileName = FS::GetFileNameWithEnding(textureLoadDesc.Filepaths[0]);
+		const auto fileName = FileSystem::GetFileNameWithEnding(textureLoadDesc.Filepaths[0]);
 		if(fileName)
 			textureDesc.Name = *fileName;
 		else

--- a/TRAP/src/Graphics/API/ResourceLoader.cpp
+++ b/TRAP/src/Graphics/API/ResourceLoader.cpp
@@ -360,7 +360,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 				updateDesc.DstOffset = offset;
 				BeginUpdateResource(updateDesc);
 				if (desc.ForceReset)
-					std::memset(updateDesc.MappedData, 0, chunkSize);
+					memset(updateDesc.MappedData, 0, chunkSize);
 				else
 				{
 					TRAP_ASSERT(data);
@@ -375,7 +375,7 @@ void TRAP::Graphics::API::ResourceLoader::AddResource(RendererAPI::BufferLoadDes
 			updateDesc.Buffer = desc.Buffer;
 			BeginUpdateResource(updateDesc);
 			if (desc.ForceReset)
-				std::memset(updateDesc.MappedData, 0, desc.Desc.Size);
+				memset(updateDesc.MappedData, 0, desc.Desc.Size);
 			else
 			{
 				TRAP_ASSERT(!desc.Desc.Size || desc.Data);

--- a/TRAP/src/Graphics/API/SPIRVTools.cpp
+++ b/TRAP/src/Graphics/API/SPIRVTools.cpp
@@ -25,7 +25,7 @@ void ReflectBoundResources(spirv_cross::Compiler& compiler,
 		resource.Set = compiler.get_decoration(resource.SPIRVCode.ID, spv::DecorationDescriptorSet);
 		resource.Binding = compiler.get_decoration(resource.SPIRVCode.ID, spv::DecorationBinding);
 
-		spirv_cross::SPIRType type = compiler.get_type(resource.SPIRVCode.TypeID);
+		const spirv_cross::SPIRType type = compiler.get_type(resource.SPIRVCode.TypeID);
 
 		//Special case for textureBuffer / imageBuffer
 		//textureBuffer is considered as separate images with dimension buffer in SPIRV but they require a
@@ -161,7 +161,7 @@ void TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectShaderResources()
 		//Location is the binding point for inputs
 		resource.Binding = m_compiler->get_decoration(resource.SPIRVCode.ID, spv::DecorationLocation);
 
-		spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
+		const spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
 		//bit width * vecsize = size
 		resource.Size = static_cast<uint64_t>(type.width / 8) * type.vecsize;
 
@@ -185,7 +185,7 @@ void TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectShaderResources()
 		//Location is the binding point for outputs
 		resource.Binding = m_compiler->get_decoration(resource.SPIRVCode.ID, spv::DecorationLocation);
 
-		spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
+		const spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
 		//bit width * vecsize = size
 		resource.Size = (static_cast<uint64_t>(type.width / 8)) * type.vecsize;
 
@@ -228,7 +228,7 @@ void TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectShaderResources()
 		resource.Set = static_cast<uint32_t>(-1); //Push constants dont have sets
 		resource.Binding = static_cast<uint32_t>(-1); //Push constants dont have bindings
 
-		spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
+		const spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
 		resource.Size = m_compiler->get_declared_struct_size(type);
 
 		resource.Name = input.name;
@@ -248,11 +248,11 @@ void TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectShaderVariables()
 	//1. Count number of variables we have
 	std::size_t variableCount = 0;
 
-	for(Resource& resource : m_shaderResources)
+	for(const Resource& resource : m_shaderResources)
 	{
 		if(resource.Type == ResourceType::UniformBuffers || resource.Type == ResourceType::PushConstant)
 		{
-			spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
+			const spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
 			variableCount += type.member_types.size();
 		}
 	}
@@ -264,14 +264,14 @@ void TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectShaderVariables()
 	//3. Reflect
 	for(std::size_t i = 0; i < m_shaderResources.size(); ++i)
 	{
-		Resource& resource = m_shaderResources[i];
+		const Resource& resource = m_shaderResources[i];
 
 		if(resource.Type != ResourceType::UniformBuffers && resource.Type != ResourceType::PushConstant)
 			continue;
 
-		std::size_t startOfBlock = currentVariable;
+		const std::size_t startOfBlock = currentVariable;
 
-		spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
+		const spirv_cross::SPIRType type = m_compiler->get_type(resource.SPIRVCode.TypeID);
 		for(std::size_t j = 0; j < type.member_types.size(); ++j)
 		{
 			Variable& variable = variables[currentVariable++];
@@ -290,7 +290,7 @@ void TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectShaderVariables()
 			variable.Name = m_compiler->get_member_name(resource.SPIRVCode.BaseTypeID, static_cast<uint32_t>(j));
 		}
 
-		spirv_cross::SmallVector<spirv_cross::BufferRange> range = m_compiler->get_active_buffer_ranges(resource.SPIRVCode.ID);
+		const spirv_cross::SmallVector<spirv_cross::BufferRange> range = m_compiler->get_active_buffer_ranges(resource.SPIRVCode.ID);
 
 		for(std::size_t j = 0; j < range.size(); ++j)
 			variables[startOfBlock + range[j].index].IsUsed = true;
@@ -301,11 +301,11 @@ void TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectShaderVariables()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::array<uint32_t, 3> TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectComputeShaderWorkGroupSize()
+std::array<uint32_t, 3> TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectComputeShaderWorkGroupSize() const
 {
 	std::array<uint32_t, 3> res{};
 
-	spirv_cross::SPIREntryPoint& entryPoint = m_compiler->get_entry_point(m_entryPoint, m_compiler->get_execution_model());
+	const spirv_cross::SPIREntryPoint& entryPoint = m_compiler->get_entry_point(m_entryPoint, m_compiler->get_execution_model());
 
 	res[0] = entryPoint.workgroup_size.x;
 	res[1] = entryPoint.workgroup_size.y;
@@ -316,7 +316,7 @@ std::array<uint32_t, 3> TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectC
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-uint32_t TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectTessellationControlShaderControlPoint()
+uint32_t TRAP::Graphics::API::SPIRVTools::CrossCompiler::ReflectTessellationControlShaderControlPoint() const
 {
 	uint32_t controlPoints = m_compiler->get_entry_point(m_entryPoint, m_compiler->get_execution_model()).output_vertices;
 
@@ -347,7 +347,7 @@ const std::vector<TRAP::Graphics::API::SPIRVTools::Variable>& TRAP::Graphics::AP
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::string TRAP::Graphics::API::SPIRVTools::CrossCompiler::GetEntryPoint()
+std::string TRAP::Graphics::API::SPIRVTools::CrossCompiler::GetEntryPoint() const
 {
 	return m_entryPoint;
 }

--- a/TRAP/src/Graphics/API/SPIRVTools.h
+++ b/TRAP/src/Graphics/API/SPIRVTools.h
@@ -171,12 +171,12 @@ namespace TRAP::Graphics::API::SPIRVTools
 		/// Reflect the compute shader work group size.
 		/// </summary>
 		/// <returns>Compute shader work group size.</returns>
-		std::array<uint32_t, 3> ReflectComputeShaderWorkGroupSize();
+		std::array<uint32_t, 3> ReflectComputeShaderWorkGroupSize() const;
 		/// <summary>
 		/// Reflect tessellation control shader control point count.
 		/// </summary>
 		/// <returns>Tessellation control shader control point count.</returns>
-		uint32_t ReflectTessellationControlShaderControlPoint();
+		uint32_t ReflectTessellationControlShaderControlPoint() const;
 
 		/// <summary>
 		/// Retrieve the shader resources.
@@ -194,7 +194,7 @@ namespace TRAP::Graphics::API::SPIRVTools
 		/// Rertieve the name of the entry point.
 		/// </summary>
 		/// <returns>Name of entry point.</returns>
-		std::string GetEntryPoint();
+		std::string GetEntryPoint() const;
 
 	private:
 		//This points to the internal compiler class

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanBuffer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanBuffer.cpp
@@ -85,10 +85,10 @@ TRAP::Graphics::API::VulkanBuffer::VulkanBuffer(const RendererAPI::BufferDesc& d
 
 	if(info.usage & VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT)
 	{
-		VkBufferViewCreateInfo viewInfo = VulkanInits::BufferViewCreateInfo(m_vkBuffer,
-		                                                                    ImageFormatToVkFormat(desc.Format),
-		                                                                    desc.FirstElement * desc.StructStride,
-		                                                                    desc.ElementCount * desc.StructStride);
+		const VkBufferViewCreateInfo viewInfo = VulkanInits::BufferViewCreateInfo(m_vkBuffer,
+		                                                                          ImageFormatToVkFormat(desc.Format),
+		                                                                          desc.FirstElement * desc.StructStride,
+		                                                                          desc.ElementCount * desc.StructStride);
 		VkFormatProperties formatProps{};
 		vkGetPhysicalDeviceFormatProperties(m_device->GetPhysicalDevice()->GetVkPhysicalDevice(), viewInfo.format,
 		                                    &formatProps);
@@ -100,10 +100,10 @@ TRAP::Graphics::API::VulkanBuffer::VulkanBuffer(const RendererAPI::BufferDesc& d
 	}
 	if(info.usage & VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT)
 	{
-		VkBufferViewCreateInfo viewInfo = VulkanInits::BufferViewCreateInfo(m_vkBuffer,
-		                                                                    ImageFormatToVkFormat(desc.Format),
-		                                                                    desc.FirstElement * desc.StructStride,
-		                                                                    desc.ElementCount * desc.StructStride);
+		const VkBufferViewCreateInfo viewInfo = VulkanInits::BufferViewCreateInfo(m_vkBuffer,
+		                                                                          ImageFormatToVkFormat(desc.Format),
+		                                                                          desc.FirstElement * desc.StructStride,
+		                                                                          desc.ElementCount * desc.StructStride);
 		VkFormatProperties formatProps{};
 		vkGetPhysicalDeviceFormatProperties(m_device->GetPhysicalDevice()->GetVkPhysicalDevice(), viewInfo.format,
 		                                    &formatProps);
@@ -142,7 +142,8 @@ TRAP::Graphics::API::VulkanBuffer::~VulkanBuffer()
 		m_vkStorageTexelView = VK_NULL_HANDLE;
 	}
 
-	vmaDestroyBuffer(m_VMA->GetVMAAllocator(), m_vkBuffer, m_allocation);
+	if(m_allocation)
+		vmaDestroyBuffer(m_VMA->GetVMAAllocator(), m_vkBuffer, m_allocation);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanBuffer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanBuffer.cpp
@@ -1,4 +1,5 @@
 #include "TRAPPCH.h"
+#include "Utils/Utils.h"
 #include "VulkanBuffer.h"
 
 #include "VulkanMemoryAllocator.h"
@@ -254,8 +255,8 @@ void TRAP::Graphics::API::VulkanBuffer::SetBufferName(const std::string_view nam
 		return;
 
 #ifdef ENABLE_DEBUG_UTILS_EXTENSION
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(m_vkBuffer), VK_OBJECT_TYPE_BUFFER, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkBuffer, uint64_t>(m_vkBuffer), VK_OBJECT_TYPE_BUFFER, name);
 #else
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(m_vkBuffer), VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkBuffer, uint64_t>(m_vkBuffer), VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, name);
 #endif
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.cpp
@@ -408,7 +408,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vect
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanCommandBuffer::AddDebugMarker(const TRAP::Math::Vec3& color, const char* name) const
+void TRAP::Graphics::API::VulkanCommandBuffer::AddDebugMarker(const TRAP::Math::Vec3& color, const std::string_view name) const
 {
 #ifdef ENABLE_DEBUG_UTILS_EXTENSION
 	if(!VulkanRenderer::s_debugUtilsExtension)
@@ -426,13 +426,13 @@ void TRAP::Graphics::API::VulkanCommandBuffer::AddDebugMarker(const TRAP::Math::
 
 #ifdef ENABLE_NSIGHT_AFTERMATH
 	if(RendererAPI::s_aftermathSupport)
-		vkCmdSetCheckpointNV(m_vkCommandBuffer, name);
+		vkCmdSetCheckpointNV(m_vkCommandBuffer, name.data());
 #endif
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanCommandBuffer::BeginDebugMarker(const TRAP::Math::Vec3& color, const char* name) const
+void TRAP::Graphics::API::VulkanCommandBuffer::BeginDebugMarker(const TRAP::Math::Vec3& color, const std::string_view name) const
 {
 #ifdef ENABLE_DEBUG_UTILS_EXTENSION
 	if(!VulkanRenderer::s_debugUtilsExtension)

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.cpp
@@ -48,7 +48,7 @@ TRAP::Graphics::API::VulkanCommandBuffer::VulkanCommandBuffer(TRAP::Ref<VulkanDe
 	TP_DEBUG(Log::RendererVulkanCommandBufferPrefix, "Creating CommandBuffer");
 #endif
 
-	VkCommandBufferAllocateInfo info = VulkanInits::CommandBufferAllocateInfo(commandPool, secondary);
+	const VkCommandBufferAllocateInfo info = VulkanInits::CommandBufferAllocateInfo(commandPool, secondary);
 
 	VkCall(vkAllocateCommandBuffers(m_device->GetVkDevice(), &info, &m_vkCommandBuffer));
 }
@@ -205,7 +205,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindPipeline(const TRAP::Ref<Pipe
 	TRAP_ASSERT(pipeline);
 	TRAP_ASSERT(m_vkCommandBuffer);
 
-	VulkanPipeline* pipe = dynamic_cast<VulkanPipeline*>(pipeline.get());
+	const VulkanPipeline* pipe = dynamic_cast<VulkanPipeline*>(pipeline.get());
 	const VkPipelineBindPoint pipelineBindPoint = VkPipelineBindPointTranslator[static_cast<uint32_t>(pipe->GetPipelineType())];
 	vkCmdBindPipeline(m_vkCommandBuffer, pipelineBindPoint, pipe->GetVkPipeline());
 }
@@ -215,9 +215,10 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindPipeline(const TRAP::Ref<Pipe
 void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vector<TRAP::Ref<RenderTarget>>& renderTargets,
 																 const TRAP::Ref<RenderTarget>& depthStencil,
 																 const RendererAPI::LoadActionsDesc* loadActions,
-																 std::vector<uint32_t>* colorArraySlices,
-																 std::vector<uint32_t>* colorMipSlices,
-																 uint32_t depthArraySlice, uint32_t depthMipSlice)
+																 const std::vector<uint32_t>* colorArraySlices,
+																 const std::vector<uint32_t>* colorMipSlices,
+																 const uint32_t depthArraySlice,
+																 const uint32_t depthMipSlice)
 {
 	TRAP_ASSERT(m_vkCommandBuffer != VK_NULL_HANDLE);
 
@@ -251,7 +252,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vect
 		else if(loadActions)
 			colorStoreActions[i] = loadActions->StoreActionsColor[i];
 
-		std::array<uint32_t, 4> hashValues =
+		const std::array<uint32_t, 4> hashValues =
 		{
 			static_cast<uint32_t>(renderTargets[i]->GetImageFormat()),
 			static_cast<uint32_t>(renderTargets[i]->GetSampleCount()),
@@ -265,7 +266,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vect
 	}
 	if(depthStencil)
 	{
-		VulkanRenderTarget* dStencil = dynamic_cast<VulkanRenderTarget*>(depthStencil.get());
+		const VulkanRenderTarget* dStencil = dynamic_cast<VulkanRenderTarget*>(depthStencil.get());
 		const VulkanTexture* vkTex = dynamic_cast<VulkanTexture*>(dStencil->GetTexture());
 
 		if(vkTex->IsLazilyAllocated())
@@ -279,7 +280,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vect
 			stencilStoreAction = loadActions->StoreActionStencil;
 		}
 
-		std::array<uint32_t, 6> hashValues =
+		const std::array<uint32_t, 6> hashValues =
 		{
 			static_cast<uint32_t>(dStencil->GetImageFormat()),
 			static_cast<uint32_t>(dStencil->GetSampleCount()),
@@ -384,7 +385,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vect
 	{
 		for(std::size_t i = 0; i < renderTargets.size(); ++i)
 		{
-			TRAP::Math::Vec4 clearColor = loadActions->ClearColorValues[i];
+			const TRAP::Math::Vec4 clearColor = loadActions->ClearColorValues[i];
 			VkClearValue val{};
 			val.color = { {clearColor.x, clearColor.y, clearColor.z, clearColor.w} };
 			clearValues.push_back(val);
@@ -398,9 +399,9 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vect
 		}
 	}
 
-	VkRenderPassBeginInfo beginInfo = VulkanInits::RenderPassBeginInfo(renderPass->GetVkRenderPass(),
-	                                                                   frameBuffer->GetVkFrameBuffer(), renderArea,
-																	   clearValues);
+	const VkRenderPassBeginInfo beginInfo = VulkanInits::RenderPassBeginInfo(renderPass->GetVkRenderPass(),
+	                                                                         frameBuffer->GetVkFrameBuffer(), renderArea,
+																	         clearValues);
 
 	vkCmdBeginRenderPass(m_vkCommandBuffer, &beginInfo, VK_SUBPASS_CONTENTS_INLINE);
 	m_activeRenderPass = renderPass->GetVkRenderPass();
@@ -414,13 +415,13 @@ void TRAP::Graphics::API::VulkanCommandBuffer::AddDebugMarker(const TRAP::Math::
 	if(!VulkanRenderer::s_debugUtilsExtension)
 		return;
 
-	VkDebugUtilsLabelEXT markerInfo = VulkanInits::DebugUtilsLabelExt(color.x, color.y, color.z, name);
+	const VkDebugUtilsLabelEXT markerInfo = VulkanInits::DebugUtilsLabelExt(color.x, color.y, color.z, name);
 	vkCmdInsertDebugUtilsLabelEXT(m_vkCommandBuffer, &markerInfo);
 #else
 	if(!VulkanRenderer::s_debugReportExtension)
 		return;
 
-	VkDebugMarkerMarkerInfoEXT markerInfo = VulkanInits::DebugMarkerMarkerInfo(color.x, color.y, color.z, name);
+	const VkDebugMarkerMarkerInfoEXT markerInfo = VulkanInits::DebugMarkerMarkerInfo(color.x, color.y, color.z, name);
 	vkCmdDebugMarkerInsertEXT(m_vkCommandBuffer, &markerInfo);
 #endif
 
@@ -438,13 +439,13 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BeginDebugMarker(const TRAP::Math
 	if(!VulkanRenderer::s_debugUtilsExtension)
 		return;
 
-	VkDebugUtilsLabelEXT markerInfo = VulkanInits::DebugUtilsLabelExt(color.x, color.y, color.z, name);
+	const VkDebugUtilsLabelEXT markerInfo = VulkanInits::DebugUtilsLabelExt(color.x, color.y, color.z, name);
 	vkCmdBeginDebugUtilsLabelEXT(m_vkCommandBuffer, &markerInfo);
 #elif !defined(USE_RENDER_DOC)
 	if(!VulkanRenderer::s_debugReportExtension)
 		return;
 
-	VkDebugMarkerMarkerInfoEXT markerInfo = VulkanInits::DebugMarkerMarkerInfo(color.x, color.y, color.z, name);
+	const VkDebugMarkerMarkerInfoEXT markerInfo = VulkanInits::DebugMarkerMarkerInfo(color.x, color.y, color.z, name);
 	vkCmdDebugMarkerBeginEXT(m_vkCommandBuffer, &markerInfo);
 #endif
 }
@@ -472,7 +473,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::Begin()
 {
 	TRAP_ASSERT(m_vkCommandBuffer != VK_NULL_HANDLE);
 
-	VkCommandBufferBeginInfo beginInfo = VulkanInits::CommandBufferBeginInfo();
+	const VkCommandBufferBeginInfo beginInfo = VulkanInits::CommandBufferBeginInfo();
 
 	VkCall(vkBeginCommandBuffer(m_vkCommandBuffer, &beginInfo));
 
@@ -583,8 +584,8 @@ void TRAP::Graphics::API::VulkanCommandBuffer::ExecuteIndirect(const TRAP::Ref<C
                                                                const TRAP::Ref<Buffer>& counterBuffer,
                                                                const uint64_t counterBufferOffset) const
 {
-	VulkanBuffer* iBuffer = dynamic_cast<VulkanBuffer*>(indirectBuffer.get());
-	VulkanCommandSignature* cSig = dynamic_cast<VulkanCommandSignature*>(cmdSignature.get());
+	const VulkanBuffer* iBuffer = dynamic_cast<VulkanBuffer*>(indirectBuffer.get());
+	const VulkanCommandSignature* cSig = dynamic_cast<VulkanCommandSignature*>(cmdSignature.get());
 
 	if (cSig->GetDrawType() == RendererAPI::IndirectArgumentType::IndirectDraw)
 	{
@@ -631,8 +632,8 @@ void TRAP::Graphics::API::VulkanCommandBuffer::UpdateBuffer(const TRAP::Ref<Buff
                                                             const TRAP::Ref<Buffer>& srcBuffer,
                                                             const uint64_t srcOffset, const uint64_t size) const
 {
-	VulkanBuffer* sBuffer = dynamic_cast<VulkanBuffer*>(srcBuffer.get());
-	VulkanBuffer* buf = dynamic_cast<VulkanBuffer*>(buffer.get());
+	const VulkanBuffer* sBuffer = dynamic_cast<VulkanBuffer*>(srcBuffer.get());
+	const VulkanBuffer* buf = dynamic_cast<VulkanBuffer*>(buffer.get());
 
 	TRAP_ASSERT(srcBuffer);
 	TRAP_ASSERT(sBuffer->GetVkBuffer());
@@ -655,7 +656,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::UpdateSubresource(TRAP::Graphics:
                                                                  const TRAP::Ref<Buffer>& srcBuffer,
                                                                  const RendererAPI::SubresourceDataDesc& subresourceDesc) const
 {
-	VkBuffer buffer = dynamic_cast<VulkanBuffer*>(srcBuffer.get())->GetVkBuffer();
+	const VkBuffer buffer = dynamic_cast<VulkanBuffer*>(srcBuffer.get())->GetVkBuffer();
 	auto* vkTexture = dynamic_cast<TRAP::Graphics::API::VulkanTexture*>(texture);
 
 	const TRAP::Graphics::API::ImageFormat fmt = texture->GetImageFormat();
@@ -735,7 +736,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::ResetQueryPool(const TRAP::Ref<Qu
 void TRAP::Graphics::API::VulkanCommandBuffer::BeginQuery(const TRAP::Ref<QueryPool>& queryPool,
                                                           const RendererAPI::QueryDesc& desc) const
 {
-	VulkanQueryPool* qPool = dynamic_cast<VulkanQueryPool*>(queryPool.get());
+	const VulkanQueryPool* qPool = dynamic_cast<VulkanQueryPool*>(queryPool.get());
 
 	const VkQueryType type = qPool->GetVkQueryType();
 	switch(type)
@@ -800,7 +801,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::ResourceBarrier(const std::vector
 	VkAccessFlags srcAccessFlags = 0;
 	VkAccessFlags dstAccessFlags = 0;
 
-	VulkanQueue* queue = dynamic_cast<VulkanQueue*>(m_queue.get());
+	const VulkanQueue* queue = dynamic_cast<VulkanQueue*>(m_queue.get());
 	if(bufferBarriers)
 	{
 		for (const auto& trans : *bufferBarriers)
@@ -1010,7 +1011,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::ResourceBarrier(const RendererAPI
 	VkAccessFlags srcAccessFlags = 0;
 	VkAccessFlags dstAccessFlags = 0;
 
-	VulkanQueue* queue = dynamic_cast<VulkanQueue*>(m_queue.get());
+	const VulkanQueue* queue = dynamic_cast<VulkanQueue*>(m_queue.get());
 	if(bufferBarrier)
 	{
 		const TRAP::Ref<Buffer>& buffer = bufferBarrier->Buffer;
@@ -1194,10 +1195,10 @@ void TRAP::Graphics::API::VulkanCommandBuffer::SetStencilReferenceValue(const ui
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanCommandBuffer::SetShadingRate(RendererAPI::ShadingRate rate,
+void TRAP::Graphics::API::VulkanCommandBuffer::SetShadingRate(const RendererAPI::ShadingRate rate,
 															  Texture* /*texture*/,
-															  RendererAPI::ShadingRateCombiner postRasterizerState,
-															  RendererAPI::ShadingRateCombiner finalRate) const
+															  const RendererAPI::ShadingRateCombiner postRasterizerState,
+															  const RendererAPI::ShadingRateCombiner finalRate) const
 {
 	//Texture would be used for https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#primsrast-fragment-shading-rate-attachment
 
@@ -1207,12 +1208,12 @@ void TRAP::Graphics::API::VulkanCommandBuffer::SetShadingRate(RendererAPI::Shadi
 
 	if(static_cast<bool>(RendererAPI::GPUSettings.ShadingRateCaps & RendererAPI::ShadingRateCaps::PerDraw))
 	{
-		std::array<VkFragmentShadingRateCombinerOpKHR, 2> combiner
+		const std::array<VkFragmentShadingRateCombinerOpKHR, 2> combiner
 		{
 			ShadingRateCombinerToVkFragmentShadingRateCombinerOpKHR(postRasterizerState),
 			ShadingRateCombinerToVkFragmentShadingRateCombinerOpKHR(finalRate)
 		};
-		VkExtent2D fragmentSize = ShadingRateToVkExtent2D(rate);
+		const VkExtent2D fragmentSize = ShadingRateToVkExtent2D(rate);
 
 		vkCmdSetFragmentShadingRateKHR(m_vkCommandBuffer, &fragmentSize, combiner.data());
 	}
@@ -1221,7 +1222,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::SetShadingRate(RendererAPI::Shadi
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanCommandBuffer::Clear(const TRAP::Math::Vec4 color, const uint32_t width,
-													 const uint32_t height)
+													 const uint32_t height) const
 {
 	VkClearRect rect;
 	VkRect2D r;
@@ -1244,7 +1245,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::Clear(const TRAP::Math::Vec4 colo
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanCommandBuffer::Clear(const float depth, const uint32_t stencil,
- 												     const uint32_t width, const uint32_t height)
+ 												     const uint32_t width, const uint32_t height) const
 {
 	VkClearRect rect;
 	VkRect2D r;
@@ -1266,7 +1267,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::Clear(const float depth, const ui
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanCommandBuffer::Clear(const float depth, const uint32_t width, const uint32_t height)
+void TRAP::Graphics::API::VulkanCommandBuffer::Clear(const float depth, const uint32_t width, const uint32_t height) const
 {
 	VkClearRect rect;
 	VkRect2D r;
@@ -1289,7 +1290,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::Clear(const float depth, const ui
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanCommandBuffer::Clear(const uint32_t stencil, const uint32_t width,
-                                                     const uint32_t height)
+                                                     const uint32_t height) const
 {
 	VkClearRect rect;
 	VkRect2D r;
@@ -1314,7 +1315,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::Clear(const uint32_t stencil, con
 void TRAP::Graphics::API::VulkanCommandBuffer::ResolveImage(TRAP::Graphics::API::VulkanTexture* srcImage,
 															const RendererAPI::ResourceState srcState,
 															TRAP::Graphics::API::VulkanTexture* dstImage,
-															const RendererAPI::ResourceState dstState)
+															const RendererAPI::ResourceState dstState) const
 {
 	VkImageResolve imageResolve{};
 	imageResolve.srcSubresource = {srcImage->GetAspectMask(), 0, 0, 1};

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.h
@@ -127,8 +127,9 @@ namespace TRAP::Graphics::API
 		void BindRenderTargets(const std::vector<TRAP::Ref<RenderTarget>>& renderTargets,
 		                       const TRAP::Ref<RenderTarget>& depthStencil,
 							   const RendererAPI::LoadActionsDesc* loadActions,
-							   std::vector<uint32_t>* colorArraySlices,
-		                       std::vector<uint32_t>* colorMipSlices, uint32_t depthArraySlice,
+							   const std::vector<uint32_t>* colorArraySlices,
+		                       const std::vector<uint32_t>* colorMipSlices,
+							   uint32_t depthArraySlice,
 							   uint32_t depthMipSlice) override;
 
 		/// <summary>
@@ -326,7 +327,7 @@ namespace TRAP::Graphics::API
 		/// <param name="color">Color to clear the color attachment with.</param>
 		/// <param name="width">Width of the area to clear.</param>
 		/// <param name="height">Height of the area to clear.</param>
-		void Clear(TRAP::Math::Vec4 color, uint32_t width, uint32_t height) override;
+		void Clear(TRAP::Math::Vec4 color, uint32_t width, uint32_t height) const override;
 		/// <summary>
 		/// Clear the currently used depth and stencil attachment.
 		/// </summary>
@@ -334,21 +335,21 @@ namespace TRAP::Graphics::API
 		/// <param name="stencil">Stencil value to clear the stencil attachment with.</param>
 		/// <param name="width">Width of the area to clear.</param>
 		/// <param name="height">Height of the area to clear.</param>
-		void Clear(float depth, uint32_t stencil, uint32_t width, uint32_t height) override;
+		void Clear(float depth, uint32_t stencil, uint32_t width, uint32_t height) const override;
 		/// <summary>
 		/// Clear the currently used depth attachment.
 		/// </summary>
 		/// <param name="depth">Depth value to clear the depth attachment with.</param>
 		/// <param name="width">Width of the area to clear.</param>
 		/// <param name="height">Height of the area to clear.</param>
-		void Clear(float depth, uint32_t width, uint32_t height) override;
+		void Clear(float depth, uint32_t width, uint32_t height) const override;
 		/// <summary>
 		/// Clear the currently used stencil attachment.
 		/// </summary>
 		/// <param name="stencil">Stencil value to clear the stencil attachment with.</param>
 		/// <param name="width">Width of the area to clear.</param>
 		/// <param name="height">Height of the area to clear.</param>
-		void Clear(uint32_t stencil, uint32_t width, uint32_t height) override;
+		void Clear(uint32_t stencil, uint32_t width, uint32_t height) const override;
 
 		/// <summary>
 		/// Resolve a multisample color texture to a non-multisample color texture.
@@ -358,7 +359,7 @@ namespace TRAP::Graphics::API
 		/// <param name="dstImage">Destination non-multisample color texture to resolve into.</param>
 		/// <param name="dstState">Destination texture state.</param>
 		void ResolveImage(API::VulkanTexture* srcImage, RendererAPI::ResourceState srcState,
-		                  API::VulkanTexture* dstImage, RendererAPI::ResourceState dstState);
+		                  API::VulkanTexture* dstImage, RendererAPI::ResourceState dstState) const;
 
 		/// <summary>
 		/// Retrieve the currently active VkRenderPass.

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.h
@@ -136,13 +136,13 @@ namespace TRAP::Graphics::API
 		/// </summary>
 		/// <param name="color">Color for the debug marker.</param>
 		/// <param name="name">Name of the marker.</param>
-		void AddDebugMarker(const TRAP::Math::Vec3& color, const char* name) const override;
+		void AddDebugMarker(const TRAP::Math::Vec3& color, std::string_view name) const override;
 		/// <summary>
 		/// Start a debug marker region.
 		/// </summary>
 		/// <param name="color">Color for the debug marker.</param>
 		/// <param name="name">Name of the marker.</param>
-		void BeginDebugMarker(const TRAP::Math::Vec3& color, const char* name) const override;
+		void BeginDebugMarker(const TRAP::Math::Vec3& color, std::string_view name) const override;
 		/// <summary>
 		/// End the currently running debug marker region.
 		/// </summary>

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandPool.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandPool.cpp
@@ -58,8 +58,7 @@ VkCommandPool TRAP::Graphics::API::VulkanCommandPool::GetVkCommandPool() const
 
 TRAP::Graphics::CommandBuffer* TRAP::Graphics::API::VulkanCommandPool::AllocateCommandBuffer(const bool secondary)
 {
-	m_commandBuffers.emplace_back(TRAP::MakeScope<VulkanCommandBuffer>(m_device, m_queue, m_vkCommandPool, secondary));
-	return m_commandBuffers.back().get();
+	return m_commandBuffers.emplace_back(TRAP::MakeScope<VulkanCommandBuffer>(m_device, m_queue, m_vkCommandPool, secondary)).get();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDebug.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDebug.cpp
@@ -83,18 +83,18 @@ VkBool32 TRAP::Graphics::API::VulkanDebug::VulkanDebugReportCallback(const VkDeb
 																	 const uint64_t /*object*/,
 																	 const size_t /*location*/,
 																	 const int32_t messageCode,
-																	 const char* layerPrefix,
-																	 const char* message, void* /*userData*/)
+																	 const std::string_view layerPrefix,
+																	 const std::string_view message, void* /*userData*/)
 {
 	std::string str = Log::RendererVulkanDebugPrefix;
 	str.pop_back();
 
 	if(flags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
-		TP_INFO(str, '[', layerPrefix ? layerPrefix : "", "] ", message, " (", messageCode, ')');
+		TP_INFO(str, '[', !layerPrefix.empty() ? layerPrefix : "", "] ", message, " (", messageCode, ')');
 	if(flags & VK_DEBUG_REPORT_WARNING_BIT_EXT)
-		TP_WARN(str, '[', layerPrefix ? layerPrefix : "", "] ", message, " (", messageCode, ')');
+		TP_WARN(str, '[', !layerPrefix.empty() ? layerPrefix : "", "] ", message, " (", messageCode, ')');
 	if(flags & VK_DEBUG_REPORT_ERROR_BIT_EXT)
-		TP_ERROR(str, '[', layerPrefix ? layerPrefix : "", "] ", message, " (", messageCode, ')');
+		TP_ERROR(str, '[', !layerPrefix.empty() ? layerPrefix : "", "] ", message, " (", messageCode, ')');
 
 	return VK_FALSE;
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDebug.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDebug.cpp
@@ -18,16 +18,16 @@ TRAP::Graphics::API::VulkanDebug::VulkanDebug(Ref<VulkanInstance> instance)
 #ifdef ENABLE_DEBUG_UTILS_EXTENSION
 	if(VulkanRenderer::s_debugUtilsExtension)
 	{
-		VkDebugUtilsMessengerCreateInfoEXT info = VulkanInits::DebugUtilsMessengerCreateInfo(VulkanDebugUtilsCallback);
-		VkResult res = vkCreateDebugUtilsMessengerEXT(m_instance->GetVkInstance(), &info, nullptr, &m_debugUtils);
+		const VkDebugUtilsMessengerCreateInfoEXT info = VulkanInits::DebugUtilsMessengerCreateInfo(VulkanDebugUtilsCallback);
+		const VkResult res = vkCreateDebugUtilsMessengerEXT(m_instance->GetVkInstance(), &info, nullptr, &m_debugUtils);
 		if(res != VK_SUCCESS)
 			TP_ERROR(TRAP::Log::RendererVulkanPrefix, "Couldn't create Debug Utils Messenger!");
 	}
 #else
 	if(VulkanRenderer::s_debugReportExtension)
 	{
-		VkDebugReportCallbackCreateInfoEXT info = VulkanInits::DebugReportCallbackCreateInfo(VulkanDebugReportCallback);
-		VkResult res = vkCreateDebugReportCallbackEXT(m_instance->GetVkInstance(), &info, nullptr, &m_debugReport);
+		const VkDebugReportCallbackCreateInfoEXT info = VulkanInits::DebugReportCallbackCreateInfo(VulkanDebugReportCallback);
+		const VkResult res = vkCreateDebugReportCallbackEXT(m_instance->GetVkInstance(), &info, nullptr, &m_debugReport);
 		if(res != VK_SUCCESS)
 			TP_ERROR(TRAP::Log::RendererVulkanPrefix, "Couldn't create Debug Report Messenger!");
 	}

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDebug.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDebug.h
@@ -67,8 +67,8 @@ namespace TRAP::Graphics::API
 																	    VkDebugReportObjectTypeEXT objectType,
 																	    uint64_t object, size_t location,
 																	    int32_t messageCode,
-																	    const char* layerPrefix,
-																	    const char* message, void* userData);
+																	    std::string_view layerPrefix,
+																	    std::string_view message, void* userData);
 
 		VkDebugUtilsMessengerEXT m_debugUtils;
 		VkDebugReportCallbackEXT m_debugReport;

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDescriptorPool.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDescriptorPool.cpp
@@ -48,8 +48,8 @@ TRAP::Graphics::API::VulkanDescriptorPool::VulkanDescriptorPool(const uint32_t n
 	for(uint32_t i = 0; i < DescriptorTypeRangeSize; i++)
 		m_descriptorPoolSizes[i] = s_descriptorPoolSizes[i];
 
-	VkDescriptorPoolCreateInfo info = VulkanInits::DescriptorPoolCreateInfo(m_descriptorPoolSizes,
-	                                                                        m_numDescriptorSets);
+	const VkDescriptorPoolCreateInfo info = VulkanInits::DescriptorPoolCreateInfo(m_descriptorPoolSizes,
+	                                                                              m_numDescriptorSets);
 	VkCall(vkCreateDescriptorPool(m_device->GetVkDevice(), &info, nullptr, &m_currentPool));
 
 	m_descriptorPools.emplace_back(m_currentPool);
@@ -141,10 +141,9 @@ TRAP::Graphics::DescriptorSet* TRAP::Graphics::API::VulkanDescriptorPool::Retrie
 		TRAP_ASSERT(dynamicOffsetCount == 1);
 	}
 
-	m_descriptorSets.emplace_back(TRAP::MakeScope<VulkanDescriptorSet>(m_device, handles, rootSignature, updateData,
-	                                                      			   maxSets, dynamicOffsetCount, updateFreq));
-
-	return m_descriptorSets.back().get();
+	return m_descriptorSets.emplace_back(TRAP::MakeScope<VulkanDescriptorSet>(m_device, handles, rootSignature,
+																			  updateData, maxSets,
+																			  dynamicOffsetCount, updateFreq)).get();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -155,7 +154,8 @@ VkDescriptorSet TRAP::Graphics::API::VulkanDescriptorPool::RetrieveVkDescriptorS
 	//This is fine since this will only happen during Init time
 	std::lock_guard<std::mutex> lockGuard(m_mutex);
 
-	VkDescriptorSetAllocateInfo info = VulkanInits::DescriptorSetAllocateInfo(m_currentPool, layout);
+	VkDescriptorSetAllocateInfo info = VulkanInits::DescriptorSetAllocateInfo(m_currentPool,
+	                                                                          layout);
 
 	VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
 	VkResult res = vkAllocateDescriptorSets(m_device->GetVkDevice(), &info, &descriptorSet);

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDescriptorSet.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDescriptorSet.cpp
@@ -129,19 +129,19 @@ void TRAP::Graphics::API::VulkanDescriptorSet::Update(uint32_t index,
 	{
 		uint32_t paramIndex = param.Index;
 
-		VALIDATE_DESCRIPTOR(param.Name || (paramIndex != std::numeric_limits<uint32_t>::max()),
+		VALIDATE_DESCRIPTOR(!param.Name.empty() || (paramIndex != std::numeric_limits<uint32_t>::max()),
 		                    "DescriptorData has nullptr name and invalid index");
 
 		const RendererAPI::DescriptorInfo* desc = (paramIndex != std::numeric_limits<uint32_t>::max()) ?
 		                                          (&rootSignature->GetDescriptors()[paramIndex]) :
-												  rootSignature->GetDescriptor(param.Name);
+												  rootSignature->GetDescriptor(param.Name.c_str());
 		if(paramIndex != std::numeric_limits<uint32_t>::max())
 		{
 			VALIDATE_DESCRIPTOR(desc, "Invalid descriptor with param index ", paramIndex);
 		}
 		else
 		{
-			VALIDATE_DESCRIPTOR(desc, "Invalid descriptor with param name ", param.Name);
+			VALIDATE_DESCRIPTOR(desc, "Invalid descriptor with param name ", param.Name.c_str());
 		}
 
 		const RendererAPI::DescriptorType type = desc->Type;

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDescriptorSet.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDescriptorSet.cpp
@@ -92,17 +92,17 @@ uint32_t TRAP::Graphics::API::VulkanDescriptorSet::GetSet() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanDescriptorSet::Update(uint32_t index,
+void TRAP::Graphics::API::VulkanDescriptorSet::Update(const uint32_t index,
                                                       const std::vector<RendererAPI::DescriptorData>& params)
 {
 #ifdef ENABLE_GRAPHICS_DEBUG
-#define VALIDATE_DESCRIPTOR(descriptor, ...)                                            \
-	if(!(descriptor))                                                                   \
-	{                                                                                   \
-		std::string msg = __FUNCTION__ + std::string(" : ") + std::string(__VA_ARGS__); \
-		TP_ERROR(Log::RendererVulkanDescriptorSetPrefix, msg);                          \
-		TRAP_ASSERT(false, msg);                                                        \
-		continue;                                                                       \
+#define VALIDATE_DESCRIPTOR(descriptor, ...)                                                  \
+	if(!(descriptor))                                                                         \
+	{                                                                                         \
+		const std::string msg = __FUNCTION__ + std::string(" : ") + std::string(__VA_ARGS__); \
+		TP_ERROR(Log::RendererVulkanDescriptorSetPrefix, msg);                                \
+		TRAP_ASSERT(false, msg);                                                              \
+		continue;                                                                             \
 	}
 #else
 #define VALIDATE_DESCRIPTOR(descriptor, ...)
@@ -117,7 +117,7 @@ void TRAP::Graphics::API::VulkanDescriptorSet::Update(uint32_t index,
 
 	std::vector<VkWriteDescriptorSet> rayTracingWrites;
 	std::vector<VkWriteDescriptorSetAccelerationStructureKHR> rayTracingWritesKHR;
-	uint32_t rayTracingWriteCount = 0;
+	const uint32_t rayTracingWriteCount = 0; //TODO Use
 
 	if(rootSignature->GetVkRayTracingDescriptorCounts()[m_set])
 	{
@@ -127,7 +127,7 @@ void TRAP::Graphics::API::VulkanDescriptorSet::Update(uint32_t index,
 
 	for (const auto& param : params)
 	{
-		uint32_t paramIndex = param.Index;
+		const uint32_t paramIndex = param.Index;
 
 		VALIDATE_DESCRIPTOR(!param.Name.empty() || (paramIndex != std::numeric_limits<uint32_t>::max()),
 		                    "DescriptorData has nullptr name and invalid index");
@@ -184,7 +184,7 @@ void TRAP::Graphics::API::VulkanDescriptorSet::Update(uint32_t index,
 			const std::vector<TRAP::Graphics::Texture*>& textures = std::get<std::vector<TRAP::Graphics::Texture*>>(param.Resource);
 			VALIDATE_DESCRIPTOR(!textures.empty(), std::string("Empty Texture (") + desc->Name + ")");
 
-			std::unordered_map<std::string, uint32_t>::const_iterator it = m_rootSignature->GetDescriptorNameToIndexMap().find(desc->Name);
+			const std::unordered_map<std::string, uint32_t>::const_iterator it = m_rootSignature->GetDescriptorNameToIndexMap().find(desc->Name);
 			if(it == m_rootSignature->GetDescriptorNameToIndexMap().end())
 			{
 				TP_ERROR(Log::RendererVulkanDescriptorSetPrefix, "No Static Sampler called (", desc->Name, ")");
@@ -322,7 +322,7 @@ void TRAP::Graphics::API::VulkanDescriptorSet::Update(uint32_t index,
 									std::to_string(RendererAPI::GPUSettings.MaxUniformBufferRange)));
 
 				m_dynamicSizeOffsets[index].Offset = !off.Offsets.empty() ? static_cast<uint32_t>(off.Offsets[0]) : 0;
-				VulkanBuffer* buf = dynamic_cast<VulkanBuffer*>(buffers[0]);
+				const VulkanBuffer* buf = dynamic_cast<VulkanBuffer*>(buffers[0]);
 				updateData[desc->HandleIndex + static_cast<std::size_t>(0)].BufferInfo =
 				{
 					buf->GetVkBuffer(),
@@ -353,7 +353,7 @@ void TRAP::Graphics::API::VulkanDescriptorSet::Update(uint32_t index,
 				VALIDATE_DESCRIPTOR(buffers[arr], std::string("nullptr Buffer (") + desc->Name +
 				                    std::string(" [") + std::to_string(arr) + "])");
 
-				VulkanBuffer* buf = dynamic_cast<VulkanBuffer*>(buffers[arr]);
+				const VulkanBuffer* buf = dynamic_cast<VulkanBuffer*>(buffers[arr]);
 				updateData[desc->HandleIndex + static_cast<std::size_t>(arr)].BufferInfo =
 				{
 					buf->GetVkBuffer(),

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
@@ -10,7 +10,7 @@
 
 TRAP::Graphics::API::VulkanDevice::VulkanDevice(TRAP::Scope<VulkanPhysicalDevice> physicalDevice,
                                                 std::vector<std::string> deviceExtensions,
-                                                bool requestAllAvailableQueues)
+                                                const bool requestAllAvailableQueues)
 	: m_physicalDevice(std::move(physicalDevice)),
       m_deviceExtensions(std::move(deviceExtensions)),
       m_graphicsQueueFamilyIndex(0),
@@ -174,8 +174,8 @@ TRAP::Graphics::API::VulkanDevice::VulkanDevice(TRAP::Scope<VulkanPhysicalDevice
 	}
 #endif
 
-	VkDeviceCreateInfo deviceCreateInfo = VulkanInits::DeviceCreateInfo(&devFeatures2, queueCreateInfos,
-	                                                                    extensions);
+	const VkDeviceCreateInfo deviceCreateInfo = VulkanInits::DeviceCreateInfo(&devFeatures2, queueCreateInfos,
+	                                                                          extensions);
 
 	VkCall(vkCreateDevice(m_physicalDevice->GetVkPhysicalDevice(), &deviceCreateInfo, nullptr, &m_device));
 
@@ -478,7 +478,7 @@ void TRAP::Graphics::API::VulkanDevice::SetDeviceName(const std::string_view nam
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanDevice::LoadShadingRateCaps(const VkPhysicalDeviceFragmentShadingRateFeaturesKHR& shadingRateFeatures)
+void TRAP::Graphics::API::VulkanDevice::LoadShadingRateCaps(const VkPhysicalDeviceFragmentShadingRateFeaturesKHR& shadingRateFeatures) const
 {
 	if(!VulkanRenderer::s_shadingRate)
 		return;

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
@@ -470,9 +470,9 @@ void TRAP::Graphics::API::VulkanDevice::SetDeviceName(const std::string_view nam
 		return;
 
 #ifdef ENABLE_DEBUG_UTILS_EXTENSION
-	VkSetObjectName(m_device, reinterpret_cast<uint64_t>(m_device), VK_OBJECT_TYPE_DEVICE, name);
+	VkSetObjectName(m_device, Utils::BitCast<VkDevice, uint64_t>(m_device), VK_OBJECT_TYPE_DEVICE, name);
 #else
-	VkSetObjectName(m_device, reinterpret_cast<uint64_t>(m_device), VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, name);
+	VkSetObjectName(m_device, Utils::BitCast<VkDevice, uint64_t>(m_device), VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, name);
 #endif
 }
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
@@ -70,20 +70,20 @@ TRAP::Graphics::API::VulkanDevice::VulkanDevice(TRAP::Scope<VulkanPhysicalDevice
 	if(VulkanRenderer::s_fragmentShaderInterlockExtension)
 	{
 		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&fragmentShaderInterlockFeatures);
-		base = reinterpret_cast<VkBaseOutStructure*>(base->pNext);
+		base = base->pNext;
 	}
 	if (VulkanRenderer::s_descriptorIndexingExtension)
 	{
 		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&descriptorIndexingFeatures);
-		base = reinterpret_cast<VkBaseOutStructure*>(base->pNext);
+		base = base->pNext;
 	}
 	if (VulkanRenderer::s_samplerYcbcrConversionExtension)
 	{
 		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&ycbcrFeatures);
-		base = reinterpret_cast<VkBaseOutStructure*>(base->pNext);
+		base = base->pNext;
 	}
 	base->pNext = reinterpret_cast<VkBaseOutStructure*>(&shaderDrawParametersFeatures);
-	base = reinterpret_cast<VkBaseOutStructure*>(base->pNext);
+	base = base->pNext;
 
 	VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bufferDeviceAddressFeatures{};
 	bufferDeviceAddressFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR;
@@ -99,29 +99,29 @@ TRAP::Graphics::API::VulkanDevice::VulkanDevice(TRAP::Scope<VulkanPhysicalDevice
 	if (VulkanRenderer::s_bufferDeviceAddressExtension)
 	{
 		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&bufferDeviceAddressFeatures);
-		base = reinterpret_cast<VkBaseOutStructure*>(base->pNext);
+		base = base->pNext;
 	}
 	if (VulkanRenderer::s_rayTracingExtension)
 	{
 		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&rayTracingPipelineFeatures);
-		base = reinterpret_cast<VkBaseOutStructure*>(base->pNext);
+		base = base->pNext;
 	}
 	if (VulkanRenderer::s_rayTracingExtension)
 	{
 		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&accelerationStructureFeatures);
-		base = reinterpret_cast<VkBaseOutStructure*>(base->pNext);
+		base = base->pNext;
 	}
 	if (VulkanRenderer::s_rayTracingExtension)
 	{
 		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&rayQueryFeatures);
-		base = reinterpret_cast<VkBaseOutStructure*>(base->pNext);
+		base = base->pNext;
 	}
 
 	//Shading rate
 	if(VulkanRenderer::s_shadingRate)
 	{
 		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&shadingRateFeatures);
-		base = reinterpret_cast<VkBaseOutStructure*>(base->pNext);
+		base = base->pNext;
 	}
 
 	vkGetPhysicalDeviceFeatures2(m_physicalDevice->GetVkPhysicalDevice(), &devFeatures2);

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.h
@@ -140,7 +140,7 @@ namespace TRAP::Graphics::API
 		/// <summary>
 		/// Load the variable shading rate capabilities from the physical device.
 		/// </summary>
-		void LoadShadingRateCaps(const VkPhysicalDeviceFragmentShadingRateFeaturesKHR& shadingRateFeatures);
+		void LoadShadingRateCaps(const VkPhysicalDeviceFragmentShadingRateFeaturesKHR& shadingRateFeatures) const;
 
 		TRAP::Scope<VulkanPhysicalDevice> m_physicalDevice;
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanFence.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanFence.cpp
@@ -17,7 +17,7 @@ TRAP::Graphics::API::VulkanFence::VulkanFence()
 	TP_DEBUG(Log::RendererVulkanFencePrefix, "Creating Fence");
 #endif
 
-	VkFenceCreateInfo info = VulkanInits::FenceCreateInfo();
+	const VkFenceCreateInfo info = VulkanInits::FenceCreateInfo();
 	VkCall(vkCreateFence(m_device->GetVkDevice(), &info, nullptr, &m_fence));
 }
 
@@ -66,7 +66,7 @@ void TRAP::Graphics::API::VulkanFence::Wait()
 	if(m_submitted)
 	{
 #ifdef ENABLE_NSIGHT_AFTERMATH
-		VkResult result = vkWaitForFences(m_device->GetVkDevice(), 1, &m_fence, VK_TRUE, std::numeric_limits<uint32_t>::max());
+		const VkResult result = vkWaitForFences(m_device->GetVkDevice(), 1, &m_fence, VK_TRUE, std::numeric_limits<uint32_t>::max());
 		if(RendererAPI::s_aftermathSupport)
 		{
 			if(result == VK_ERROR_DEVICE_LOST)

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanFrameBuffer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanFrameBuffer.cpp
@@ -58,7 +58,7 @@ TRAP::Graphics::API::VulkanFrameBuffer::VulkanFrameBuffer(TRAP::Ref<VulkanDevice
 	//Color
 	for(std::size_t i = 0; i < desc.RenderTargets.size(); i++)
 	{
-		VulkanRenderTarget* rTarget = dynamic_cast<VulkanRenderTarget*>(desc.RenderTargets[i].get());
+		const VulkanRenderTarget* rTarget = dynamic_cast<VulkanRenderTarget*>(desc.RenderTargets[i].get());
 		if(desc.ColorMipSlices.empty() && desc.ColorArraySlices.empty())
 		{
 			*iterAttachments = rTarget->GetVkImageView();
@@ -86,7 +86,7 @@ TRAP::Graphics::API::VulkanFrameBuffer::VulkanFrameBuffer(TRAP::Ref<VulkanDevice
 	//Depth/Stencil
 	if(desc.DepthStencil)
 	{
-		VulkanRenderTarget* rTarget = dynamic_cast<VulkanRenderTarget*>(desc.DepthStencil.get());
+		const VulkanRenderTarget* rTarget = dynamic_cast<VulkanRenderTarget*>(desc.DepthStencil.get());
 		if(desc.DepthMipSlice == std::numeric_limits<uint32_t>::max() &&
 		   desc.DepthArraySlice == std::numeric_limits<uint32_t>::max())
 		{
@@ -111,8 +111,9 @@ TRAP::Graphics::API::VulkanFrameBuffer::VulkanFrameBuffer(TRAP::Ref<VulkanDevice
 		}
 	}
 
-	VkFramebufferCreateInfo info = VulkanInits::FramebufferCreateInfo(desc.RenderPass->GetVkRenderPass(),
-	                                                                  imageViews, m_width, m_height, m_arraySize);
+	const VkFramebufferCreateInfo info = VulkanInits::FramebufferCreateInfo(desc.RenderPass->GetVkRenderPass(),
+	                                                                        imageViews, m_width,
+																			m_height, m_arraySize);
 	VkCall(vkCreateFramebuffer(m_device->GetVkDevice(), &info, nullptr, &m_framebuffer));
 
 	imageViews.clear();

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanInits.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanInits.cpp
@@ -113,7 +113,7 @@ VkDebugMarkerObjectNameInfoEXT TRAP::Graphics::API::VulkanInits::DebugMarkerObje
 //-------------------------------------------------------------------------------------------------------------------//
 
 VkDebugUtilsLabelEXT TRAP::Graphics::API::VulkanInits::DebugUtilsLabelExt(const float r, const float g,
-                                                                          const float b, const char* name) noexcept
+                                                                          const float b, const std::string_view name) noexcept
 {
 	VkDebugUtilsLabelEXT info{};
 
@@ -122,7 +122,7 @@ VkDebugUtilsLabelEXT TRAP::Graphics::API::VulkanInits::DebugUtilsLabelExt(const 
 	info.color[1] = g;
 	info.color[2] = b;
 	info.color[3] = 1.0f;
-	info.pLabelName = name;
+	info.pLabelName = name.data();
 
 	return info;
 }
@@ -130,7 +130,7 @@ VkDebugUtilsLabelEXT TRAP::Graphics::API::VulkanInits::DebugUtilsLabelExt(const 
 //-------------------------------------------------------------------------------------------------------------------//
 
 VkDebugMarkerMarkerInfoEXT TRAP::Graphics::API::VulkanInits::DebugMarkerMarkerInfo(const float r, const float g,
-                                                                                   const float b, const char* name) noexcept
+                                                                                   const float b, const std::string_view name) noexcept
 {
 	VkDebugMarkerMarkerInfoEXT info{};
 
@@ -139,7 +139,7 @@ VkDebugMarkerMarkerInfoEXT TRAP::Graphics::API::VulkanInits::DebugMarkerMarkerIn
 	info.color[1] = g;
 	info.color[2] = b;
 	info.color[3] = 1.0f;
-	info.pMarkerName = name;
+	info.pMarkerName = name.data();
 
 	return info;
 }
@@ -735,7 +735,7 @@ VkPipelineCacheCreateInfo TRAP::Graphics::API::VulkanInits::PipelineCacheCreateI
 
 VkPipelineShaderStageCreateInfo TRAP::Graphics::API::VulkanInits::PipelineShaderStageCreateInfo(const VkShaderStageFlagBits stage,
 	                                                                                            VkShaderModule module,
-	                                                                                            const char* name) noexcept
+	                                                                                            const std::string_view name) noexcept
 {
 	VkPipelineShaderStageCreateInfo info;
 
@@ -744,7 +744,7 @@ VkPipelineShaderStageCreateInfo TRAP::Graphics::API::VulkanInits::PipelineShader
 	info.flags = 0;
 	info.stage = stage;
 	info.module = module;
-	info.pName = name;
+	info.pName = name.data();
 	info.pSpecializationInfo = nullptr;
 
 	return info;

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanInits.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanInits.h
@@ -67,7 +67,7 @@ namespace TRAP::Graphics::API::VulkanInits
 	/// <param name="b">Blue color.</param>
 	/// <param name="name">Name for the label.</param>
 	/// <returns>VkDebugUtilsLabelEXT.</returns>
-	VkDebugUtilsLabelEXT DebugUtilsLabelExt(float r, float g, float b, const char* name) noexcept;
+	VkDebugUtilsLabelEXT DebugUtilsLabelExt(float r, float g, float b, std::string_view name) noexcept;
 
 	/// <summary>
 	/// Create a Vulkan debug marker.
@@ -77,7 +77,7 @@ namespace TRAP::Graphics::API::VulkanInits
 	/// <param name="b">Blue color.</param>
 	/// <param name="name">Name for the label.</param>
 	/// <returns>VkDebugMarkerMarkerInfoEXT.</returns>
-	VkDebugMarkerMarkerInfoEXT DebugMarkerMarkerInfo(float r, float g, float b, const char* name) noexcept;
+	VkDebugMarkerMarkerInfoEXT DebugMarkerMarkerInfo(float r, float g, float b, std::string_view name) noexcept;
 
 	//-------------------------------------------------------------------------------------------------------------------//
 
@@ -413,7 +413,7 @@ namespace TRAP::Graphics::API::VulkanInits
 	/// <param name="name">Shader entry point name.</param>
 	/// <returns>VkPipelineShaderStageCreateInfo.</returns>
 	VkPipelineShaderStageCreateInfo PipelineShaderStageCreateInfo(VkShaderStageFlagBits stage, VkShaderModule module,
-	                                                              const char* name) noexcept;
+	                                                              std::string_view name) noexcept;
 
 	/// <summary>
 	/// Create a Vulkan pipeline vertex input state create info.

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanMemoryAllocator.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanMemoryAllocator.cpp
@@ -75,9 +75,9 @@ TRAP::Graphics::API::VulkanMemoryAllocator::VulkanMemoryAllocator(const TRAP::Re
 	}
 #endif
 
-	VmaAllocatorCreateInfo info = VulkanInits::VMAAllocatorCreateInfo(device->GetVkDevice(),
-		                                                              device->GetPhysicalDevice()->GetVkPhysicalDevice(),
-		                                                              instance->GetVkInstance(), vulkanFunctions);
+	const VmaAllocatorCreateInfo info = VulkanInits::VMAAllocatorCreateInfo(device->GetVkDevice(),
+		                                                                    device->GetPhysicalDevice()->GetVkPhysicalDevice(),
+		                                                                    instance->GetVkInstance(), vulkanFunctions);
 
 	VkCall(vmaCreateAllocator(&info, &m_allocator));
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
@@ -68,7 +68,7 @@ TRAP::Graphics::API::VulkanPhysicalDevice::VulkanPhysicalDevice(const TRAP::Ref<
 											 m_queueFamilyProperties.data());
 
 	// Copy UUID
-	std::memcpy(m_deviceUUID.data(), m_physicalDeviceIDProperties.deviceUUID, m_deviceUUID.size());
+	memcpy(m_deviceUUID.data(), m_physicalDeviceIDProperties.deviceUUID, m_deviceUUID.size());
 
 	// Capabilities for VulkanRenderer
 	for (uint32_t i = 0; i < static_cast<uint32_t>(TRAP::Graphics::API::ImageFormat::IMAGE_FORMAT_COUNT); ++i)
@@ -374,7 +374,7 @@ VkPhysicalDevice TRAP::Graphics::API::VulkanPhysicalDevice::FindPhysicalDeviceVi
 		vkGetPhysicalDeviceProperties2(device, &props2);
 
 		// Copy UUID
-		std::memcpy(testUUID.data(), physicalDeviceIDProperties.deviceUUID, testUUID.size());
+		memcpy(testUUID.data(), physicalDeviceIDProperties.deviceUUID, testUUID.size());
 
 		bool same = true;
 		for (uint32_t i = 0; i < physicalDeviceUUID.size(); i++)
@@ -785,7 +785,7 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 		vkGetPhysicalDeviceProperties2(dev, &props2);
 
 		// Copy UUID
-		std::memcpy(physicalDeviceUUID.data(), physicalDeviceIDProperties.deviceUUID, physicalDeviceUUID.size());
+		memcpy(physicalDeviceUUID.data(), physicalDeviceIDProperties.deviceUUID, physicalDeviceUUID.size());
 
 		TP_INFO(Log::RendererVulkanPrefix, "Found GPU: \"", devProps.deviceName, '(', TRAP::Utils::UUIDToString(physicalDeviceUUID), ')', "\" Score: ", score);
 		s_availablePhysicalDeviceUUIDs.emplace(score, physicalDeviceUUID);

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
@@ -68,7 +68,7 @@ TRAP::Graphics::API::VulkanPhysicalDevice::VulkanPhysicalDevice(const TRAP::Ref<
 											 m_queueFamilyProperties.data());
 
 	// Copy UUID
-	memcpy(m_deviceUUID.data(), m_physicalDeviceIDProperties.deviceUUID, m_deviceUUID.size());
+	std::copy_n(m_physicalDeviceIDProperties.deviceUUID, m_deviceUUID.size(), m_deviceUUID.begin());
 
 	// Capabilities for VulkanRenderer
 	for (uint32_t i = 0; i < static_cast<uint32_t>(TRAP::Graphics::API::ImageFormat::IMAGE_FORMAT_COUNT); ++i)
@@ -374,7 +374,7 @@ VkPhysicalDevice TRAP::Graphics::API::VulkanPhysicalDevice::FindPhysicalDeviceVi
 		vkGetPhysicalDeviceProperties2(device, &props2);
 
 		// Copy UUID
-		memcpy(testUUID.data(), physicalDeviceIDProperties.deviceUUID, testUUID.size());
+		std::copy_n(physicalDeviceIDProperties.deviceUUID, testUUID.size(), testUUID.begin());
 
 		bool same = true;
 		for (uint32_t i = 0; i < physicalDeviceUUID.size(); i++)
@@ -785,7 +785,7 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 		vkGetPhysicalDeviceProperties2(dev, &props2);
 
 		// Copy UUID
-		memcpy(physicalDeviceUUID.data(), physicalDeviceIDProperties.deviceUUID, physicalDeviceUUID.size());
+		std::copy_n(physicalDeviceIDProperties.deviceUUID, physicalDeviceUUID.size(), physicalDeviceUUID.begin());
 
 		TP_INFO(Log::RendererVulkanPrefix, "Found GPU: \"", devProps.deviceName, '(', TRAP::Utils::UUIDToString(physicalDeviceUUID), ')', "\" Score: ", score);
 		s_availablePhysicalDeviceUUIDs.emplace(score, physicalDeviceUUID);

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
@@ -74,7 +74,7 @@ TRAP::Graphics::API::VulkanPhysicalDevice::VulkanPhysicalDevice(const TRAP::Ref<
 	for (uint32_t i = 0; i < static_cast<uint32_t>(TRAP::Graphics::API::ImageFormat::IMAGE_FORMAT_COUNT); ++i)
 	{
 		VkFormatProperties formatSupport;
-		VkFormat fmt = ImageFormatToVkFormat(static_cast<TRAP::Graphics::API::ImageFormat>(i));
+		const VkFormat fmt = ImageFormatToVkFormat(static_cast<TRAP::Graphics::API::ImageFormat>(i));
 		if (fmt == VK_FORMAT_UNDEFINED)
 			continue;
 
@@ -806,7 +806,7 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::LoadAllPhysicalDeviceExtensions(
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-uint32_t TRAP::Graphics::API::VulkanPhysicalDevice::GetMaxUsableMSAASampleCount()
+uint32_t TRAP::Graphics::API::VulkanPhysicalDevice::GetMaxUsableMSAASampleCount() const
 {
 	VkSampleCountFlags sampleCounts = TRAP::Math::Min(m_physicalDeviceProperties.limits.framebufferColorSampleCounts,
 	                                                  m_physicalDeviceProperties.limits.framebufferDepthSampleCounts);

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.h
@@ -181,7 +181,7 @@ namespace TRAP::Graphics::API
 		/// Retrieve the max usable MSAA sample count for the GPU.
 		/// </summary>
 		/// <returns>Max usable MSAA sample count.</returns>
-		uint32_t GetMaxUsableMSAASampleCount();
+		uint32_t GetMaxUsableMSAASampleCount() const;
 
 		VkPhysicalDevice m_physicalDevice;
 		VkPhysicalDeviceProperties m_physicalDeviceProperties;

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.cpp
@@ -73,13 +73,13 @@ TRAP::Graphics::API::VulkanPipeline::~VulkanPipeline()
 void TRAP::Graphics::API::VulkanPipeline::InitComputePipeline(const RendererAPI::PipelineDesc& desc)
 {
 	const auto& computeDesc = std::get<RendererAPI::ComputePipelineDesc>(desc.Pipeline);
-	VkPipelineCache psoCache = desc.Cache ?
-	                           dynamic_cast<VulkanPipelineCache*>(desc.Cache.get())->GetVkPipelineCache() :
-							   VK_NULL_HANDLE;
+	const VkPipelineCache psoCache = desc.Cache ?
+	                                 dynamic_cast<VulkanPipelineCache*>(desc.Cache.get())->GetVkPipelineCache() :
+							         VK_NULL_HANDLE;
 
 	TRAP_ASSERT(computeDesc.ShaderProgram);
 	TRAP_ASSERT(computeDesc.RootSignature);
-	VulkanShader* vShader = dynamic_cast<VulkanShader*>(computeDesc.ShaderProgram);
+	const VulkanShader* vShader = dynamic_cast<VulkanShader*>(computeDesc.ShaderProgram);
 	TRAP_ASSERT(vShader->GetVkShaderModules()[0] != VK_NULL_HANDLE);
 
 	m_type = RendererAPI::PipelineType::Compute;
@@ -93,7 +93,7 @@ void TRAP::Graphics::API::VulkanPipeline::InitComputePipeline(const RendererAPI:
 			 vShader->GetReflection()->StageReflections[0].EntryPoint.data()
 		);
 
-		VkComputePipelineCreateInfo info = VulkanInits::ComputePipelineCreateInfo
+		const VkComputePipelineCreateInfo info = VulkanInits::ComputePipelineCreateInfo
 		(
 			stage,
 			dynamic_cast<VulkanRootSignature*>(computeDesc.RootSignature.get())->GetVkPipelineLayout()
@@ -108,9 +108,9 @@ void TRAP::Graphics::API::VulkanPipeline::InitComputePipeline(const RendererAPI:
 void TRAP::Graphics::API::VulkanPipeline::InitGraphicsPipeline(const RendererAPI::PipelineDesc& desc)
 {
 	const auto& graphicsDesc = std::get<RendererAPI::GraphicsPipelineDesc>(desc.Pipeline);
-	VkPipelineCache psoCache = desc.Cache ?
-	                           dynamic_cast<VulkanPipelineCache*>(desc.Cache.get())->GetVkPipelineCache() :
-							   VK_NULL_HANDLE;
+	const VkPipelineCache psoCache = desc.Cache ?
+	                                 dynamic_cast<VulkanPipelineCache*>(desc.Cache.get())->GetVkPipelineCache() :
+							         VK_NULL_HANDLE;
 
 	TRAP_ASSERT(graphicsDesc.ShaderProgram);
 	TRAP_ASSERT(graphicsDesc.RootSignature);
@@ -128,7 +128,7 @@ void TRAP::Graphics::API::VulkanPipeline::InitGraphicsPipeline(const RendererAPI
 	renderPassDesc.DepthStencilFormat = graphicsDesc.DepthStencilFormat;
 	TRAP::Scope<VulkanRenderPass> renderPass = TRAP::MakeScope<VulkanRenderPass>(m_device, renderPassDesc);
 
-	VulkanShader* vShader = dynamic_cast<VulkanShader*>(shaderProgram);
+	const VulkanShader* vShader = dynamic_cast<VulkanShader*>(shaderProgram);
 	for(uint32_t i = 0; i < vShader->GetReflection()->StageReflectionCount; ++i)
 	{
 		TRAP_ASSERT(vShader->GetVkShaderModules()[i] != VK_NULL_HANDLE);
@@ -238,10 +238,10 @@ void TRAP::Graphics::API::VulkanPipeline::InitGraphicsPipeline(const RendererAPI
 			}
 		}
 
-		VkPipelineVertexInputStateCreateInfo vi = VulkanInits::PipelineVertexInputStateCreateInfo(inputBindingCount,
-		                                                                                          inputBindings.data(),
-																								  inputAttributeCount,
-																								  inputAttributes.data());
+		const VkPipelineVertexInputStateCreateInfo vi = VulkanInits::PipelineVertexInputStateCreateInfo(inputBindingCount,
+		                                                                                                inputBindings.data(),
+																								        inputAttributeCount,
+																								        inputAttributes.data());
 
 		VkPrimitiveTopology topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 		switch(graphicsDesc.PrimitiveTopology)
@@ -275,8 +275,8 @@ void TRAP::Graphics::API::VulkanPipeline::InitGraphicsPipeline(const RendererAPI
 			break;
 		}
 
-		VkPipelineInputAssemblyStateCreateInfo ia = VulkanInits::PipelineInputAssemblyStateCreateInfo(topology,
-		                                                                                              VK_FALSE);
+		const VkPipelineInputAssemblyStateCreateInfo ia = VulkanInits::PipelineInputAssemblyStateCreateInfo(topology,
+		                                                                                                    VK_FALSE);
 
 		VkPipelineTessellationStateCreateInfo ts{};
 		if (static_cast<uint32_t>(shaderProgram->GetShaderStages() & RendererAPI::ShaderStage::TessellationControl) &&
@@ -288,22 +288,22 @@ void TRAP::Graphics::API::VulkanPipeline::InitGraphicsPipeline(const RendererAPI
 			);
 		}
 
-		VkPipelineViewportStateCreateInfo vs = VulkanInits::PipelineViewportStateCreateInfo();
+		const VkPipelineViewportStateCreateInfo vs = VulkanInits::PipelineViewportStateCreateInfo();
 
-		VkPipelineMultisampleStateCreateInfo ms = VulkanInits::PipelineMultisampleStateCreateInfo
+		const VkPipelineMultisampleStateCreateInfo ms = VulkanInits::PipelineMultisampleStateCreateInfo
 		(
 			SampleCountToVkSampleCount(graphicsDesc.SampleCount),
 			graphicsDesc.SampleCount != RendererAPI::SampleCount::One ? RendererAPI::GPUSettings.SampleRateShadingSupported : VK_FALSE,
 			graphicsDesc.SampleCount != RendererAPI::SampleCount::One ? 0.25f : 0.0f
 		);
 
-		VkPipelineRasterizationStateCreateInfo rs = graphicsDesc.RasterizerState ?
-		                                            UtilToRasterizerDesc(*graphicsDesc.RasterizerState) :
-													VulkanRenderer::DefaultRasterizerDesc;
+		const VkPipelineRasterizationStateCreateInfo rs = graphicsDesc.RasterizerState ?
+		                                                  UtilToRasterizerDesc(*graphicsDesc.RasterizerState) :
+													      VulkanRenderer::DefaultRasterizerDesc;
 
-		VkPipelineDepthStencilStateCreateInfo ds = graphicsDesc.DepthState ?
-		                                           UtilToDepthDesc(*graphicsDesc.DepthState) :
-												   VulkanRenderer::DefaultDepthDesc;
+		const VkPipelineDepthStencilStateCreateInfo ds = graphicsDesc.DepthState ?
+		                                                 UtilToDepthDesc(*graphicsDesc.DepthState) :
+												         VulkanRenderer::DefaultDepthDesc;
 
 		std::vector<VkPipelineColorBlendAttachmentState> cbAttachments(8);
 		VkPipelineColorBlendStateCreateInfo cb = graphicsDesc.BlendState ?
@@ -322,7 +322,7 @@ void TRAP::Graphics::API::VulkanPipeline::InitGraphicsPipeline(const RendererAPI
 		};
 		if(static_cast<uint32_t>(RendererAPI::GPUSettings.ShadingRateCaps))
 			dynamicStates.emplace_back(VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR);
-		VkPipelineDynamicStateCreateInfo dy = VulkanInits::PipelineDynamicStateCreateInfo(dynamicStates);
+		const VkPipelineDynamicStateCreateInfo dy = VulkanInits::PipelineDynamicStateCreateInfo(dynamicStates);
 
 		VkGraphicsPipelineCreateInfo info = VulkanInits::GraphicsPipelineCreateInfo(static_cast<uint32_t>(stageCount), stages.data(),
 																					vi, ia, vs, rs, ms, ds, cb, dy,

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.cpp
@@ -1,4 +1,5 @@
 #include "TRAPPCH.h"
+#include "Utils/Utils.h"
 #include "VulkanPipeline.h"
 
 #include "VulkanRenderPass.h"
@@ -360,8 +361,8 @@ void TRAP::Graphics::API::VulkanPipeline::SetPipelineName(const std::string_view
 		return;
 
 #ifdef ENABLE_DEBUG_UTILS_EXTENSION
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(m_vkPipeline), VK_OBJECT_TYPE_PIPELINE, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkPipeline, uint64_t>(m_vkPipeline), VK_OBJECT_TYPE_PIPELINE, name);
 #else
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(m_vkPipeline), VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkPipeline, uint64_t>(m_vkPipeline), VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, name);
 #endif
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.cpp
@@ -47,7 +47,7 @@ TRAP::Graphics::API::VulkanPipeline::VulkanPipeline(const RendererAPI::PipelineD
 	}
 
 #ifdef ENABLE_GRAPHICS_DEBUG
-	if(desc.Name && m_vkPipeline != VK_NULL_HANDLE)
+	if(!desc.Name.empty() && m_vkPipeline != VK_NULL_HANDLE)
 		SetPipelineName(desc.Name);
 #endif
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.h
@@ -71,7 +71,7 @@ namespace TRAP::Graphics::API
 		RendererAPI::PipelineType m_type;
 		//In DX12 this information is stored in ID3D12StateObject.
 		//But for Vulkan we need to store it manually.
-		std::vector<const char*> m_shaderStageNames;
+		std::vector<std::string> m_shaderStageNames;
 
 		TRAP::Ref<VulkanDevice> m_device;
 	};

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipelineCache.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipelineCache.cpp
@@ -60,7 +60,7 @@ void TRAP::Graphics::API::VulkanPipelineCache::Save(const std::filesystem::path&
 
 	if (!TRAP::FileSystem::WriteFile(path, data))
 		TP_ERROR(Log::RendererVulkanPipelineCachePrefix, "Saving of PipelineCache to path: \"",
-		         path.generic_u8string(), "\" failed!");
+		         path.u8string(), "\" failed!");
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipelineCache.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipelineCache.cpp
@@ -5,7 +5,7 @@
 #include "VulkanInits.h"
 #include "Graphics/API/Vulkan/VulkanCommon.h"
 #include "Graphics/API/Vulkan/VulkanRenderer.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 TRAP::Graphics::API::VulkanPipelineCache::VulkanPipelineCache(const RendererAPI::PipelineCacheDesc& desc)
 	: m_cache(VK_NULL_HANDLE), m_device(dynamic_cast<VulkanRenderer*>(RendererAPI::GetRenderer())->GetDevice())
@@ -58,7 +58,7 @@ void TRAP::Graphics::API::VulkanPipelineCache::Save(const std::filesystem::path&
 	data.resize(dataSize);
 	GetPipelineCacheData(&dataSize, data.data());
 
-	if (!TRAP::FS::WriteFile(path, data))
+	if (!TRAP::FileSystem::WriteFile(path, data))
 		TP_ERROR(Log::RendererVulkanPipelineCachePrefix, "Saving of PipelineCache to path: \"",
 		         path.generic_u8string(), "\" failed!");
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipelineCache.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipelineCache.cpp
@@ -16,9 +16,8 @@ TRAP::Graphics::API::VulkanPipelineCache::VulkanPipelineCache(const RendererAPI:
 	TP_DEBUG(Log::RendererVulkanPipelineCachePrefix, "Creating PipelineCache");
 #endif
 
-	VkPipelineCacheCreateInfo psoCacheCreateInfo;
-	psoCacheCreateInfo = VulkanInits::PipelineCacheCreateInfo(desc.Data,
-	                                                          PipelineCacheFlagsToVkPipelineCacheCreateFlags(desc.Flags));
+	const VkPipelineCacheCreateInfo psoCacheCreateInfo = VulkanInits::PipelineCacheCreateInfo(desc.Data,
+	                                                     PipelineCacheFlagsToVkPipelineCacheCreateFlags(desc.Flags));
 	VkCall(vkCreatePipelineCache(m_device->GetVkDevice(), &psoCacheCreateInfo, nullptr, &m_cache));
 }
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueryPool.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueryPool.cpp
@@ -9,7 +9,7 @@
 TRAP::Graphics::API::VulkanQueryPool::VulkanQueryPool(const RendererAPI::QueryPoolDesc& desc)
 	: m_vkQueryPool(VK_NULL_HANDLE), m_type(), m_count()
 {
-	TRAP::Ref<VulkanDevice> device = dynamic_cast<VulkanRenderer*>(RendererAPI::GetRenderer())->GetDevice();
+	const TRAP::Ref<VulkanDevice> device = dynamic_cast<VulkanRenderer*>(RendererAPI::GetRenderer())->GetDevice();
 	TRAP_ASSERT(device);
 
 #ifdef VERBOSE_GRAPHICS_DEBUG
@@ -19,8 +19,8 @@ TRAP::Graphics::API::VulkanQueryPool::VulkanQueryPool(const RendererAPI::QueryPo
 	m_type = QueryTypeToVkQueryType(desc.Type);
 	m_count = desc.QueryCount;
 
-	VkQueryPoolCreateInfo info = VulkanInits::QueryPoolCreateInfo(desc.QueryCount,
-	                                                              QueryTypeToVkQueryType(desc.Type));
+	const VkQueryPoolCreateInfo info = VulkanInits::QueryPoolCreateInfo(desc.QueryCount,
+	                                                                    QueryTypeToVkQueryType(desc.Type));
 	VkCall(vkCreateQueryPool(device->GetVkDevice(), &info, nullptr, &m_vkQueryPool));
 }
 
@@ -37,6 +37,8 @@ TRAP::Graphics::API::VulkanQueryPool::~VulkanQueryPool()
 	vkDestroyQueryPool(dynamic_cast<VulkanRenderer*>(RendererAPI::GetRenderer())->GetDevice()->GetVkDevice(),
 	                   m_vkQueryPool, nullptr);
 }
+
+//-------------------------------------------------------------------------------------------------------------------//
 
 VkQueryPool TRAP::Graphics::API::VulkanQueryPool::GetVkQueryPool() const
 {

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.cpp
@@ -170,7 +170,8 @@ void TRAP::Graphics::API::VulkanQueue::Submit(const RendererAPI::QueueSubmitDesc
 		++signalCount;
 	}
 
-	VkSubmitInfo submitInfo = VulkanInits::SubmitInfo(waitSemaphores, waitCount, waitMasks, cmds, signalSemaphores, signalCount);
+	const VkSubmitInfo submitInfo = VulkanInits::SubmitInfo(waitSemaphores, waitCount, waitMasks,
+	                                                        cmds, signalSemaphores, signalCount);
 
 	//Lightweight lock to make sure multiple threads dont use the same queue simultaneously
 	//Many setups have just one queue family and one queue.
@@ -215,9 +216,9 @@ TRAP::Graphics::RendererAPI::PresentStatus TRAP::Graphics::API::VulkanQueue::Pre
 
 	uint32_t presentIndex = desc.Index;
 
-	VulkanSwapChain* sChain = dynamic_cast<VulkanSwapChain*>(desc.SwapChain.get());
-	VkSwapchainKHR sc = sChain->GetVkSwapChain();
-	VkPresentInfoKHR presentInfo = VulkanInits::PresentInfo(wSemaphores, sc, presentIndex);
+	const VulkanSwapChain* sChain = dynamic_cast<VulkanSwapChain*>(desc.SwapChain.get());
+	const VkSwapchainKHR sc = sChain->GetVkSwapChain();
+	const VkPresentInfoKHR presentInfo = VulkanInits::PresentInfo(wSemaphores, sc, presentIndex);
 
 	//Lightweigt lock to make sure multiple threads dont use the same queue simultaneously
 	std::lock_guard<std::mutex> lock(m_submitMutex);

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.cpp
@@ -245,8 +245,8 @@ void TRAP::Graphics::API::VulkanQueue::SetQueueName(const std::string_view name)
 		return;
 
 #ifdef ENABLE_DEBUG_UTILS_EXTENSION
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(m_vkQueue), VK_OBJECT_TYPE_QUEUE, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkQueue, uint64_t>(m_vkQueue), VK_OBJECT_TYPE_QUEUE, name);
 #else
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(m_vkQueue), VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkQueue, uint64_t>(m_vkQueue), VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT, name);
 #endif
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderPass.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderPass.cpp
@@ -96,7 +96,7 @@ TRAP::Graphics::API::VulkanRenderPass::VulkanRenderPass(TRAP::Ref<VulkanDevice> 
 	else
 		subpass = VulkanInits::SubPassDescription(VK_PIPELINE_BIND_POINT_GRAPHICS, {}, colorAttachmentRefs);
 
-	VkRenderPassCreateInfo info = VulkanInits::RenderPassCreateInfo(attachments, subpass);
+	const VkRenderPassCreateInfo info = VulkanInits::RenderPassCreateInfo(attachments, subpass);
 
 	VkCall(vkCreateRenderPass(m_device->GetVkDevice(), &info, nullptr, &m_renderPass));
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.cpp
@@ -220,7 +220,7 @@ uint32_t TRAP::Graphics::API::VulkanRenderTarget::GetID() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderTarget::SetRenderTargetName(const std::string& name) const
+void TRAP::Graphics::API::VulkanRenderTarget::SetRenderTargetName(const std::string_view name) const
 {
 	m_texture->SetTextureName(name);
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.cpp
@@ -43,7 +43,7 @@ TRAP::Graphics::API::VulkanRenderTarget::VulkanRenderTarget(const RendererAPI::R
 	TRAP_ASSERT(!((isDepth) && static_cast<uint32_t>(desc.Descriptors & RendererAPI::DescriptorType::RWTexture)),
 	            "Cannot use depth stencil as UAV");
 
-	uint32_t depthOrArraySize = desc.ArraySize * desc.Depth;
+	const uint32_t depthOrArraySize = desc.ArraySize * desc.Depth;
 	uint32_t numRTVs = m_mipLevels;
 	if(static_cast<uint32_t>(desc.Descriptors & RendererAPI::DescriptorType::RenderTargetArraySlices) ||
 	   static_cast<uint32_t>(desc.Descriptors & RendererAPI::DescriptorType::RenderTargetDepthSlices))
@@ -96,15 +96,15 @@ TRAP::Graphics::API::VulkanRenderTarget::VulkanRenderTarget(const RendererAPI::R
 	if(isDepth)
 	{
 		//Make sure depth/stencil format is supported - fall back to VK_FORMAT_D16_UNORM if not
-		VkFormat vkDepthStencilFormat = ImageFormatToVkFormat(desc.Format);
+		const VkFormat vkDepthStencilFormat = ImageFormatToVkFormat(desc.Format);
 		if(VK_FORMAT_UNDEFINED != vkDepthStencilFormat)
 		{
 			VkImageFormatProperties props{};
-			VkResult res = vkGetPhysicalDeviceImageFormatProperties(m_device->GetPhysicalDevice()->GetVkPhysicalDevice(),
-				                                                    vkDepthStencilFormat,
-																	VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
-				                                                    VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
-																	0, &props);
+			const VkResult res = vkGetPhysicalDeviceImageFormatProperties(m_device->GetPhysicalDevice()->GetVkPhysicalDevice(),
+				                                                          vkDepthStencilFormat,
+																	      VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+				                                                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+																	      0, &props);
 			//Fall back to something that's guaranteed to work
 			if(res != VK_SUCCESS)
 			{

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.h
@@ -66,8 +66,8 @@ namespace TRAP::Graphics::API
 		friend void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vector<TRAP::Ref<RenderTarget>>& renderTargets,
 			                                                                    const TRAP::Ref<RenderTarget>& depthStencil,
 			                                                                    const RendererAPI::LoadActionsDesc* loadActions,
-			                                                                    std::vector<uint32_t>* colorArraySlices,
-			                                                                    std::vector<uint32_t>* colorMipSlices,
+			                                                                    const std::vector<uint32_t>* colorArraySlices,
+			                                                                    const std::vector<uint32_t>* colorMipSlices,
 			                                                                    uint32_t depthArraySlice,
 			                                                                    uint32_t depthMipSlice);
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.h
@@ -75,7 +75,7 @@ namespace TRAP::Graphics::API
 		/// Set the name of the render target.
 		/// </summary>
 		/// <param name="name">Name to use.</param>
-		void SetRenderTargetName(const std::string& name) const;
+		void SetRenderTargetName(const std::string_view name) const;
 
 		TRAP::Ref<VulkanDevice> m_device;
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRootSignature.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRootSignature.cpp
@@ -54,7 +54,7 @@ TRAP::Graphics::API::VulkanRootSignature::VulkanRootSignature(const RendererAPI:
 	//be considered the same resource)
 	for(auto* sh : desc.Shaders)
 	{
-		TRAP::Ref<ShaderReflection::PipelineReflection> reflection = dynamic_cast<VulkanShader*>
+		const TRAP::Ref<ShaderReflection::PipelineReflection> reflection = dynamic_cast<VulkanShader*>
 		(
 			sh
 		)->GetReflection();
@@ -68,11 +68,11 @@ TRAP::Graphics::API::VulkanRootSignature::VulkanRootSignature(const RendererAPI:
 
 		for(auto& res : reflection->ShaderResources)
 		{
-			auto resNameIt = indexMap.find(res.Name);
+			const auto resNameIt = indexMap.find(res.Name);
 			if(resNameIt == indexMap.end())
 			{
-				auto resIt = std::find_if(shaderResources.begin(), shaderResources.end(),
-				                          [res](const ShaderReflection::ShaderResource& a)
+				const auto resIt = std::find_if(shaderResources.begin(), shaderResources.end(),
+				                                [res](const ShaderReflection::ShaderResource& a)
 				{
 					return (a.Type == res.Type) && (a.UsedStages == res.UsedStages) &&
 					       (((a.Reg ^ res.Reg) | (a.Set ^ res.Set)) == 0);
@@ -160,7 +160,7 @@ TRAP::Graphics::API::VulkanRootSignature::VulkanRootSignature(const RendererAPI:
 			binding.descriptorCount = descInfo.Size;
 			binding.descriptorType = DescriptorTypeToVkDescriptorType(descInfo.Type);
 
-			std::string name = Utils::String::ToLower(res.Name);
+			const std::string name = Utils::String::ToLower(res.Name);
 
 			//If a user specified a uniform buffer to be used as a dynamic uniform buffer change its type to
 			//VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC
@@ -191,12 +191,12 @@ TRAP::Graphics::API::VulkanRootSignature::VulkanRootSignature(const RendererAPI:
 				layouts[setIndex].DynamicDescriptors.emplace_back(&descInfo);
 
 			//Find if the given descriptor is a static sampler
-			auto it = staticSamplerMap.find(descInfo.Name);
-			bool hasStaticSampler = it != staticSamplerMap.end();
+			const auto it = staticSamplerMap.find(descInfo.Name);
+			const bool hasStaticSampler = it != staticSamplerMap.end();
 			if (hasStaticSampler)
 			{
 				TP_INFO("Descriptor (", descInfo.Name, "): User specified Static Sampler");
-				VkSampler sampler = it->second->GetVkSampler();
+				const VkSampler sampler = it->second->GetVkSampler();
 				binding.pImmutableSamplers = &sampler;
 			}
 
@@ -270,7 +270,7 @@ TRAP::Graphics::API::VulkanRootSignature::VulkanRootSignature(const RendererAPI:
 
 		if(createLayout)
 		{
-			VkDescriptorSetLayoutCreateInfo layoutInfo = VulkanInits::DescriptorSetLayoutCreateInfo(layout.Bindings);
+			const VkDescriptorSetLayoutCreateInfo layoutInfo = VulkanInits::DescriptorSetLayoutCreateInfo(layout.Bindings);
 
 			VkCall(vkCreateDescriptorSetLayout(m_device->GetVkDevice(), &layoutInfo, nullptr,
 			                                   &m_vkDescriptorSetLayouts[i]));
@@ -307,10 +307,10 @@ TRAP::Graphics::API::VulkanRootSignature::VulkanRootSignature(const RendererAPI:
 			descriptorSetLayouts[descriptorSetLayoutCount++] = m_vkDescriptorSetLayouts[i];
 	}
 
-	VkPipelineLayoutCreateInfo addInfo = VulkanInits::PipelineLayoutCreateInfo(descriptorSetLayoutCount,
-	                                                                           descriptorSetLayouts.data(),
-																			   m_vkPushConstantCount,
-																			   pushConstants.data());
+	const VkPipelineLayoutCreateInfo addInfo = VulkanInits::PipelineLayoutCreateInfo(descriptorSetLayoutCount,
+	                                                                                 descriptorSetLayouts.data(),
+																			         m_vkPushConstantCount,
+																			         pushConstants.data());
 	VkCall(vkCreatePipelineLayout(m_device->GetVkDevice(), &addInfo, nullptr, &m_pipelineLayout));
 
 	//Update templates
@@ -431,7 +431,7 @@ TRAP::Graphics::API::VulkanRootSignature::VulkanRootSignature(const RendererAPI:
 				++entryCount;
 			}
 
-			VkDescriptorUpdateTemplateCreateInfo createInfo = VulkanInits::DescriptorUpdateTemplateCreateInfo
+			const VkDescriptorUpdateTemplateCreateInfo createInfo = VulkanInits::DescriptorUpdateTemplateCreateInfo
 			(
 				m_vkDescriptorSetLayouts[setIndex], entryCount, entries.data(),
 				VkPipelineBindPointTranslator[static_cast<uint32_t>(m_pipelineType)],

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSampler.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSampler.cpp
@@ -57,7 +57,7 @@ TRAP::Graphics::API::VulkanSampler::VulkanSampler(const RendererAPI::SamplerDesc
 		return;
 	}
 
-	auto& conversionDesc = m_samplerDesc.SamplerConversionDesc;
+	const auto& conversionDesc = m_samplerDesc.SamplerConversionDesc;
 	const VkFormat format = ImageFormatToVkFormat(conversionDesc.Format);
 
 	//Check format props

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.cpp
@@ -544,9 +544,9 @@ void TRAP::Graphics::API::VulkanShader::SetShaderStageName(const std::string_vie
 		return;
 
 #ifdef ENABLE_DEBUG_UTILS_EXTENSION
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(stage), VK_OBJECT_TYPE_SHADER_MODULE, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkShaderModule, uint64_t>(stage), VK_OBJECT_TYPE_SHADER_MODULE, name);
 #else
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(stage), VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkShaderModule, uint64_t>(stage), VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, name);
 #endif
 }
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.cpp
@@ -128,7 +128,7 @@ void TRAP::Graphics::API::VulkanShader::Use(Window* window)
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanShader::UseTexture(const uint32_t set, const uint32_t binding,
-                                                   TRAP::Graphics::Texture* const texture, Window* window)
+                                                   TRAP::Graphics::Texture* const texture, Window* window) const
 {
 	TRAP_ASSERT(texture, "Texture is nullptr!");
 
@@ -170,7 +170,7 @@ void TRAP::Graphics::API::VulkanShader::UseTexture(const uint32_t set, const uin
 
 void TRAP::Graphics::API::VulkanShader::UseTextures(const uint32_t set, const uint32_t binding,
 													const std::vector<TRAP::Graphics::Texture*>& textures,
-													Window* window)
+													Window* window) const
 {
 	TRAP_ASSERT(!textures.empty(), "Textures are empty!");
 
@@ -213,7 +213,7 @@ void TRAP::Graphics::API::VulkanShader::UseTextures(const uint32_t set, const ui
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanShader::UseSampler(const uint32_t set, const uint32_t binding,
-	                                               TRAP::Graphics::Sampler* const sampler, Window* window)
+	                                               TRAP::Graphics::Sampler* const sampler, Window* window) const
 {
 	TRAP_ASSERT(sampler, "Sampler is nullptr!");
 
@@ -248,7 +248,7 @@ void TRAP::Graphics::API::VulkanShader::UseSampler(const uint32_t set, const uin
 
 void TRAP::Graphics::API::VulkanShader::UseSamplers(const uint32_t set, const uint32_t binding,
 	                                                const std::vector<TRAP::Graphics::Sampler*>& samplers,
-													Window* window)
+													Window* window) const
 {
 	TRAP_ASSERT(!samplers.empty(), "Samplers are empty!");
 
@@ -285,7 +285,7 @@ void TRAP::Graphics::API::VulkanShader::UseSamplers(const uint32_t set, const ui
 
 void TRAP::Graphics::API::VulkanShader::UseUBO(const uint32_t set, const uint32_t binding,
                                                TRAP::Graphics::UniformBuffer* uniformBuffer,
-											   const uint64_t size,  const uint64_t offset, Window* window)
+											   const uint64_t size,  const uint64_t offset, Window* window) const
 {
 	TRAP_ASSERT(uniformBuffer, "UniformBuffer is nullptr!");
 
@@ -305,7 +305,7 @@ void TRAP::Graphics::API::VulkanShader::UseUBO(const uint32_t set, const uint32_
 
 void TRAP::Graphics::API::VulkanShader::UseSSBO(const uint32_t set, const uint32_t binding,
                                                 TRAP::Graphics::StorageBuffer* storageBuffer,
-											    const uint64_t size, Window* window)
+											    const uint64_t size, Window* window) const
 {
 	TRAP_ASSERT(storageBuffer, "StorageBuffer is nullptr!");
 
@@ -353,7 +353,7 @@ void TRAP::Graphics::API::VulkanShader::Init(const RendererAPI::BinaryShaderDesc
 
 			const RendererAPI::BinaryShaderStageDesc* stageDesc = nullptr;
 
-			std::string stageName = m_name + "_";
+			const std::string stageName = m_name + "_";
 			switch(stageMask)
 			{
 				case RendererAPI::ShaderStage::Vertex:
@@ -554,7 +554,7 @@ void TRAP::Graphics::API::VulkanShader::SetShaderStageName(const std::string_vie
 
 void TRAP::Graphics::API::VulkanShader::UseBuffer(const uint32_t set, const uint32_t binding,
 												  TRAP::Graphics::Buffer* buffer, uint64_t size, uint64_t offset,
-												  Window* window)
+												  Window* window) const
 {
 	//OPTIMIZE Use index into root signature instead of name
 	std::string name = RetrieveDescriptorName(set, binding,

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.h
@@ -93,7 +93,7 @@ namespace TRAP::Graphics::API
 		/// <param name="texture">Texture to use.</param>
 		/// <param name="window">Window to use the shader for.</param>
 		void UseTexture(uint32_t set, uint32_t binding, TRAP::Graphics::Texture* texture,
-		                Window* window) override;
+		                Window* window) const override;
 
 
 		//TODO Combined Textures
@@ -106,7 +106,7 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to use the shader for.</param>
 		void UseTextures(uint32_t set, uint32_t binding,
 						 const std::vector<TRAP::Graphics::Texture*>& textures,
-						 Window* window) override;
+						 Window* window) const override;
 		/// <summary>
 		/// Use sampler with this shader on the given window.
 		/// </summary>
@@ -115,7 +115,7 @@ namespace TRAP::Graphics::API
 		/// <param name="sampler">Sampler to use.</param>
 		/// <param name="window">Window to use the shader for.</param>
 		void UseSampler(uint32_t set, uint32_t binding, TRAP::Graphics::Sampler* sampler,
-		                Window* window) override;
+		                Window* window) const override;
 		/// <summary>
 		/// Use multiple samplers with this shader on the given window.
 		/// </summary>
@@ -125,7 +125,7 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to use the shader for.</param>
 		void UseSamplers(uint32_t set, uint32_t binding,
 		                 const std::vector<TRAP::Graphics::Sampler*>& samplers,
-						 Window* window) override;
+						 Window* window) const override;
 		/// <summary>
 		/// Use uniform buffer object with this shader on the given window.
 		/// </summary>
@@ -136,7 +136,7 @@ namespace TRAP::Graphics::API
 		/// <param name="offset">Offset of the UBO.</param>
 		/// <param name="window">Window to use the shader for.</param>
 		void UseUBO(uint32_t set, uint32_t binding, TRAP::Graphics::UniformBuffer* uniformBuffer,
-		            uint64_t size, uint64_t offset, Window* window) override;
+		            uint64_t size, uint64_t offset, Window* window) const override;
 		/// <summary>
 		/// Use shader storage buffer object with this shader on the given window.
 		/// </summary>
@@ -146,7 +146,7 @@ namespace TRAP::Graphics::API
 		/// <param name="size">Size of the SSBO.</param>
 		/// <param name="window">Window to use the shader for.</param>
 		void UseSSBO(uint32_t set, uint32_t binding, TRAP::Graphics::StorageBuffer* storageBuffer,
-		             uint64_t size, Window* window) override;
+		             uint64_t size, Window* window) const override;
 
 		/// <summary>
 		/// Retrieve the shaders thread count per work group.
@@ -183,7 +183,7 @@ namespace TRAP::Graphics::API
 		/// <param name="offset">Offset into the buffer to start at.</param>
 		/// <param name="window">Window to use the buffer for.
 		void UseBuffer(uint32_t set, uint32_t binding, TRAP::Graphics::Buffer* buffer,
-		               uint64_t size, uint64_t offset, Window* window);
+		               uint64_t size, uint64_t offset, Window* window) const;
 
 		/// <summary>
 		///	Retrieve a descriptor's name via its set, binding, descriptor type and size.

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.cpp
@@ -16,11 +16,7 @@ TRAP::Graphics::API::VulkanSwapChain::VulkanSwapChain(RendererAPI::SwapChainDesc
 	: m_vma(dynamic_cast<VulkanRenderer*>(RendererAPI::GetRenderer())->GetVMA()),
 	  m_instance(dynamic_cast<VulkanRenderer*>(RendererAPI::GetRenderer())->GetInstance()),
 	  m_device(dynamic_cast<VulkanRenderer*>(RendererAPI::GetRenderer())->GetDevice()),
-	  m_presentQueue(),
-	  m_swapChain(),
-	  m_presentQueueFamilyIndex(),
-	  m_imageCount(),
-	  m_enableVSync()
+	  m_presentQueue(), m_swapChain(), m_presentQueueFamilyIndex(), m_imageCount(), m_enableVSync()
 {
 	TRAP_ASSERT(m_device);
 	TRAP_ASSERT(desc.ImageCount >= RendererAPI::ImageCount);
@@ -52,7 +48,7 @@ void TRAP::Graphics::API::VulkanSwapChain::InitSwapchain(RendererAPI::SwapChainD
 	//////////////////
 	//Create Surface//
 	//////////////////
-	TRAP::Ref<VulkanSurface> surface = TRAP::MakeRef<VulkanSurface>(m_instance, m_device, desc.Window);
+	const TRAP::Ref<VulkanSurface> surface = TRAP::MakeRef<VulkanSurface>(m_instance, m_device, desc.Window);
 
 	////////////////////
 	//Create SwapChain//
@@ -123,7 +119,7 @@ void TRAP::Graphics::API::VulkanSwapChain::InitSwapchain(RendererAPI::SwapChainD
 	VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
 	const std::vector<VkPresentModeKHR>& modes = surface->GetVkSurfacePresentModes();
 
-	std::array<VkPresentModeKHR, 4> preferredModeList =
+	const std::array<VkPresentModeKHR, 4> preferredModeList =
 	{
 		VK_PRESENT_MODE_IMMEDIATE_KHR,
 		VK_PRESENT_MODE_MAILBOX_KHR,
@@ -156,7 +152,7 @@ void TRAP::Graphics::API::VulkanSwapChain::InitSwapchain(RendererAPI::SwapChainD
 	desc.Width = extent.width;
 	desc.Height = extent.height;
 
-	VkSharingMode sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	const VkSharingMode sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 	uint32_t queueFamilyIndexCount = 0;
 	std::array<uint32_t, 2> queueFamilyIndices =
 	{
@@ -228,7 +224,7 @@ void TRAP::Graphics::API::VulkanSwapChain::InitSwapchain(RendererAPI::SwapChainD
 	else
 		preTransform = caps.currentTransform;
 
-	std::array<VkCompositeAlphaFlagBitsKHR, 4> compositeAlphaFlags =
+	const std::array<VkCompositeAlphaFlagBitsKHR, 4> compositeAlphaFlags =
 	{
 		VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR,
 		VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
@@ -248,16 +244,16 @@ void TRAP::Graphics::API::VulkanSwapChain::InitSwapchain(RendererAPI::SwapChainD
 	TRAP_ASSERT(compositeAlpha != VK_COMPOSITE_ALPHA_FLAG_BITS_MAX_ENUM_KHR);
 
 	VkSwapchainKHR swapChain = VK_NULL_HANDLE;
-	VkSwapchainCreateInfoKHR swapChainCreateInfo = VulkanInits::SwapchainCreateInfoKHR(surface->GetVkSurface(),
-		                                                                               desc.ImageCount,
-		                                                                               surfaceFormat,
-		                                                                               extent,
-		                                                                               sharingMode,
-		                                                                               queueFamilyIndexCount,
-		                                                                               queueFamilyIndices,
-		                                                                               preTransform,
-		                                                                               compositeAlpha,
-		                                                                               presentMode);
+	const VkSwapchainCreateInfoKHR swapChainCreateInfo = VulkanInits::SwapchainCreateInfoKHR(surface->GetVkSurface(),
+		                                                                                     desc.ImageCount,
+		                                                                                     surfaceFormat,
+		                                                                                     extent,
+		                                                                                     sharingMode,
+		                                                                                     queueFamilyIndexCount,
+		                                                                                     queueFamilyIndices,
+		                                                                                     preTransform,
+		                                                                                     compositeAlpha,
+		                                                                                     presentMode);
 
 	VkCall(vkCreateSwapchainKHR(m_device->GetVkDevice(), &swapChainCreateInfo, nullptr, &swapChain));
 
@@ -346,7 +342,7 @@ uint32_t TRAP::Graphics::API::VulkanSwapChain::AcquireNextImage(const TRAP::Ref<
 		//If SwapChain is out of date, let caller know by returning -1
 		if(res == VK_ERROR_OUT_OF_DATE_KHR)
 		{
-			VkFence vkF = fen->GetVkFence();
+			const VkFence vkF = fen->GetVkFence();
 			VkCall(vkResetFences(m_device->GetVkDevice(), 1, &vkF));
 			fen->m_submitted = false;
 			return std::numeric_limits<uint32_t>::max();

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
@@ -224,7 +224,7 @@ void TRAP::Graphics::API::VulkanTexture::Init(const RendererAPI::TextureDesc &de
 				VkExternalMemoryHandleTypeFlagBits HandleType;
 			};
 
-			ImportHandleInfo *handleInfo = reinterpret_cast<ImportHandleInfo *>(desc.NativeHandle);
+			ImportHandleInfo *handleInfo = reinterpret_cast<ImportHandleInfo*>(desc.NativeHandle);
 			importInfo.handle = handleInfo->Handle;
 			importInfo.handleType = handleInfo->HandleType;
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
@@ -461,7 +461,7 @@ bool TRAP::Graphics::API::VulkanTexture::IsLazilyAllocated() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanTexture::SetTextureName(const std::string& name) const
+void TRAP::Graphics::API::VulkanTexture::SetTextureName(const std::string_view name) const
 {
 	TRAP_ASSERT(!name.empty());
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
@@ -224,7 +224,7 @@ void TRAP::Graphics::API::VulkanTexture::Init(const RendererAPI::TextureDesc &de
 				VkExternalMemoryHandleTypeFlagBits HandleType;
 			};
 
-			ImportHandleInfo *handleInfo = reinterpret_cast<ImportHandleInfo*>(desc.NativeHandle);
+			ImportHandleInfo *handleInfo = static_cast<ImportHandleInfo*>(desc.NativeHandle);
 			importInfo.handle = handleInfo->Handle;
 			importInfo.handleType = handleInfo->HandleType;
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
@@ -137,8 +137,8 @@ void TRAP::Graphics::API::VulkanTexture::Init(const RendererAPI::TextureDesc &de
 	RendererAPI::DescriptorType descriptors = desc.Descriptors;
 	if(static_cast<bool>(desc.Flags & RendererAPI::TextureCreationFlags::Storage))
 		descriptors |= RendererAPI::DescriptorType::RWTexture;
-	bool cubeMapRequired = (descriptors & RendererAPI::DescriptorType::TextureCube) ==
-						   RendererAPI::DescriptorType::TextureCube;
+	const bool cubeMapRequired = (descriptors & RendererAPI::DescriptorType::TextureCube) ==
+						         RendererAPI::DescriptorType::TextureCube;
 	bool arrayRequired = false;
 
 	const bool isPlanarFormat = TRAP::Graphics::API::ImageFormatIsPlanar(desc.Format);
@@ -248,15 +248,15 @@ void TRAP::Graphics::API::VulkanTexture::Init(const RendererAPI::TextureDesc &de
 		}
 
 		// If lazy allocation is requested check that the hardware supports it
-		bool lazyAllocation = static_cast<bool>(desc.Flags & RendererAPI::TextureCreationFlags::OnTile);
+		const bool lazyAllocation = static_cast<bool>(desc.Flags & RendererAPI::TextureCreationFlags::OnTile);
 		if (lazyAllocation)
 		{
 			uint32_t memoryTypeIndex = 0;
 			VmaAllocationCreateInfo lazyMemReqs = memReqs;
 			lazyMemReqs.usage = VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED;
-			VkResult result = vmaFindMemoryTypeIndex(m_vma->GetVMAAllocator(),
-													 std::numeric_limits<uint32_t>::max(),
-													 &lazyMemReqs, &memoryTypeIndex);
+			const VkResult result = vmaFindMemoryTypeIndex(m_vma->GetVMAAllocator(),
+													       std::numeric_limits<uint32_t>::max(),
+													       &lazyMemReqs, &memoryTypeIndex);
 			if (result == VK_SUCCESS)
 			{
 				memReqs = lazyMemReqs;
@@ -284,7 +284,7 @@ void TRAP::Graphics::API::VulkanTexture::Init(const RendererAPI::TextureDesc &de
 			// Might help to keep DCC enabled if we ever use this as a output format
 			// DCC gets disabled when we pass mutable format bit to the create info.
 			// Passing the format list helps the driver to enable it
-			VkFormat planarFormat = ImageFormatToVkFormat(desc.Format);
+			const VkFormat planarFormat = ImageFormatToVkFormat(desc.Format);
 			VkImageFormatListCreateInfo formatList{};
 			formatList.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO;
 			formatList.pNext = nullptr;
@@ -440,7 +440,7 @@ const std::vector<VkImageView> &TRAP::Graphics::API::VulkanTexture::GetUAVVkImag
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-VkImage TRAP::Graphics::API::VulkanTexture::GetVkImage()
+VkImage TRAP::Graphics::API::VulkanTexture::GetVkImage() const
 {
 	return m_vkImage;
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
@@ -469,9 +469,9 @@ void TRAP::Graphics::API::VulkanTexture::SetTextureName(const std::string& name)
 		return;
 
 #ifdef ENABLE_DEBUG_UTILS_EXTENSION
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(m_vkImage), VK_OBJECT_TYPE_IMAGE, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkImage, uint64_t>(m_vkImage), VK_OBJECT_TYPE_IMAGE, name);
 #else
-	VkSetObjectName(m_device->GetVkDevice(), reinterpret_cast<uint64_t>(m_vkImage), VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, name);
+	VkSetObjectName(m_device->GetVkDevice(), Utils::BitCast<VkImage, uint64_t>(m_vkImage), VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, name);
 #endif
 }
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.h
@@ -101,7 +101,7 @@ namespace TRAP::Graphics::API
 		/// Set the name of the texture.
 		/// </summary>
 		/// <param name="name">Name for the texture.</param>
-		void SetTextureName(const std::string& name) const override;
+		void SetTextureName(const std::string_view name) const override;
 
 	protected:
 		/// <summary>

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.h
@@ -84,7 +84,7 @@ namespace TRAP::Graphics::API
 		/// Retrieve the Vulkan image handle.
 		/// </summary>
 		/// <returns>Vulkan image handle.</returns>
-		VkImage GetVkImage();
+		VkImage GetVkImage() const;
 		/// <summary>
 		/// Retrieve the VMA allocation handle used by the texture.
 		/// </summary>

--- a/TRAP/src/Graphics/API/Vulkan/VulkanCommon.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanCommon.cpp
@@ -15,7 +15,7 @@ void TRAP::Graphics::API::VkSetObjectName([[maybe_unused]] VkDevice device, [[ma
 #if defined(ENABLE_GRAPHICS_DEBUG)
 	if (VulkanRenderer::s_debugUtilsExtension)
 	{
-		VkDebugUtilsObjectNameInfoEXT nameInfo = VulkanInits::DebugUtilsObjectNameInfo(type, handle, name);
+		const VkDebugUtilsObjectNameInfoEXT nameInfo = VulkanInits::DebugUtilsObjectNameInfo(type, handle, name);
 		VkCall(vkSetDebugUtilsObjectNameEXT(device, &nameInfo));
 	}
 #endif
@@ -28,7 +28,7 @@ void TRAP::Graphics::API::VkSetObjectName([[maybe_unused]] VkDevice device, [[ma
 #if defined(ENABLE_GRAPHICS_DEBUG)
 	if (VulkanRenderer::s_debugReportExtension)
 	{
-		VkDebugMarkerObjectNameInfoEXT nameInfo = VulkanInits::DebugMarkerObjectNameInfo(type, handle, name);
+		const VkDebugMarkerObjectNameInfoEXT nameInfo = VulkanInits::DebugMarkerObjectNameInfo(type, handle, name);
 		VkCall(vkDebugMarkerSetObjectNameEXT(device, &nameInfo));
 	}
 #endif

--- a/TRAP/src/Graphics/API/Vulkan/VulkanCommon.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanCommon.h
@@ -361,7 +361,8 @@ namespace TRAP::Graphics::API
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr bool TRAP::Graphics::API::ErrorCheck(VkResult result, const std::string_view function, const std::string_view file, int32_t line)
+constexpr bool TRAP::Graphics::API::ErrorCheck(const VkResult result, const std::string_view function,
+                                               const std::string_view file, const int32_t line)
 {
 	if(result >= 0)
 		return true;
@@ -437,7 +438,7 @@ constexpr bool TRAP::Graphics::API::ErrorCheck(VkResult result, const std::strin
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkQueueFlags TRAP::Graphics::API::QueueTypeToVkQueueFlags(RendererAPI::QueueType queueType)
+constexpr VkQueueFlags TRAP::Graphics::API::QueueTypeToVkQueueFlags(const RendererAPI::QueueType queueType)
 {
 	switch(queueType)
 	{
@@ -458,7 +459,7 @@ constexpr VkQueueFlags TRAP::Graphics::API::QueueTypeToVkQueueFlags(RendererAPI:
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkSampleCountFlagBits TRAP::Graphics::API::SampleCountToVkSampleCount(RendererAPI::SampleCount sampleCount)
+constexpr VkSampleCountFlagBits TRAP::Graphics::API::SampleCountToVkSampleCount(const RendererAPI::SampleCount sampleCount)
 {
 	switch(sampleCount)
 	{
@@ -484,7 +485,7 @@ constexpr VkSampleCountFlagBits TRAP::Graphics::API::SampleCountToVkSampleCount(
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkFormat TRAP::Graphics::API::ImageFormatToVkFormat(TRAP::Graphics::API::ImageFormat imageFormat)
+constexpr VkFormat TRAP::Graphics::API::ImageFormatToVkFormat(const TRAP::Graphics::API::ImageFormat imageFormat)
 {
 	switch(imageFormat)
 	{
@@ -659,7 +660,7 @@ constexpr VkFormat TRAP::Graphics::API::ImageFormatToVkFormat(TRAP::Graphics::AP
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkImageAspectFlags TRAP::Graphics::API::DetermineAspectMask(VkFormat format, const bool includeStencilBit)
+constexpr VkImageAspectFlags TRAP::Graphics::API::DetermineAspectMask(const VkFormat format, const bool includeStencilBit)
 {
 	switch(format)
 	{
@@ -692,7 +693,7 @@ constexpr VkImageAspectFlags TRAP::Graphics::API::DetermineAspectMask(VkFormat f
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkImageUsageFlags TRAP::Graphics::API::DescriptorTypeToVkImageUsage(RendererAPI::DescriptorType type)
+constexpr VkImageUsageFlags TRAP::Graphics::API::DescriptorTypeToVkImageUsage(const RendererAPI::DescriptorType type)
 {
 	VkImageUsageFlags result = 0;
 
@@ -706,7 +707,7 @@ constexpr VkImageUsageFlags TRAP::Graphics::API::DescriptorTypeToVkImageUsage(Re
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkFormatFeatureFlags TRAP::Graphics::API::VkImageUsageToFormatFeatures(VkImageUsageFlags usage)
+constexpr VkFormatFeatureFlags TRAP::Graphics::API::VkImageUsageToFormatFeatures(const VkImageUsageFlags usage)
 {
 	VkFormatFeatureFlags result = 0;
 
@@ -724,7 +725,7 @@ constexpr VkFormatFeatureFlags TRAP::Graphics::API::VkImageUsageToFormatFeatures
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkBufferUsageFlags TRAP::Graphics::API::DescriptorTypeToVkBufferUsage(RendererAPI::DescriptorType usage,
+constexpr VkBufferUsageFlags TRAP::Graphics::API::DescriptorTypeToVkBufferUsage(const RendererAPI::DescriptorType usage,
                                                                                 const bool typed)
 {
 	VkBufferUsageFlags result = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
@@ -765,7 +766,7 @@ constexpr VkBufferUsageFlags TRAP::Graphics::API::DescriptorTypeToVkBufferUsage(
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkFilter TRAP::Graphics::API::FilterTypeToVkFilter(RendererAPI::FilterType filter)
+constexpr VkFilter TRAP::Graphics::API::FilterTypeToVkFilter(const RendererAPI::FilterType filter)
 {
 	switch(filter)
 	{
@@ -782,7 +783,7 @@ constexpr VkFilter TRAP::Graphics::API::FilterTypeToVkFilter(RendererAPI::Filter
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkSamplerMipmapMode TRAP::Graphics::API::MipMapModeToVkMipMapMode(RendererAPI::MipMapMode mipMapMode)
+constexpr VkSamplerMipmapMode TRAP::Graphics::API::MipMapModeToVkMipMapMode(const RendererAPI::MipMapMode mipMapMode)
 {
 	switch (mipMapMode)
 	{
@@ -800,7 +801,7 @@ constexpr VkSamplerMipmapMode TRAP::Graphics::API::MipMapModeToVkMipMapMode(Rend
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkSamplerAddressMode TRAP::Graphics::API::AddressModeToVkAddressMode(RendererAPI::AddressMode addressMode)
+constexpr VkSamplerAddressMode TRAP::Graphics::API::AddressModeToVkAddressMode(const RendererAPI::AddressMode addressMode)
 {
 	switch(addressMode)
 	{
@@ -823,7 +824,7 @@ constexpr VkSamplerAddressMode TRAP::Graphics::API::AddressModeToVkAddressMode(R
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkDescriptorType TRAP::Graphics::API::DescriptorTypeToVkDescriptorType(RendererAPI::DescriptorType type)
+constexpr VkDescriptorType TRAP::Graphics::API::DescriptorTypeToVkDescriptorType(const RendererAPI::DescriptorType type)
 {
 	switch(type)
 	{
@@ -871,7 +872,7 @@ constexpr VkDescriptorType TRAP::Graphics::API::DescriptorTypeToVkDescriptorType
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkShaderStageFlags TRAP::Graphics::API::ShaderStageToVkShaderStageFlags(RendererAPI::ShaderStage stages)
+constexpr VkShaderStageFlags TRAP::Graphics::API::ShaderStageToVkShaderStageFlags(const RendererAPI::ShaderStage stages)
 {
 	VkShaderStageFlags res = 0;
 
@@ -902,7 +903,7 @@ constexpr VkShaderStageFlags TRAP::Graphics::API::ShaderStageToVkShaderStageFlag
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkPipelineCacheCreateFlags TRAP::Graphics::API::PipelineCacheFlagsToVkPipelineCacheCreateFlags(RendererAPI::PipelineCacheFlags flags)
+constexpr VkPipelineCacheCreateFlags TRAP::Graphics::API::PipelineCacheFlagsToVkPipelineCacheCreateFlags(const RendererAPI::PipelineCacheFlags flags)
 {
 	VkPipelineCacheCreateFlags ret = 0;
 
@@ -914,7 +915,7 @@ constexpr VkPipelineCacheCreateFlags TRAP::Graphics::API::PipelineCacheFlagsToVk
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkAccessFlags TRAP::Graphics::API::ResourceStateToVkAccessFlags(RendererAPI::ResourceState state)
+constexpr VkAccessFlags TRAP::Graphics::API::ResourceStateToVkAccessFlags(const RendererAPI::ResourceState state)
 {
 	VkAccessFlags ret = 0;
 
@@ -948,7 +949,7 @@ constexpr VkAccessFlags TRAP::Graphics::API::ResourceStateToVkAccessFlags(Render
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkImageLayout TRAP::Graphics::API::ResourceStateToVkImageLayout(RendererAPI::ResourceState usage)
+constexpr VkImageLayout TRAP::Graphics::API::ResourceStateToVkImageLayout(const RendererAPI::ResourceState usage)
 {
 	if (static_cast<uint32_t>(usage & RendererAPI::ResourceState::CopySource))
 		return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
@@ -979,7 +980,7 @@ constexpr VkImageLayout TRAP::Graphics::API::ResourceStateToVkImageLayout(Render
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr VkQueryType TRAP::Graphics::API::QueryTypeToVkQueryType(RendererAPI::QueryType type)
+constexpr VkQueryType TRAP::Graphics::API::QueryTypeToVkQueryType(const RendererAPI::QueryType type)
 {
 	switch(type)
 	{
@@ -1000,7 +1001,7 @@ constexpr VkQueryType TRAP::Graphics::API::QueryTypeToVkQueryType(RendererAPI::Q
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr TRAP::Graphics::API::ImageFormat TRAP::Graphics::API::ImageFormatFromVkFormat(VkFormat format)
+constexpr TRAP::Graphics::API::ImageFormat TRAP::Graphics::API::ImageFormatFromVkFormat(const VkFormat format)
 {
 	switch(format)
 	{

--- a/TRAP/src/Graphics/API/Vulkan/VulkanCommon.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanCommon.h
@@ -45,7 +45,7 @@ namespace TRAP::Graphics::API
 	/// <param name="file">Name of the file where the function is in that called the error checker.</param>
 	/// <param name="line">Line number of the error check call.</param>
 	/// <returns>True for non error codes, otherwise false.</returns>
-	constexpr bool ErrorCheck(VkResult result, const char* function, const char* file, int32_t line);
+	constexpr bool ErrorCheck(VkResult result, std::string_view function, std::string_view file, int32_t line);
 	/// <summary>
 	/// Convert the RendererAPI::QueueType to VkQueueFlags.
 	/// </summary>
@@ -361,7 +361,7 @@ namespace TRAP::Graphics::API
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-constexpr bool TRAP::Graphics::API::ErrorCheck(VkResult result, const char* function, const char* file, int32_t line)
+constexpr bool TRAP::Graphics::API::ErrorCheck(VkResult result, const std::string_view function, const std::string_view file, int32_t line)
 {
 	if(result >= 0)
 		return true;

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -6,7 +6,7 @@
 #include "Window/WindowingAPI.h"
 #include "Utils/Utils.h"
 #include "Utils/Dialogs/Dialogs.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "VulkanCommon.h"
 #include "Embed.h"
 
@@ -126,7 +126,7 @@ TRAP::Graphics::API::VulkanRenderer::~VulkanRenderer()
 
 	s_pipelines.clear();
 
-	const auto tempFolder = TRAP::FS::GetGameTempFolderPath();
+	const auto tempFolder = TRAP::FileSystem::GetGameTempFolderPath();
 	if(tempFolder)
 	{
 		for(auto& [hash, cache] : s_pipelineCaches)
@@ -2401,7 +2401,7 @@ const TRAP::Ref<TRAP::Graphics::Pipeline>& TRAP::Graphics::API::VulkanRenderer::
 
 	const auto cacheIt = s_pipelineCaches.find(hash);
 
-	const auto tempFolder = TRAP::FS::GetGameTempFolderPath();
+	const auto tempFolder = TRAP::FileSystem::GetGameTempFolderPath();
 	if(tempFolder)
 	{
 		std::pair<std::unordered_map<uint64_t, TRAP::Ref<PipelineCache>>::iterator, bool> res;

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -1595,7 +1595,7 @@ void TRAP::Graphics::API::VulkanRenderer::MapRenderTarget(const TRAP::Ref<Render
 	s_graphicQueue->WaitQueueIdle();
 
 	//Copy to CPU memory.
-	std::memcpy(outPixelData, buffer->GetCPUMappedAddress(), static_cast<std::size_t>(renderTarget->GetWidth()) *
+	memcpy(outPixelData, buffer->GetCPUMappedAddress(), static_cast<std::size_t>(renderTarget->GetWidth()) *
 																renderTarget->GetHeight() * formatByteWidth);
 
 	//Cleanup

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -170,7 +170,7 @@ void TRAP::Graphics::API::VulkanRenderer::StartGraphicRecording(PerWindowData* c
 		renderTarget = p->RenderTargets[p->CurrentSwapChainImageIndex];
 #endif
 
-	TRAP::Ref<Fence> renderCompleteFence = p->RenderCompleteFences[p->ImageIndex];
+	const TRAP::Ref<Fence> renderCompleteFence = p->RenderCompleteFences[p->ImageIndex];
 
 	//Stall if CPU is running "Swap Chain Buffer Count" frames ahead of GPU
 	if (renderCompleteFence->GetStatus() == FenceStatus::Incomplete)
@@ -182,7 +182,7 @@ void TRAP::Graphics::API::VulkanRenderer::StartGraphicRecording(PerWindowData* c
 	p->GraphicCommandBuffers[p->ImageIndex]->Begin();
 
 #ifndef TRAP_HEADLESS_MODE
-	RenderTargetBarrier barrier{renderTarget, ResourceState::Present, ResourceState::RenderTarget};
+	const RenderTargetBarrier barrier{renderTarget, ResourceState::Present, ResourceState::RenderTarget};
 	p->GraphicCommandBuffers[p->ImageIndex]->ResourceBarrier(nullptr, nullptr, &barrier);
 #endif
 
@@ -228,8 +228,8 @@ void TRAP::Graphics::API::VulkanRenderer::EndGraphicRecording(PerWindowData* con
 	p->GraphicCommandBuffers[p->ImageIndex]->BindRenderTargets({}, nullptr, nullptr, nullptr, nullptr,
 																std::numeric_limits<uint32_t>::max(),
 																std::numeric_limits<uint32_t>::max());
-	TRAP::Ref<RenderTarget> presentRenderTarget = p->SwapChain->GetRenderTargets()[p->CurrentSwapChainImageIndex];
-	RenderTargetBarrier barrier{presentRenderTarget, ResourceState::RenderTarget, ResourceState::Present};
+	const TRAP::Ref<RenderTarget> presentRenderTarget = p->SwapChain->GetRenderTargets()[p->CurrentSwapChainImageIndex];
+	const RenderTargetBarrier barrier{presentRenderTarget, ResourceState::RenderTarget, ResourceState::Present};
 	p->GraphicCommandBuffers[p->ImageIndex]->ResourceBarrier(nullptr, nullptr, &barrier);
 #endif
 
@@ -360,7 +360,7 @@ void TRAP::Graphics::API::VulkanRenderer::StartComputeRecording(PerWindowData* c
 		return;
 
 	//Start Recording
-	TRAP::Ref<Fence> computeCompleteFence = p->ComputeCompleteFences[p->ImageIndex];
+	const TRAP::Ref<Fence> computeCompleteFence = p->ComputeCompleteFences[p->ImageIndex];
 
 	//Stall if CPU is running "Swap Chain Buffer Count" frames ahead of GPU
 	if (computeCompleteFence->GetStatus() == FenceStatus::Incomplete)
@@ -402,11 +402,11 @@ void TRAP::Graphics::API::VulkanRenderer::EndComputeRecording(PerWindowData* con
 void TRAP::Graphics::API::VulkanRenderer::MSAAResolvePass(PerWindowData* const p)
 {
 #ifndef TRAP_HEADLESS_MODE
-	TRAP::Ref<Graphics::RenderTarget> presentRT = p->SwapChain->GetRenderTargets()[p->CurrentSwapChainImageIndex];
-	TRAP::Ref<Graphics::RenderTarget> MSAAResolveRT = p->SwapChain->GetRenderTargetsMSAA()[p->CurrentSwapChainImageIndex];
+	const TRAP::Ref<Graphics::RenderTarget> presentRT = p->SwapChain->GetRenderTargets()[p->CurrentSwapChainImageIndex];
+	const TRAP::Ref<Graphics::RenderTarget> MSAAResolveRT = p->SwapChain->GetRenderTargetsMSAA()[p->CurrentSwapChainImageIndex];
 #else
-	TRAP::Ref<Graphics::RenderTarget> presentRT = p->RenderTargets[p->CurrentSwapChainImageIndex];
-	TRAP::Ref<Graphics::RenderTarget> MSAAResolveRT = p->RenderTargetsMSAA[p->CurrentSwapChainImageIndex];
+	const TRAP::Ref<Graphics::RenderTarget> presentRT = p->RenderTargets[p->CurrentSwapChainImageIndex];
+	const TRAP::Ref<Graphics::RenderTarget> MSAAResolveRT = p->RenderTargetsMSAA[p->CurrentSwapChainImageIndex];
 #endif
 
 	VulkanTexture* presentTex = dynamic_cast<VulkanTexture*>(presentRT->GetTexture());
@@ -430,7 +430,7 @@ void TRAP::Graphics::API::VulkanRenderer::MSAAResolvePass(PerWindowData* const p
 	p->GraphicCommandBuffers[p->ImageIndex]->ResourceBarrier(nullptr, nullptr, &barrier);
 #endif
 
-	VulkanCommandBuffer* vkCmdBuf = dynamic_cast<VulkanCommandBuffer*>(p->GraphicCommandBuffers[p->ImageIndex]);
+	const VulkanCommandBuffer* vkCmdBuf = dynamic_cast<VulkanCommandBuffer*>(p->GraphicCommandBuffers[p->ImageIndex]);
 	vkCmdBuf->ResolveImage(MSAAResolveTex, ResourceState::CopySource, presentTex, ResourceState::CopyDestination);
 
 	//Transition presentRT from CopyDestination to RenderTarget
@@ -521,7 +521,7 @@ void TRAP::Graphics::API::VulkanRenderer::InitInternal(const std::string_view ga
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::Present(Window* window)
+void TRAP::Graphics::API::VulkanRenderer::Present(Window* window) const
 {
 	PerWindowData* const p = s_perWindowDataMap[window].get();
 
@@ -588,7 +588,7 @@ void TRAP::Graphics::API::VulkanRenderer::Present(Window* window)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::Dispatch(std::array<uint32_t, 3> workGroupElements, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::Dispatch(std::array<uint32_t, 3> workGroupElements, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -614,7 +614,7 @@ void TRAP::Graphics::API::VulkanRenderer::Dispatch(std::array<uint32_t, 3> workG
 
 //------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetVSync(const bool vsync, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetVSync(const bool vsync, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -624,7 +624,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetVSync(const bool vsync, Window* win
 
 //------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetClearColor(const Math::Vec4& color, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetClearColor(const Math::Vec4& color, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -634,7 +634,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetClearColor(const Math::Vec4& color,
 
 //------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetClearDepth(const float depth, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetClearDepth(const float depth, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -644,7 +644,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetClearDepth(const float depth, Windo
 
 //------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetClearStencil(const uint32_t stencil, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetClearStencil(const uint32_t stencil, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -656,7 +656,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetClearStencil(const uint32_t stencil
 
 #ifdef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanRenderer::SetResolution(const uint32_t width, const uint32_t height,
-														Window* window)
+														Window* window) const
 {
 	TRAP_ASSERT(width > 0 && height > 0, "Invalid render target resolution!");
 
@@ -672,7 +672,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetResolution(const uint32_t width, co
 
 //------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetDepthTesting(const bool enabled, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetDepthTesting(const bool enabled, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -685,7 +685,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetDepthTesting(const bool enabled, Wi
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetDepthWriting(const bool enabled, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetDepthWriting(const bool enabled, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -698,7 +698,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetDepthWriting(const bool enabled, Wi
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetDepthFunction(const CompareMode function, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetDepthFunction(const CompareMode function, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -711,7 +711,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetDepthFunction(const CompareMode fun
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetDepthFail(const StencilOp front, const StencilOp back, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetDepthFail(const StencilOp front, const StencilOp back, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -727,7 +727,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetDepthFail(const StencilOp front, co
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetDepthBias(const int32_t depthBias, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetDepthBias(const int32_t depthBias, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -740,7 +740,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetDepthBias(const int32_t depthBias, 
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetDepthBiasSlopeFactor(const float factor, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetDepthBiasSlopeFactor(const float factor, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -753,7 +753,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetDepthBiasSlopeFactor(const float fa
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetStencilTesting(const bool enabled, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetStencilTesting(const bool enabled, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -767,7 +767,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetStencilTesting(const bool enabled, 
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::SetStencilFail(const StencilOp front, const StencilOp back,
-                                                         Window* window)
+                                                         Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -783,7 +783,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetStencilFail(const StencilOp front, 
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetStencilPass(const StencilOp front, const StencilOp back, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetStencilPass(const StencilOp front, const StencilOp back, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -800,7 +800,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetStencilPass(const StencilOp front, 
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::SetStencilFunction(const CompareMode front, const CompareMode back,
-                                                             Window* window)
+                                                             Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -816,7 +816,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetStencilFunction(const CompareMode f
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetStencilMask(const uint8_t read, const uint8_t write, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetStencilMask(const uint8_t read, const uint8_t write, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -832,7 +832,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetStencilMask(const uint8_t read, con
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetCullMode(const CullMode mode, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetCullMode(const CullMode mode, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -845,7 +845,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetCullMode(const CullMode mode, Windo
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetFillMode(const FillMode mode, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetFillMode(const FillMode mode, Window* window) const
 {
 	if(mode != FillMode::Solid && !GPUSettings.FillModeNonSolid)
 		return;
@@ -853,14 +853,14 @@ void TRAP::Graphics::API::VulkanRenderer::SetFillMode(const FillMode mode, Windo
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	std::get<GraphicsPipelineDesc>(p->GraphicsPipelineDesc.Pipeline).RasterizerState->FillMode = mode;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetPrimitiveTopology(const PrimitiveTopology topology, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetPrimitiveTopology(const PrimitiveTopology topology, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -872,12 +872,12 @@ void TRAP::Graphics::API::VulkanRenderer::SetPrimitiveTopology(const PrimitiveTo
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::SetFrontFace(const FrontFace face, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::SetFrontFace(const FrontFace face, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	std::get<GraphicsPipelineDesc>(p->GraphicsPipelineDesc.Pipeline).RasterizerState->FrontFace = face;
 }
@@ -885,7 +885,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetFrontFace(const FrontFace face, Win
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::SetBlendMode(const BlendMode modeRGB, const BlendMode modeAlpha,
-                                                       Window* window)
+                                                       Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -903,7 +903,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetBlendMode(const BlendMode modeRGB, 
 void TRAP::Graphics::API::VulkanRenderer::SetBlendConstant(const BlendConstant sourceRGB,
 														   const BlendConstant sourceAlpha,
                                                            const BlendConstant destinationRGB,
-                                                           const BlendConstant destinationAlpha, Window* window)
+                                                           const BlendConstant destinationAlpha, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -923,12 +923,12 @@ void TRAP::Graphics::API::VulkanRenderer::SetBlendConstant(const BlendConstant s
 void TRAP::Graphics::API::VulkanRenderer::SetShadingRate(const ShadingRate shadingRate,
 						            					 TRAP::Graphics::Texture* texture,
 		                            					 const ShadingRateCombiner postRasterizerRate,
-							        					 const ShadingRateCombiner finalRate, Window* window)
+							        					 const ShadingRateCombiner finalRate, Window* window) const
 {
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	p->GraphicCommandBuffers[p->ImageIndex]->SetShadingRate(shadingRate, texture, postRasterizerRate, finalRate);
 }
@@ -936,7 +936,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetShadingRate(const ShadingRate shadi
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::SetAntiAliasing(const AntiAliasing antiAliasing, SampleCount sampleCount,
-                                                          Window* window)
+                                                          Window* window) const
 {
 	TRAP_ASSERT(GPUSettings.MaxMSAASampleCount >= sampleCount, "Sample count is higher than max supported by GPU");
 
@@ -959,12 +959,12 @@ void TRAP::Graphics::API::VulkanRenderer::SetAntiAliasing(const AntiAliasing ant
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::GetAntiAliasing(AntiAliasing& outAntiAliasing,
-                                                          SampleCount& outSampleCount, Window* window)
+                                                          SampleCount& outSampleCount, Window* window) const
 {
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	outAntiAliasing = p->NewAntiAliasing;
 	outSampleCount = p->NewSampleCount;
@@ -972,12 +972,12 @@ void TRAP::Graphics::API::VulkanRenderer::GetAntiAliasing(AntiAliasing& outAntiA
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::Clear(const ClearBufferType clearType, Window* window)
+void TRAP::Graphics::API::VulkanRenderer::Clear(const ClearBufferType clearType, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const data = s_perWindowDataMap[window].get();
+	const PerWindowData* const data = s_perWindowDataMap[window].get();
 
 	TRAP::Ref<RenderTarget> renderTarget;
 #ifndef TRAP_HEADLESS_MODE
@@ -1023,7 +1023,7 @@ void TRAP::Graphics::API::VulkanRenderer::Clear(const ClearBufferType clearType,
 
 void TRAP::Graphics::API::VulkanRenderer::SetViewport(const uint32_t x, const uint32_t y, const uint32_t width,
                                                       const uint32_t height, const float minDepth,
-                                                      const float maxDepth, Window* window)
+                                                      const float maxDepth, Window* window) const
 {
 	if (width == 0 || height == 0)
 		return;
@@ -1031,7 +1031,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetViewport(const uint32_t x, const ui
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const data = s_perWindowDataMap[window].get();
+	const PerWindowData* const data = s_perWindowDataMap[window].get();
 
 	data->GraphicCommandBuffers[data->ImageIndex]->SetViewport(static_cast<float>(x), static_cast<float>(y),
 	                                                           static_cast<float>(width), static_cast<float>(height),
@@ -1041,12 +1041,12 @@ void TRAP::Graphics::API::VulkanRenderer::SetViewport(const uint32_t x, const ui
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::SetScissor(const uint32_t x, const uint32_t y, const uint32_t width,
-                                                     const uint32_t height, Window* window)
+                                                     const uint32_t height, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const data = s_perWindowDataMap[window].get();
+	const PerWindowData* const data = s_perWindowDataMap[window].get();
 
 	data->GraphicCommandBuffers[data->ImageIndex]->SetScissor(x, y, width, height);
 }
@@ -1054,12 +1054,12 @@ void TRAP::Graphics::API::VulkanRenderer::SetScissor(const uint32_t x, const uin
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::Draw(const uint32_t vertexCount, const uint32_t firstVertex,
-                                               Window* window)
+                                               Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const data = s_perWindowDataMap[window].get();
+	const PerWindowData* const data = s_perWindowDataMap[window].get();
 
 	data->GraphicCommandBuffers[data->ImageIndex]->Draw(vertexCount, firstVertex);
 }
@@ -1067,12 +1067,12 @@ void TRAP::Graphics::API::VulkanRenderer::Draw(const uint32_t vertexCount, const
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::DrawIndexed(const uint32_t indexCount, const uint32_t firstIndex,
-                                                      const uint32_t firstVertex, Window* window)
+                                                      const uint32_t firstVertex, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const data = s_perWindowDataMap[window].get();
+	const PerWindowData* const data = s_perWindowDataMap[window].get();
 
 	data->GraphicCommandBuffers[data->ImageIndex]->DrawIndexed(indexCount, firstIndex, firstVertex);
 }
@@ -1081,12 +1081,12 @@ void TRAP::Graphics::API::VulkanRenderer::DrawIndexed(const uint32_t indexCount,
 
 void TRAP::Graphics::API::VulkanRenderer::DrawInstanced(const uint32_t vertexCount, const uint32_t instanceCount,
                                                         const uint32_t firstVertex, const uint32_t firstInstance,
-                                                        Window* window)
+                                                        Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const data = s_perWindowDataMap[window].get();
+	const PerWindowData* const data = s_perWindowDataMap[window].get();
 
 	data->GraphicCommandBuffers[data->ImageIndex]->DrawInstanced(vertexCount, firstVertex, instanceCount,
 	                                                             firstInstance);
@@ -1096,12 +1096,12 @@ void TRAP::Graphics::API::VulkanRenderer::DrawInstanced(const uint32_t vertexCou
 
 void TRAP::Graphics::API::VulkanRenderer::DrawIndexedInstanced(const uint32_t indexCount, const uint32_t instanceCount,
                                                                const uint32_t firstIndex, const uint32_t firstInstance,
-						                                       const uint32_t firstVertex, Window* window)
+						                                       const uint32_t firstVertex, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const data = s_perWindowDataMap[window].get();
+	const PerWindowData* const data = s_perWindowDataMap[window].get();
 
 	data->GraphicCommandBuffers[data->ImageIndex]->DrawIndexedInstanced(indexCount, firstIndex, instanceCount,
 	                                                                    firstInstance, firstVertex);
@@ -1194,7 +1194,7 @@ void TRAP::Graphics::API::VulkanRenderer::BindShader(Shader* shader, Window* win
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::BindVertexBuffer(const TRAP::Ref<Buffer>& vBuffer,
-                                                           const VertexBufferLayout& layout, Window* window)
+                                                           const VertexBufferLayout& layout, Window* window) const
 {
 	//Vertex Buffer realistically only consists of floating point values
 	constexpr auto ShaderDataTypeToImageFormat = [](const ShaderDataType s) -> ImageFormat
@@ -1226,7 +1226,7 @@ void TRAP::Graphics::API::VulkanRenderer::BindVertexBuffer(const TRAP::Ref<Buffe
 
 	p->GraphicCommandBuffers[p->ImageIndex]->BindVertexBuffer({ vBuffer }, { layout.GetStride() }, {});
 
-	TRAP::Ref<VertexLayout> lay = TRAP::MakeRef<VertexLayout>();
+	const TRAP::Ref<VertexLayout> lay = TRAP::MakeRef<VertexLayout>();
 	const std::vector<VertexBufferElement>& elements = layout.GetElements();
 	lay->AttributeCount = static_cast<uint32_t>(elements.size());
 	for(uint32_t i = 0; i < elements.size(); ++i)
@@ -1243,12 +1243,12 @@ void TRAP::Graphics::API::VulkanRenderer::BindVertexBuffer(const TRAP::Ref<Buffe
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::BindIndexBuffer(const TRAP::Ref<Buffer>& iBuffer,
-                                                          const IndexType indexType, Window* window)
+                                                          const IndexType indexType, Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	p->GraphicCommandBuffers[p->ImageIndex]->BindIndexBuffer(iBuffer, indexType, 0);
 }
@@ -1256,14 +1256,14 @@ void TRAP::Graphics::API::VulkanRenderer::BindIndexBuffer(const TRAP::Ref<Buffer
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::BindDescriptorSet(DescriptorSet& dSet, const uint32_t index,
-															const QueueType queueType, Window* window)
+															const QueueType queueType, Window* window) const
 {
 	TRAP_ASSERT(queueType == QueueType::Graphics || queueType == QueueType::Compute, "Invalid QueueType provided!");
 
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	if(queueType == QueueType::Graphics)
 		p->GraphicCommandBuffers[p->ImageIndex]->BindDescriptorSet(index, dSet);
@@ -1274,14 +1274,14 @@ void TRAP::Graphics::API::VulkanRenderer::BindDescriptorSet(DescriptorSet& dSet,
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::BindPushConstants(const char* name, const void* constantsData,
-															const QueueType queueType, Window* window)
+															const QueueType queueType, Window* window) const
 {
 	TRAP_ASSERT(queueType == QueueType::Graphics || queueType == QueueType::Compute, "Invalid QueueType provided!");
 
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	if(queueType == QueueType::Graphics)
 	{
@@ -1306,14 +1306,14 @@ void TRAP::Graphics::API::VulkanRenderer::BindPushConstants(const char* name, co
 void TRAP::Graphics::API::VulkanRenderer::BindPushConstantsByIndex(const uint32_t paramIndex,
                                                                    const void* constantsData,
 																   const QueueType queueType,
-																   Window* window)
+																   Window* window) const
 {
 	TRAP_ASSERT(queueType == QueueType::Graphics || queueType == QueueType::Compute, "Invalid QueueType provided!");
 
 	if (!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	if(queueType == QueueType::Graphics)
 	{
@@ -1341,12 +1341,12 @@ void TRAP::Graphics::API::VulkanRenderer::BindRenderTarget(const TRAP::Ref<Graph
 							                               std::vector<uint32_t>* colorArraySlices,
 							                               std::vector<uint32_t>* colorMipSlices,
 							                               const uint32_t depthArraySlice,
-														   const uint32_t depthMipSlice, Window* window)
+														   const uint32_t depthMipSlice, Window* window) const
 {
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	std::vector<TRAP::Ref<Graphics::RenderTarget>> targets;
 	if(colorTarget)
@@ -1365,12 +1365,12 @@ void TRAP::Graphics::API::VulkanRenderer::BindRenderTargets(const std::vector<TR
 							                                std::vector<uint32_t>* colorArraySlices,
 							                                std::vector<uint32_t>* colorMipSlices,
 							                                const uint32_t depthArraySlice,
-														    const uint32_t depthMipSlice, Window* window)
+														    const uint32_t depthMipSlice, Window* window) const
 {
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	p->GraphicCommandBuffers[p->ImageIndex]->BindRenderTargets
 	(
@@ -1381,14 +1381,14 @@ void TRAP::Graphics::API::VulkanRenderer::BindRenderTargets(const std::vector<TR
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::ResourceBufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
-															    const QueueType queueType, Window* window)
+															    const QueueType queueType, Window* window) const
 {
 	TRAP_ASSERT(queueType == QueueType::Graphics || queueType == QueueType::Compute, "Invalid QueueType provided!");
 
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	if(queueType == QueueType::Graphics)
 		p->GraphicCommandBuffers[p->ImageIndex]->ResourceBarrier(&bufferBarrier, nullptr, nullptr);
@@ -1399,14 +1399,14 @@ void TRAP::Graphics::API::VulkanRenderer::ResourceBufferBarrier(const RendererAP
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::ResourceBufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
-																 const QueueType queueType, Window* window)
+																 const QueueType queueType, Window* window) const
 {
 	TRAP_ASSERT(queueType == QueueType::Graphics || queueType == QueueType::Compute, "Invalid QueueType provided!");
 
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	if(queueType == QueueType::Graphics)
 		p->GraphicCommandBuffers[p->ImageIndex]->ResourceBarrier(&bufferBarriers, nullptr, nullptr);
@@ -1417,14 +1417,14 @@ void TRAP::Graphics::API::VulkanRenderer::ResourceBufferBarriers(const std::vect
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::ResourceTextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
-																 const QueueType queueType, Window* window)
+																 const QueueType queueType, Window* window) const
 {
 	TRAP_ASSERT(queueType == QueueType::Graphics || queueType == QueueType::Compute, "Invalid QueueType provided!");
 
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	if(queueType == QueueType::Graphics)
 		p->GraphicCommandBuffers[p->ImageIndex]->ResourceBarrier(nullptr, &textureBarrier, nullptr);
@@ -1435,14 +1435,14 @@ void TRAP::Graphics::API::VulkanRenderer::ResourceTextureBarrier(const RendererA
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::ResourceTextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
-																  const QueueType queueType, Window* window)
+																  const QueueType queueType, Window* window) const
 {
 	TRAP_ASSERT(queueType == QueueType::Graphics || queueType == QueueType::Compute, "Invalid QueueType provided!");
 
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	if(queueType == QueueType::Graphics)
 		p->GraphicCommandBuffers[p->ImageIndex]->ResourceBarrier(nullptr, &textureBarriers, nullptr);
@@ -1453,12 +1453,12 @@ void TRAP::Graphics::API::VulkanRenderer::ResourceTextureBarriers(const std::vec
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::ResourceRenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier,
-									                                  Window* window)
+									                                  Window* window) const
 {
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	p->GraphicCommandBuffers[p->ImageIndex]->ResourceBarrier(nullptr, nullptr, &renderTargetBarrier);
 }
@@ -1466,12 +1466,12 @@ void TRAP::Graphics::API::VulkanRenderer::ResourceRenderTargetBarrier(const Rend
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::Graphics::API::VulkanRenderer::ResourceRenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers,
-									                                   Window* window)
+									                                   Window* window) const
 {
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	PerWindowData* const p = s_perWindowDataMap[window].get();
+	const PerWindowData* const p = s_perWindowDataMap[window].get();
 
 	p->GraphicCommandBuffers[p->ImageIndex]->ResourceBarrier(nullptr, nullptr, &renderTargetBarriers);
 }
@@ -1485,7 +1485,7 @@ std::string TRAP::Graphics::API::VulkanRenderer::GetTitle() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::Graphics::API::VulkanRenderer::GetVSync(Window* window)
+bool TRAP::Graphics::API::VulkanRenderer::GetVSync(Window* window) const
 {
 	if (!window)
 		window = TRAP::Application::GetWindow();
@@ -1495,28 +1495,28 @@ bool TRAP::Graphics::API::VulkanRenderer::GetVSync(Window* window)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::array<uint8_t, 16> TRAP::Graphics::API::VulkanRenderer::GetCurrentGPUUUID()
+std::array<uint8_t, 16> TRAP::Graphics::API::VulkanRenderer::GetCurrentGPUUUID() const
 {
 	return m_device->GetPhysicalDevice()->GetPhysicalDeviceUUID();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::string TRAP::Graphics::API::VulkanRenderer::GetCurrentGPUName()
+std::string TRAP::Graphics::API::VulkanRenderer::GetCurrentGPUName() const
 {
 	return m_device->GetPhysicalDevice()->GetVkPhysicalDeviceProperties().deviceName;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::vector<std::pair<std::string, std::array<uint8_t, 16>>> TRAP::Graphics::API::VulkanRenderer::GetAllGPUs()
+std::vector<std::pair<std::string, std::array<uint8_t, 16>>> TRAP::Graphics::API::VulkanRenderer::GetAllGPUs() const
 {
 	if(!s_usableGPUs.empty())
 		return s_usableGPUs;
 
 	for (const auto& [score, devUUID] : VulkanPhysicalDevice::GetAllRatedPhysicalDevices(m_instance))
 	{
-		VkPhysicalDevice dev = VulkanPhysicalDevice::FindPhysicalDeviceViaUUID(m_instance, devUUID);
+		const VkPhysicalDevice dev = VulkanPhysicalDevice::FindPhysicalDeviceViaUUID(m_instance, devUUID);
 		VkPhysicalDeviceProperties props;
 		vkGetPhysicalDeviceProperties(dev, &props);
 
@@ -1530,7 +1530,7 @@ std::vector<std::pair<std::string, std::array<uint8_t, 16>>> TRAP::Graphics::API
 
 //Helper function to generate screenshot data. See CaptureScreenshot.
 void TRAP::Graphics::API::VulkanRenderer::MapRenderTarget(const TRAP::Ref<RenderTarget>& renderTarget,
-														  ResourceState currResState, void* outPixelData)
+														  const ResourceState currResState, void* outPixelData)
 {
 	CommandPoolDesc cmdPoolDesc{};
 	cmdPoolDesc.Queue = s_graphicQueue;
@@ -1540,7 +1540,7 @@ void TRAP::Graphics::API::VulkanRenderer::MapRenderTarget(const TRAP::Ref<Render
 	CommandBuffer* cmd = cmdPool->AllocateCommandBuffer(false);
 
 	//Add a staging buffer
-	uint16_t formatByteWidth = static_cast<uint16_t>(ImageFormatBitSizeOfBlock(renderTarget->GetImageFormat()) / 8u);
+	const uint16_t formatByteWidth = static_cast<uint16_t>(ImageFormatBitSizeOfBlock(renderTarget->GetImageFormat()) / 8u);
 	BufferDesc bufferDesc{};
 	bufferDesc.Descriptors = DescriptorType::RWBuffer;
 	bufferDesc.MemoryUsage = ResourceMemoryUsage::GPUToCPU;
@@ -1556,7 +1556,7 @@ void TRAP::Graphics::API::VulkanRenderer::MapRenderTarget(const TRAP::Ref<Render
 	RenderTargetBarrier srcBarrier = {renderTarget, currResState, ResourceState::CopySource};
 	cmd->ResourceBarrier(nullptr, nullptr, &srcBarrier);
 
-	uint32_t rowPitch = renderTarget->GetWidth() * formatByteWidth;
+	const uint32_t rowPitch = renderTarget->GetWidth() * formatByteWidth;
 	const uint32_t width = renderTarget->GetTexture()->GetWidth();
 	const uint32_t height = renderTarget->GetTexture()->GetHeight();
 	const uint32_t depth = Math::Max(1u, renderTarget->GetTexture()->GetDepth());
@@ -1564,17 +1564,17 @@ void TRAP::Graphics::API::VulkanRenderer::MapRenderTarget(const TRAP::Ref<Render
 	const uint32_t numBlocksWide = rowPitch / (ImageFormatBitSizeOfBlock(fmt) >> 3);
 
 	//Copy the render target to the staging buffer
-	uint32_t bufferRowLength = numBlocksWide * ImageFormatWidthOfBlock(fmt);
+	const uint32_t bufferRowLength = numBlocksWide * ImageFormatWidthOfBlock(fmt);
 	VkImageSubresourceLayers layers{};
 	layers.aspectMask = static_cast<VkImageAspectFlags>(renderTarget->GetTexture()->GetAspectMask());
 	layers.mipLevel = 0;
 	layers.baseArrayLayer = 0;
 	layers.layerCount = 1;
-	VkBufferImageCopy copy = API::VulkanInits::ImageCopy(bufferRowLength, width, height, depth, layers);
+	const VkBufferImageCopy copy = API::VulkanInits::ImageCopy(bufferRowLength, width, height, depth, layers);
 
-	VulkanCommandBuffer* vkCmd = dynamic_cast<VulkanCommandBuffer*>(cmd);
-	VulkanTexture* vkTex = dynamic_cast<VulkanTexture*>(renderTarget->GetTexture());
-	VulkanBuffer* vkBuf = dynamic_cast<VulkanBuffer*>(buffer.get());
+	const VulkanCommandBuffer* vkCmd = dynamic_cast<VulkanCommandBuffer*>(cmd);
+	const VulkanTexture* vkTex = dynamic_cast<VulkanTexture*>(renderTarget->GetTexture());
+	const VulkanBuffer* vkBuf = dynamic_cast<VulkanBuffer*>(buffer.get());
 
 	vkCmdCopyImageToBuffer(vkCmd->GetVkCommandBuffer(), vkTex->GetVkImage(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, vkBuf->GetVkBuffer(), 1, &copy);
 
@@ -1607,22 +1607,22 @@ void TRAP::Graphics::API::VulkanRenderer::MapRenderTarget(const TRAP::Ref<Render
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Scope<TRAP::Image> TRAP::Graphics::API::VulkanRenderer::CaptureScreenshot(Window* window)
+TRAP::Scope<TRAP::Image> TRAP::Graphics::API::VulkanRenderer::CaptureScreenshot(Window* window) const
 {
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
-	auto* winData = s_perWindowDataMap[window].get();
-	uint32_t lastFrame = (winData->ImageIndex - 1) % RendererAPI::ImageCount;
+	const auto* winData = s_perWindowDataMap[window].get();
+	const uint32_t lastFrame = (winData->ImageIndex - 1) % RendererAPI::ImageCount;
 
 	//Wait for queues to finish
 	s_computeQueue->WaitQueueIdle();
 	s_graphicQueue->WaitQueueIdle();
 
 #ifdef TRAP_HEADLESS_MODE
-	TRAP::Ref<RenderTarget> rT = winData->RenderTargets[lastFrame];
+	const TRAP::Ref<RenderTarget> rT = winData->RenderTargets[lastFrame];
 #else
-	TRAP::Ref<RenderTarget> rT = winData->SwapChain->GetRenderTargets()[lastFrame];
+	const TRAP::Ref<RenderTarget> rT = winData->SwapChain->GetRenderTargets()[lastFrame];
 #endif
 
 	const uint8_t channelCount = static_cast<uint8_t>(ImageFormatChannelCount(rT->GetImageFormat()));
@@ -1674,24 +1674,24 @@ TRAP::Scope<TRAP::Image> TRAP::Graphics::API::VulkanRenderer::CaptureScreenshot(
 		{
 			for(uint32_t x = 0; x < rT->GetWidth(); ++x)
 			{
-				uint32_t pixelIndex = (y * rT->GetWidth() + x) * channelCount;
+				const uint32_t pixelIndex = (y * rT->GetWidth() + x) * channelCount;
 
 				//Swap blue and red
 				if(!hdr && u16)
 				{
-					uint16_t red = pixelDatau8[pixelIndex];
+					const uint16_t red = pixelDatau8[pixelIndex];
 					pixelDatau16[pixelIndex] = pixelDatau8[pixelIndex + 2];
 					pixelDatau16[pixelIndex + 2] = red;
 				}
 				else if(!hdr)
 				{
-					uint8_t red = pixelDatau8[pixelIndex];
+					const uint8_t red = pixelDatau8[pixelIndex];
 					pixelDatau8[pixelIndex] = pixelDatau8[pixelIndex + 2];
 					pixelDatau8[pixelIndex + 2] = red;
 				}
 				else
 				{
-					float red = pixelDataf32[pixelIndex];
+					const float red = pixelDataf32[pixelIndex];
 					pixelDataf32[pixelIndex] = pixelDataf32[pixelIndex + 2];
 					pixelDataf32[pixelIndex + 2] = red;
 				}
@@ -1712,7 +1712,7 @@ TRAP::Scope<TRAP::Image> TRAP::Graphics::API::VulkanRenderer::CaptureScreenshot(
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::InitPerWindowData(Window* window)
+void TRAP::Graphics::API::VulkanRenderer::InitPerWindowData(Window* window) const
 {
 	if (s_perWindowDataMap.find(window) != s_perWindowDataMap.end())
 		//Window is already in map
@@ -1870,7 +1870,7 @@ void TRAP::Graphics::API::VulkanRenderer::InitPerWindowData(Window* window)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::RemovePerWindowData(Window* window)
+void TRAP::Graphics::API::VulkanRenderer::RemovePerWindowData(Window* window) const
 {
 	if (s_perWindowDataMap.find(window) != s_perWindowDataMap.end())
 		s_perWindowDataMap.erase(window);
@@ -1878,7 +1878,7 @@ void TRAP::Graphics::API::VulkanRenderer::RemovePerWindowData(Window* window)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::API::VulkanRenderer::WaitIdle()
+void TRAP::Graphics::API::VulkanRenderer::WaitIdle() const
 {
 	m_device->WaitIdle();
 }
@@ -1972,7 +1972,7 @@ std::vector<std::string> TRAP::Graphics::API::VulkanRenderer::SetupInstanceExten
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::vector<std::string> TRAP::Graphics::API::VulkanRenderer::SetupDeviceExtensions(VulkanPhysicalDevice* const physicalDevice)
+std::vector<std::string> TRAP::Graphics::API::VulkanRenderer::SetupDeviceExtensions(VulkanPhysicalDevice* physicalDevice)
 {
 	std::vector<std::string> extensions{};
 
@@ -2260,16 +2260,16 @@ void TRAP::Graphics::API::VulkanRenderer::AddDefaultResources()
 	//Create Command Buffer to transition resources to the correct state
 	QueueDesc queueDesc{};
 	queueDesc.Type = QueueType::Graphics;
-	TRAP::Ref<VulkanQueue> graphicsQueue = TRAP::MakeRef<VulkanQueue>(queueDesc);
+	const TRAP::Ref<VulkanQueue> graphicsQueue = TRAP::MakeRef<VulkanQueue>(queueDesc);
 
 	CommandPoolDesc cmdPoolDesc{};
 	cmdPoolDesc.Queue = graphicsQueue;
 	cmdPoolDesc.Transient = true;
-	TRAP::Ref<VulkanCommandPool> cmdPool = TRAP::MakeRef<VulkanCommandPool>(cmdPoolDesc);
+	const TRAP::Ref<VulkanCommandPool> cmdPool = TRAP::MakeRef<VulkanCommandPool>(cmdPoolDesc);
 
 	CommandBuffer* cmd = cmdPool->AllocateCommandBuffer(false);
 
-	TRAP::Ref<VulkanFence> fence = TRAP::MakeRef<VulkanFence>();
+	const TRAP::Ref<VulkanFence> fence = TRAP::MakeRef<VulkanFence>();
 
 	s_NullDescriptors->InitialTransitionQueue = graphicsQueue;
 	s_NullDescriptors->InitialTransitionCmdPool = cmdPool;
@@ -2326,7 +2326,7 @@ void TRAP::Graphics::API::VulkanRenderer::UtilInitialTransition(TRAP::Graphics::
 	VulkanCommandBuffer* cmd = s_NullDescriptors->InitialTransitionCmd;
 	s_NullDescriptors->InitialTransitionCmdPool->Reset();
 	cmd->Begin();
-	TextureBarrier barrier{texture, RendererAPI::ResourceState::Undefined, startState};
+	const TextureBarrier barrier{texture, RendererAPI::ResourceState::Undefined, startState};
 	cmd->ResourceBarrier(nullptr, &barrier, nullptr);
 	cmd->End();
 	RendererAPI::QueueSubmitDesc submitDesc{};
@@ -2342,7 +2342,7 @@ TRAP::Graphics::API::VulkanRenderer::RenderPassMap& TRAP::Graphics::API::VulkanR
 {
 	//Only need a lock when creating a new RenderPass Map for this thread
 	std::lock_guard<std::mutex> lock(s_renderPassMutex);
-	auto it = s_renderPassMap.find(std::this_thread::get_id());
+	const auto it = s_renderPassMap.find(std::this_thread::get_id());
 	if (it == s_renderPassMap.end())
 	{
 		s_renderPassMap[std::this_thread::get_id()] = {};
@@ -2358,7 +2358,7 @@ TRAP::Graphics::API::VulkanRenderer::FrameBufferMap& TRAP::Graphics::API::Vulkan
 {
 	//Only need a lock when creating a new FrameBuffer Map for this thread
 	std::lock_guard<std::mutex> lock(s_renderPassMutex);
-	auto it = s_frameBufferMap.find(std::this_thread::get_id());
+	const auto it = s_frameBufferMap.find(std::this_thread::get_id());
 	if(it == s_frameBufferMap.end())
 	{
 		s_frameBufferMap[std::this_thread::get_id()] = {};
@@ -2393,7 +2393,7 @@ TRAP::Ref<TRAP::Graphics::API::VulkanMemoryAllocator> TRAP::Graphics::API::Vulka
 
 const TRAP::Ref<TRAP::Graphics::Pipeline>& TRAP::Graphics::API::VulkanRenderer::GetPipeline(PipelineDesc& desc)
 {
-	std::size_t hash = std::hash<PipelineDesc>{}(desc);
+	const std::size_t hash = std::hash<PipelineDesc>{}(desc);
 	const auto pipelineIt = s_pipelines.find(hash);
 
 	if(pipelineIt != s_pipelines.end())
@@ -2419,7 +2419,7 @@ const TRAP::Ref<TRAP::Graphics::Pipeline>& TRAP::Graphics::API::VulkanRenderer::
 #ifdef VERBOSE_GRAPHICS_DEBUG
 	TP_TRACE(Log::RendererVulkanPipelinePrefix, "Recreating Graphics Pipeline...");
 #endif
-	TRAP::Ref<TRAP::Graphics::Pipeline> pipeline = Pipeline::Create(desc);
+	const TRAP::Ref<TRAP::Graphics::Pipeline> pipeline = Pipeline::Create(desc);
 	const auto pipeRes = s_pipelines.try_emplace(hash, pipeline);
 #ifdef VERBOSE_GRAPHICS_DEBUG
 	TP_TRACE(Log::RendererVulkanPipelinePrefix, "Cached Graphics Pipeline");

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -1478,7 +1478,7 @@ void TRAP::Graphics::API::VulkanRenderer::ResourceRenderTargetBarriers(const std
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Graphics::API::VulkanRenderer::GetTitle() const
+std::string TRAP::Graphics::API::VulkanRenderer::GetTitle() const
 {
 	return m_rendererTitle;
 }

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -1595,8 +1595,9 @@ void TRAP::Graphics::API::VulkanRenderer::MapRenderTarget(const TRAP::Ref<Render
 	s_graphicQueue->WaitQueueIdle();
 
 	//Copy to CPU memory.
-	memcpy(outPixelData, buffer->GetCPUMappedAddress(), static_cast<std::size_t>(renderTarget->GetWidth()) *
-																renderTarget->GetHeight() * formatByteWidth);
+	std::copy_n(static_cast<uint8_t*>(buffer->GetCPUMappedAddress()),
+	            static_cast<std::size_t>(renderTarget->GetWidth()) * renderTarget->GetHeight() * formatByteWidth,
+				static_cast<uint8_t*>(outPixelData));
 
 	//Cleanup
 	cmdPool->FreeCommandBuffer(cmd);

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -470,7 +470,7 @@ namespace TRAP::Graphics::API
 		/// Example title: "[Vulkan 1.3.0]".
 		/// </summary>
 		/// <returns>Renderer title.</returns>
-		const std::string& GetTitle() const override;
+		std::string GetTitle() const override;
 		/// <summary>
 		/// Retrieve whether VSync is enabled or not for the given window.
 		/// </summary>

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -70,7 +70,7 @@ namespace TRAP::Graphics::API
 		/// Present to the given window.
 		/// </summary>
 		/// <param name="window">Window to present.</param>
-		void Present(Window* window) override;
+		void Present(Window* window) const override;
 
 		/// <summary>
 		/// Dispatch to the given window.
@@ -80,7 +80,7 @@ namespace TRAP::Graphics::API
 		/// These values will be divided by the shader's work group size and rounded up.
 		/// </param>
 		/// <param name="window">Window to Dispatch.</param>
-		void Dispatch(std::array<uint32_t, 3> workGroupElements, Window* window) override;
+		void Dispatch(std::array<uint32_t, 3> workGroupElements, Window* window) const override;
 		//TODO DispatchIndirect
 
 		/// <summary>
@@ -88,26 +88,26 @@ namespace TRAP::Graphics::API
 		/// </summary>
 		/// <param name="vsync">Enable or disable VSync.</param>
 		/// <param name="window">Window to set VSync for. Default: Main Window.</param>
-		void SetVSync(bool vsync, Window* window) override;
+		void SetVSync(bool vsync, Window* window) const override;
 
 		/// <summary>
 		/// Set the clear color to be used by the given window.
 		/// </summary>
 		/// <param name="color">New clear color.</param>
 		/// <param name="window">Window to set clear color for. Default: Main Window.</param>
-		void SetClearColor(const Math::Vec4& color, Window* window) override;
+		void SetClearColor(const Math::Vec4& color, Window* window) const override;
 		/// <summary>
 		/// Set the clear depth value to be used by the given window.
 		/// </summary>
 		/// <param name="depth">New clear depth value. Must be between 0.0f and 1.0f</param>
 		/// <param name="window">Window to set clear depth value for. Default: Main Window.</param>
-		void SetClearDepth(float depth, Window* window) override;
+		void SetClearDepth(float depth, Window* window) const override;
 		/// <summary>
 		/// Set the clear stencil value to be used by the given window.
 		/// </summary>
 		/// <param name="stencil">New clear stencil value.</param>
 		/// <param name="window">Window to set clear stencil value for. Default: Main Window.</param>
-		void SetClearStencil(uint32_t stencil, Window* window) override;
+		void SetClearStencil(uint32_t stencil, Window* window) const override;
 #ifdef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the resolution of the render targets used by the given window.
@@ -117,110 +117,110 @@ namespace TRAP::Graphics::API
 		/// <param name="width">New width.</param>
 		/// <param name="height">New height.</param>
 		/// <param name="window">Window to set resolution for. Default: Main Window.</param>
-		void SetResolution(uint32_t width, uint32_t height, Window* window) override;
+		void SetResolution(uint32_t width, uint32_t height, Window* window) const override;
 #endif
 		/// <summary>
 		/// Enable or disable depth testing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth testing.</param>
 		/// <param name="window">Window to set depth testing for. Default: Main Window.</param>
-		void SetDepthTesting(bool enabled, Window* window) override;
+		void SetDepthTesting(bool enabled, Window* window) const override;
 		/// <summary>
 		/// Enable or disable depth writing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth writing.</param>
 		/// <param name="window">Window to set depth writing for. Default: Main Window.</param>
-		void SetDepthWriting(bool enabled, Window* window) override;
+		void SetDepthWriting(bool enabled, Window* window) const override;
 		/// <summary>
 		/// Set the depth function for the given window.
 		/// </summary>
 		/// <param name="function">Function to use for depth testing.</param>
 		/// <param name="window">Window to set depth function for. Default: Main Window.</param>
-		void SetDepthFunction(CompareMode function, Window* window) override;
+		void SetDepthFunction(CompareMode function, Window* window) const override;
 		/// <summary>
 		/// Set the depth action to perform when depth testing fails for the given window.
 		/// </summary>
 		/// <param name="front">Depth action to perform when depth testing fails.</param>
 		/// <param name="back">Depth action to perform when depth testing fails.</param>
 		/// <param name="window">Window to set the depth fail action for. Default: Main Window.</param>
-		void SetDepthFail(StencilOp front, StencilOp back, Window* window) override;
+		void SetDepthFail(StencilOp front, StencilOp back, Window* window) const override;
 		/// <summary>
 		/// Set the depth bias (scalar factor to add to each fragments depth value) for the given window.
 		/// </summary>
 		/// <param name="depthBias">Depth bias.</param>
 		/// <param name="window">Window to set the depth bias for. Default: Main Window.</param>
-		void SetDepthBias(int32_t depthBias, Window* window) override;
+		void SetDepthBias(int32_t depthBias, Window* window) const override;
 		/// <summary>
 		/// Set the depth bias slope factor (scalar factor applied to fragment's slope in depth bias calculation) for the given window.
 		/// </summary>
 		/// <param name="factor">Depth bias slope factor.</param>
 		/// <param name="window">Window to set the depth bias slope factor for. Default: Main Window.</param>
-		void SetDepthBiasSlopeFactor(float factor, Window* window) override;
+		void SetDepthBiasSlopeFactor(float factor, Window* window) const override;
 		/// <summary>
 		/// Enable or disable stencil testing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable stencil testing.</param>
 		/// <param name="window">Window to set stencil testing for. Default: Main Window.</param>
-		void SetStencilTesting(bool enabled, Window* window) override;
+		void SetStencilTesting(bool enabled, Window* window) const override;
 		/// <summary>
 		/// Set the stencil action to perform when stencil testing fails for the given window.
 		/// </summary>
 		/// <param name="front">Stencil action to perform when stencil testing fails.</param>
 		/// <param name="back">Stencil action to perform when stencil testing fails.</param>
 		/// <param name="window">Window to set the stencil fail action for. Default: Main Window.</param>
-		void SetStencilFail(StencilOp front, StencilOp back, Window* window) override;
+		void SetStencilFail(StencilOp front, StencilOp back, Window* window) const override;
 		/// <summary>
 		/// Set the stencil action to perform when stencil testing and depth testing passes for the given window.
 		/// </summary>
 		/// <param name="front">Stencil action to perform when passed.</param>
 		/// <param name="back">Stencil action to perform when passed.</param>
 		/// <param name="window">Window to set the stencil pass action for. Default: Main Window.</param>
-		void SetStencilPass(StencilOp front, StencilOp back, Window* window) override;
+		void SetStencilPass(StencilOp front, StencilOp back, Window* window) const override;
 		/// <summary>
 		/// Set the stencil functions for the given window.
 		/// </summary>
 		/// <param name="front">Function to use on the front for stencil testing.</param>
 		/// <param name="back">Function to use on the back for stencil testing.</param>
 		/// <param name="window">Window to set stencil functions for. Default: Main Window.</param>
-		void SetStencilFunction(CompareMode front, CompareMode back, Window* window) override;
+		void SetStencilFunction(CompareMode front, CompareMode back, Window* window) const override;
 		/// <summary>
 		/// Set the stencil mask for the given window.
 		/// </summary>
 		/// <param name="read">Select the bits of the stencil values to test.</param>
 		/// <param name="write">Select the bits of the stencil values updated by the stencil test.</param>
 		/// <param name="window">Window to set stencil mask for. Default: Main Window.</param>
-		void SetStencilMask(uint8_t read, uint8_t write, Window* window) override;
+		void SetStencilMask(uint8_t read, uint8_t write, Window* window) const override;
 		/// <summary>
 		/// Set the cull mode for the given window.
 		/// </summary>
 		/// <param name="mode">Cull mode to use.</param>
 		/// <param name="window">Window to set cull mode for. Default: Main Window.</param>
-		void SetCullMode(CullMode mode, Window* window) override;
+		void SetCullMode(CullMode mode, Window* window) const override;
 		/// <summary>
 		/// Set the fill mode for the given window.
 		/// </summary>
 		/// <param name="mode">Fill mode to use.</param>
 		/// <param name="window">Window to set fill mode for. Default: Main Window.</param>
-		void SetFillMode(FillMode mode, Window* window) override;
+		void SetFillMode(FillMode mode, Window* window) const override;
 		/// <summary>
 		/// Set the primitive topology for the given window.
 		/// </summary>
 		/// <param name="topology">Primitive topology to use.</param>
 		/// <param name="window">Window to set primitive topology for. Default: Main Window.</param>
-		void SetPrimitiveTopology(PrimitiveTopology topology, Window* window) override;
+		void SetPrimitiveTopology(PrimitiveTopology topology, Window* window) const override;
 		/// <summary>
 		/// Set the front face winding order for the given window.
 		/// </summary>
 		/// <param name="face">Front face winding order to use.</param>
 		/// <param name="window">Window to set front face winding order for. Default: Main Window.</param>
-		void SetFrontFace(FrontFace face, Window* window) override;
+		void SetFrontFace(FrontFace face, Window* window) const override;
 		/// <summary>
 		/// Set the blend mode for the given window.
 		/// </summary>
 		/// <param name="modeRGB">Blend mode to use for the RGB channels.</param>
 		/// <param name="modeAlpha">Blend mode to use for the alpha channel.</param>
 		/// <param name="window">Window to set the blend mode for. Default: Main Window.</param>
-		void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha, Window* window) override;
+		void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha, Window* window) const override;
 		/// <summary>
 		/// Set the blend constants/factors for the given window.
 		/// </summary>
@@ -231,7 +231,7 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to set the blend constants for. Default: Main Window.</param>
 		void SetBlendConstant(BlendConstant sourceRGB, BlendConstant sourceAlpha,
 							  BlendConstant destinationRGB, BlendConstant destinationAlpha,
-							  Window* window) override;
+							  Window* window) const override;
 		/// <summary>
 		/// Set the pipeline fragment shading rate and combiner operation for the command buffer.
 		/// </summary>
@@ -243,7 +243,7 @@ namespace TRAP::Graphics::API
 		void SetShadingRate(ShadingRate shadingRate,
 							TRAP::Graphics::Texture* texture,
 							ShadingRateCombiner postRasterizerRate,
-							ShadingRateCombiner finalRate, Window* window = nullptr) override;
+							ShadingRateCombiner finalRate, Window* window = nullptr) const override;
 		/// <summary>
 		/// Set the anti aliasing method and the sample count for the window.
 		/// Use AntiAliasing::Off and SampleCount::One to disable anti aliasing.
@@ -251,21 +251,21 @@ namespace TRAP::Graphics::API
 		/// <param name="antiAliasing">Anti aliasing method to use.</param>
 		/// <param name="sampleCount">Sample count to use.</param>
 		/// <param name="window">Window to set anti aliasing for. Default: Main Window.</param>
-		void SetAntiAliasing(AntiAliasing antiAliasing, SampleCount sampleCount, Window* window = nullptr) override;
+		void SetAntiAliasing(AntiAliasing antiAliasing, SampleCount sampleCount, Window* window = nullptr) const override;
 		/// <summary>
 		/// Retrieve the anti aliasing method and the sample count of the window.
 		/// </summary>
 		/// <param name="outAntiAliasing">Output: Used anti aliasing method.</param>
 		/// <param name="outSampleCount">Output: Used sample count.</param>
 		/// <param name="window">Window to get anti aliasing from. Default: Main Window.</param>
-		void GetAntiAliasing(AntiAliasing& outAntiAliasing, SampleCount& outSampleCount, Window* window = nullptr) override;
+		void GetAntiAliasing(AntiAliasing& outAntiAliasing, SampleCount& outSampleCount, Window* window = nullptr) const override;
 
 		/// <summary>
 		/// Clear the given window's render target.
 		/// </summary>
 		/// <param name="clearType">Type of buffer to clear.</param>
 		/// <param name="window">Window to clear. Default: Main Window.</param>
-		void Clear(ClearBufferType clearType, Window* window) override;
+		void Clear(ClearBufferType clearType, Window* window) const override;
 
 		/// <summary>
 		/// Set viewport size for the given window.
@@ -278,7 +278,7 @@ namespace TRAP::Graphics::API
 		/// <param name="maxDepth">New max depth value. Default: 1.0f.</param>
 		/// <param name="window">Window to set viewport for. Default: Main Window.</param>
 		void SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height, float minDepth,
-		                 float maxDepth, Window* window) override;
+		                 float maxDepth, Window* window) const override;
 		/// <summary>
 		/// Set scissor size for the given window.
 		/// </summary>
@@ -287,7 +287,7 @@ namespace TRAP::Graphics::API
 		/// <param name="width">New scissor width.</param>
 		/// <param name="height">New scissor height.</param>
 		/// <param name="window">Window to set scissor size for. Default: Main Window.</param>
-		void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height, Window* window) override;
+		void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height, Window* window) const override;
 
 		/// <summary>
 		/// Draw non-indexed, non-instanced geometry for the given window.
@@ -295,7 +295,7 @@ namespace TRAP::Graphics::API
 		/// <param name="vertexCount">Number of vertices to draw.</param>
 		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
-		void Draw(uint32_t vertexCount, uint32_t firstVertex, Window* window) override;
+		void Draw(uint32_t vertexCount, uint32_t firstVertex, Window* window) const override;
 		/// <summary>
 		/// Draw indexed, non-instanced geometry for the given window.
 		/// </summary>
@@ -304,7 +304,7 @@ namespace TRAP::Graphics::API
 		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		void DrawIndexed(uint32_t indexCount, uint32_t firstIndex, uint32_t firstVertex,
-		                 Window* window) override;
+		                 Window* window) const override;
 		/// <summary>
 		/// Draw non-indexed, instanced geometry for the given window.
 		/// </summary>
@@ -314,7 +314,7 @@ namespace TRAP::Graphics::API
 		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
-		                   uint32_t firstInstance, Window* window) override;
+		                   uint32_t firstInstance, Window* window) const override;
 		/// <summary>
 		/// Draw indexed, instanced geometry for the given window.
 		/// </summary>
@@ -326,7 +326,7 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
 		                          uint32_t firstIndex, uint32_t firstInstance,
-							      uint32_t firstVertex, Window* window) override;
+							      uint32_t firstVertex, Window* window) const override;
 
 		/// <summary>
 		/// Bind shader on the given window.
@@ -341,7 +341,7 @@ namespace TRAP::Graphics::API
 		/// <param name="layout">Layout of the vertex buffer.</param>
 		/// <param name="window">Window to bind the vertex buffer for. Default: Main Window.</param>
 		void BindVertexBuffer(const TRAP::Ref<Buffer>& vBuffer, const VertexBufferLayout& layout,
-		                      Window* window) override;
+		                      Window* window) const override;
 		/// <summary>
 		/// Bind an index buffer on the given window.
 		/// </summary>
@@ -349,7 +349,7 @@ namespace TRAP::Graphics::API
 		/// <param name="indexType">Data type used by the index buffer.</param>
 		/// <param name="window">Window to bind the vertex buffer for. Default: Main Window.</param>
 		void BindIndexBuffer(const TRAP::Ref<Buffer>& iBuffer, IndexType indexType,
-		                     Window* window ) override;
+		                     Window* window ) const override;
 		/// <summary>
 		/// Bind a descriptor set on the given window.
 		/// </summary>
@@ -357,7 +357,7 @@ namespace TRAP::Graphics::API
 		/// <param name="index">Index for which descriptor set to bind.</param>
 		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
 		/// <param name="window">Window to bind the descriptor set for. Default: Main Window.</param>
-		void BindDescriptorSet(DescriptorSet& dSet, uint32_t index, QueueType queueType, Window* window) override;
+		void BindDescriptorSet(DescriptorSet& dSet, uint32_t index, QueueType queueType, Window* window) const override;
 		/// <summary>
 		/// Bind push constant buffer data on the given window.
 		/// Note: There is an optimized function which uses the index into the RootSignature
@@ -367,7 +367,7 @@ namespace TRAP::Graphics::API
 		/// <param name="constantsData">Pointer to the constant buffer data.</param>
 		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
 		/// <param name="window">Window to bind the push constants for. Default: Main Window.</param>
-		void BindPushConstants(const char* name, const void* constantsData, QueueType queueType, Window* window) override;
+		void BindPushConstants(const char* name, const void* constantsData, QueueType queueType, Window* window) const override;
 		/// <summary>
 		/// Bind push constant buffer data on the given window.
 		/// </summary>
@@ -376,7 +376,7 @@ namespace TRAP::Graphics::API
 		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
 		/// <param name="window">Window to bind the push constants for. Default: Main Window.</param>
 		void BindPushConstantsByIndex(uint32_t paramIndex, const void* constantsData, QueueType queueType,
-		                              Window* window) override;
+		                              Window* window) const override;
 		/// <summary>
 		/// Bind render target(s) on the given window.
 		///
@@ -396,7 +396,7 @@ namespace TRAP::Graphics::API
 							  std::vector<uint32_t>* colorArraySlices,
 							  std::vector<uint32_t>* colorMipSlices,
 							  uint32_t depthArraySlice, uint32_t depthMipSlice,
-							  Window* window) override;
+							  Window* window) const override;
 		/// <summary>
 		/// Bind render target(s) on the given window.
 		///
@@ -416,7 +416,7 @@ namespace TRAP::Graphics::API
 							   std::vector<uint32_t>* colorArraySlices,
 							   std::vector<uint32_t>* colorMipSlices,
 							   uint32_t depthArraySlice, uint32_t depthMipSlice,
-							   Window* window) override;
+							   Window* window) const override;
 
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
@@ -425,7 +425,7 @@ namespace TRAP::Graphics::API
 		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
 		/// <param name="window">Window to add the barrier for. Default: Main Window.</param>
 		void ResourceBufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier, QueueType queueType,
-		                           Window* window) override;
+		                           Window* window) const override;
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
@@ -433,7 +433,7 @@ namespace TRAP::Graphics::API
 		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
 		/// <param name="window">Window to add the barriers for. Default: Main Window.</param>
 		void ResourceBufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
-									QueueType queueType, Window* window) override;
+									QueueType queueType, Window* window) const override;
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
@@ -441,7 +441,7 @@ namespace TRAP::Graphics::API
 		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
 		/// <param name="window">Window to add the barrier for. Default: Main Window.</param>
 		void ResourceTextureBarrier(const RendererAPI::TextureBarrier& textureBarrier, QueueType queueType,
-		                            Window* window) override;
+		                            Window* window) const override;
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
@@ -449,21 +449,21 @@ namespace TRAP::Graphics::API
 		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
 		/// <param name="window">Window to add the barriers for. Default: Main Window.</param>
 		void ResourceTextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
-									 QueueType queueType, Window* window) override;
+									 QueueType queueType, Window* window) const override;
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
 		/// <param name="renderTargetBarrier">Render target barrier.</param>
 		/// <param name="window">Window to add the barrier for. Default: Main Window.</param>
 		void ResourceRenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier,
-		                                 Window* window ) override;
+		                                 Window* window ) const override;
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
 		/// <param name="renderTargetBarriers">Render target barriers.</param>
 		/// <param name="window">Window to add the barriers for. Default: Main Window.</param>
 		void ResourceRenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers,
-								          Window* window) override;
+								          Window* window) const override;
 
 		/// <summary>
 		/// Retrieve the renderer title.
@@ -476,44 +476,44 @@ namespace TRAP::Graphics::API
 		/// </summary>
 		/// <param name="window">Window to retrieve VSync for. Default: Main Window.</param>
 		/// <returns>True if VSync is enabled, false otherwise.</returns>
-		bool GetVSync(Window* window) override;
+		bool GetVSync(Window* window) const override;
 
 		/// <summary>
 		/// Retrieve the currently used GPUs UUID.
 		/// </summary>
 		/// <returns>GPU's UUID.</returns>
-		std::array<uint8_t, 16> GetCurrentGPUUUID() override;
+		std::array<uint8_t, 16> GetCurrentGPUUUID() const override;
 		/// <summary>
 		/// Retrieve the name of the currently used GPU.
 		/// </summary>
 		/// <returns>GPU's name.</returns>
-		std::string GetCurrentGPUName() override;
+		std::string GetCurrentGPUName() const override;
 		/// <summary>
 		/// Retrieve a list of all supported GPUs.
 		/// The list contains the GPUs name and UUID.
 		/// </summary>
 		/// <returns>List of all supported GPUs.</returns>
-		std::vector<std::pair<std::string, std::array<uint8_t, 16>>> GetAllGPUs() override;
+		std::vector<std::pair<std::string, std::array<uint8_t, 16>>> GetAllGPUs() const override;
 
 		/// <summary>
 		/// Capture a screenshot of the last presented frame.
 		/// </summary>
 		/// <param name="window">Window to capture screenshot on. Default: Main Window.</param>
 		/// <returns>Captured screenshot as TRAP::Image on success, Black 1x1 TRAP::Image otherwise.</returns>
-		TRAP::Scope<TRAP::Image> CaptureScreenshot(Window* window) override;
+		TRAP::Scope<TRAP::Image> CaptureScreenshot(Window* window) const override;
 
 		/// <summary>
 		/// Initialize the internal rendering data of the given window.
 		/// </summary>
 		/// <param name="window">Window to initialize the internal rendering data for.</param>
-		void InitPerWindowData(Window* window) override;
+		void InitPerWindowData(Window* window) const override;
 		/// <summary>
 		/// Remove the internal rendering data of the given window.
 		/// </summary>
 		/// <param name="window">Window to remove the internal rendering data from.</param>
-		void RemovePerWindowData(Window* window) override;
+		void RemovePerWindowData(Window* window) const override;
 
-		void WaitIdle() override;
+		void WaitIdle() const override;
 
 		//Instance Extensions
 		static bool s_debugUtilsExtension;
@@ -734,7 +734,7 @@ namespace TRAP::Graphics::API
 		/// </summary>
 		/// <param name="physicalDevice">Physical device to use.</param>
 		/// <returns>List of device extensions.</returns>
-		static std::vector<std::string> SetupDeviceExtensions(VulkanPhysicalDevice* const physicalDevice);
+		static std::vector<std::string> SetupDeviceExtensions(VulkanPhysicalDevice* physicalDevice);
 
 		/// <summary>
 		/// Add the default resources to the renderer.

--- a/TRAP/src/Graphics/API/Vulkan/VulkanShaderReflection.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanShaderReflection.cpp
@@ -6,8 +6,8 @@
 #include "Graphics/API/SPIRVTools.h"
 #include "Utils/String/String.h"
 
-std::array<TRAP::Graphics::RendererAPI::DescriptorType,
-           static_cast<uint32_t>(TRAP::Graphics::API::SPIRVTools::ResourceType::RESOURCE_TYPE_COUNT)> SPIRVToDescriptorType =
+constexpr std::array<TRAP::Graphics::RendererAPI::DescriptorType,
+                     static_cast<uint32_t>(TRAP::Graphics::API::SPIRVTools::ResourceType::RESOURCE_TYPE_COUNT)> SPIRVToDescriptorType =
 {
 	TRAP::Graphics::RendererAPI::DescriptorType::Undefined, TRAP::Graphics::RendererAPI::DescriptorType::Undefined,
 	TRAP::Graphics::RendererAPI::DescriptorType::UniformBuffer,
@@ -23,8 +23,8 @@ std::array<TRAP::Graphics::RendererAPI::DescriptorType,
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::array<TRAP::Graphics::API::ShaderReflection::TextureDimension,
-           static_cast<uint32_t>(TRAP::Graphics::API::SPIRVTools::ResourceTextureDimension::RESOURCE_TEXTURE_DIMENSION_COUNT)> SPIRVToTextureDimension =
+constexpr std::array<TRAP::Graphics::API::ShaderReflection::TextureDimension,
+                     static_cast<uint32_t>(TRAP::Graphics::API::SPIRVTools::ResourceTextureDimension::RESOURCE_TEXTURE_DIMENSION_COUNT)> SPIRVToTextureDimension =
 {
 	TRAP::Graphics::API::ShaderReflection::TextureDimension::TextureDimUndefined,
 	TRAP::Graphics::API::ShaderReflection::TextureDimension::TextureDimUndefined,
@@ -41,14 +41,14 @@ std::array<TRAP::Graphics::API::ShaderReflection::TextureDimension,
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool FilterResource(const TRAP::Graphics::API::SPIRVTools::Resource& resource,
-                    const TRAP::Graphics::RendererAPI::ShaderStage currentStage)
+constexpr bool FilterResource(const TRAP::Graphics::API::SPIRVTools::Resource& resource,
+                              const TRAP::Graphics::RendererAPI::ShaderStage currentStage)
 {
 	bool filter = false;
 
 	//Check for invalid PushConstant
 	filter = filter || (resource.Type == TRAP::Graphics::API::SPIRVTools::ResourceType::PushConstant &&
-		resource.Size > TRAP::Graphics::RendererAPI::GPUSettings.MaxPushConstantSize);
+		                resource.Size > TRAP::Graphics::RendererAPI::GPUSettings.MaxPushConstantSize);
 
 	//Remove unused resources
 	filter = filter || (!resource.IsUsed);
@@ -66,7 +66,7 @@ bool FilterResource(const TRAP::Graphics::API::SPIRVTools::Resource& resource,
 //-------------------------------------------------------------------------------------------------------------------//
 
 TRAP::Graphics::API::ShaderReflection::ShaderReflection TRAP::Graphics::API::VkCreateShaderReflection(const std::vector<uint32_t>& shaderCode,
-                                                                                                      RendererAPI::ShaderStage shaderStage)
+                                                                                                      const RendererAPI::ShaderStage shaderStage)
 {
 	SPIRVTools::CrossCompiler cc(shaderCode.data(), static_cast<uint32_t>(shaderCode.size()));
 
@@ -92,7 +92,7 @@ TRAP::Graphics::API::ShaderReflection::ShaderReflection TRAP::Graphics::API::VkC
 			TP_WARN(TRAP::Log::ShaderSPIRVPrefix, "Found unused resource with name: ", resource.Name, "!");
 		}
 		if(resource.Type == TRAP::Graphics::API::SPIRVTools::ResourceType::PushConstant &&
-			resource.Size > TRAP::Graphics::RendererAPI::GPUSettings.MaxPushConstantSize)
+		   resource.Size > TRAP::Graphics::RendererAPI::GPUSettings.MaxPushConstantSize)
 		{
 			TRAP_ASSERT(false);
 			TP_ERROR(Log::ShaderSPIRVPrefix, "Found PushConstants with invalid size: ", resource.Size,
@@ -168,7 +168,7 @@ TRAP::Graphics::API::ShaderReflection::ShaderReflection TRAP::Graphics::API::VkC
 				resources[j].Type = SPIRVToDescriptorType[static_cast<uint32_t>(resource.Type)];
 				resources[j].Set = resource.Set;
 				resources[j].Reg = resource.Binding;
-				std::string lowerName = Utils::String::ToLower(resource.Name);
+				const std::string lowerName = Utils::String::ToLower(resource.Name);
 				if(lowerName.find("rootcbv") == std::string::npos &&
 				   lowerName.find("dynamic") == std::string::npos &&
 				   resources[j].Type != TRAP::Graphics::RendererAPI::DescriptorType::RWBuffer)

--- a/TRAP/src/Graphics/Buffers/IndexBuffer.h
+++ b/TRAP/src/Graphics/Buffers/IndexBuffer.h
@@ -197,7 +197,7 @@ void TRAP::Graphics::IndexBuffer::SetDataInternal(const T* indices, const uint64
 	desc.Buffer = m_indexBuffer;
 	desc.DstOffset = offset;
 	RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-	memcpy(desc.MappedData, indices, size);
+	std::copy_n(indices, size, static_cast<T*>(desc.MappedData));
 	RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_token);
 
 	if constexpr(std::is_same_v<T, uint16_t>)

--- a/TRAP/src/Graphics/Buffers/IndexBuffer.h
+++ b/TRAP/src/Graphics/Buffers/IndexBuffer.h
@@ -197,7 +197,7 @@ void TRAP::Graphics::IndexBuffer::SetDataInternal(const T* indices, const uint64
 	desc.Buffer = m_indexBuffer;
 	desc.DstOffset = offset;
 	RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-	std::copy_n(indices, size, static_cast<T*>(desc.MappedData));
+	std::copy_n(indices, size / sizeof(T), static_cast<T*>(desc.MappedData));
 	RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_token);
 
 	if constexpr(std::is_same_v<T, uint16_t>)

--- a/TRAP/src/Graphics/Buffers/StorageBuffer.cpp
+++ b/TRAP/src/Graphics/Buffers/StorageBuffer.cpp
@@ -75,7 +75,7 @@ void TRAP::Graphics::StorageBuffer::SetData(const void* data, const uint64_t siz
 		desc.Buffer = m_storageBuffers[i];
 		desc.DstOffset = offset;
 		RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-		std::memcpy(desc.MappedData, data, size);
+		memcpy(desc.MappedData, data, size);
 		RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_tokens[i]);
 	}
 	AwaitLoading();

--- a/TRAP/src/Graphics/Buffers/StorageBuffer.cpp
+++ b/TRAP/src/Graphics/Buffers/StorageBuffer.cpp
@@ -75,7 +75,7 @@ void TRAP::Graphics::StorageBuffer::SetData(const void* data, const uint64_t siz
 		desc.Buffer = m_storageBuffers[i];
 		desc.DstOffset = offset;
 		RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-		memcpy(desc.MappedData, data, size);
+		std::copy_n(static_cast<const uint8_t*>(data), size, static_cast<uint8_t*>(desc.MappedData));
 		RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_tokens[i]);
 	}
 	AwaitLoading();

--- a/TRAP/src/Graphics/Buffers/StorageBuffer.h
+++ b/TRAP/src/Graphics/Buffers/StorageBuffer.h
@@ -142,7 +142,7 @@ inline void TRAP::Graphics::StorageBuffer::GetData(const T* data, const uint64_t
 	desc.Buffer = m_storageBuffers[imageIndex];
 	desc.DstOffset = offset;
 	RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-	memcpy(data, desc.MappedData, size);
+	std::copy_n(static_cast<uint8_t*>(desc.MappedData), size, data);
 	RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_tokens[imageIndex]);
 }
 

--- a/TRAP/src/Graphics/Buffers/UniformBuffer.cpp
+++ b/TRAP/src/Graphics/Buffers/UniformBuffer.cpp
@@ -76,7 +76,7 @@ void TRAP::Graphics::UniformBuffer::SetData(const void* data, const uint64_t siz
 		desc.Buffer = m_uniformBuffers[i];
 		desc.DstOffset = offset;
 		RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-		std::memcpy(desc.MappedData, data, size);
+		memcpy(desc.MappedData, data, size);
 		RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_tokens[i]);
 	}
 	AwaitLoading();

--- a/TRAP/src/Graphics/Buffers/UniformBuffer.cpp
+++ b/TRAP/src/Graphics/Buffers/UniformBuffer.cpp
@@ -76,7 +76,7 @@ void TRAP::Graphics::UniformBuffer::SetData(const void* data, const uint64_t siz
 		desc.Buffer = m_uniformBuffers[i];
 		desc.DstOffset = offset;
 		RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-		memcpy(desc.MappedData, data, size);
+		std::copy_n(static_cast<const uint8_t*>(data), size, static_cast<uint8_t*>(desc.MappedData));
 		RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_tokens[i]);
 	}
 	AwaitLoading();

--- a/TRAP/src/Graphics/Buffers/VertexBuffer.cpp
+++ b/TRAP/src/Graphics/Buffers/VertexBuffer.cpp
@@ -91,7 +91,7 @@ void TRAP::Graphics::VertexBuffer::SetData(float* data, const uint64_t size, con
 	desc.Buffer = m_vertexBuffer;
 	desc.DstOffset = offset;
 	RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-	std::copy_n(data, size, static_cast<float*>(desc.MappedData));
+	std::copy_n(data, size / sizeof(float), static_cast<float*>(desc.MappedData));
 	RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_token);
 }
 

--- a/TRAP/src/Graphics/Buffers/VertexBuffer.cpp
+++ b/TRAP/src/Graphics/Buffers/VertexBuffer.cpp
@@ -91,7 +91,7 @@ void TRAP::Graphics::VertexBuffer::SetData(float* data, const uint64_t size, con
 	desc.Buffer = m_vertexBuffer;
 	desc.DstOffset = offset;
 	RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-	memcpy(desc.MappedData, static_cast<void*>(data), size);
+	std::copy_n(data, size, static_cast<float*>(desc.MappedData));
 	RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_token);
 }
 

--- a/TRAP/src/Graphics/Buffers/VertexBuffer.cpp
+++ b/TRAP/src/Graphics/Buffers/VertexBuffer.cpp
@@ -91,7 +91,7 @@ void TRAP::Graphics::VertexBuffer::SetData(float* data, const uint64_t size, con
 	desc.Buffer = m_vertexBuffer;
 	desc.DstOffset = offset;
 	RendererAPI::GetResourceLoader()->BeginUpdateResource(desc);
-	std::memcpy(desc.MappedData, static_cast<void*>(data), size);
+	memcpy(desc.MappedData, static_cast<void*>(data), size);
 	RendererAPI::GetResourceLoader()->EndUpdateResource(desc, &m_token);
 }
 

--- a/TRAP/src/Graphics/Buffers/VertexBufferLayout.cpp
+++ b/TRAP/src/Graphics/Buffers/VertexBufferLayout.cpp
@@ -1,33 +1,6 @@
 #include "TRAPPCH.h"
 #include "VertexBufferLayout.h"
 
-uint32_t TRAP::Graphics::ShaderDataTypeSize(const ShaderDataType type)
-{
-	switch (type)
-	{
-	case ShaderDataType::Float:  return 4;
-	case ShaderDataType::Float2: return 4 * 2;
-	case ShaderDataType::Float3: return 4 * 3;
-	case ShaderDataType::Float4: return 4 * 4;
-
-	case ShaderDataType::Mat3:   return 4 * 3 * 3;
-	case ShaderDataType::Mat4:   return 4 * 4 * 4;
-
-	case ShaderDataType::Int:    return 4;
-	case ShaderDataType::Int2:   return 4 * 2;
-	case ShaderDataType::Int3:   return 4 * 3;
-	case ShaderDataType::Int4:   return 4 * 4;
-
-	case ShaderDataType::Bool:   return 1;
-
-	default:
-		TRAP_ASSERT(false, "Unknown shader data type!");
-		return 0;
-	}
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Graphics::VertexBufferElement::VertexBufferElement(const ShaderDataType type, std::string name,
                                                          const bool normalized)
 	: Name(std::move(name)), Type(type), Size(ShaderDataTypeSize(type)), Offset(0), Normalized(normalized)

--- a/TRAP/src/Graphics/Buffers/VertexBufferLayout.h
+++ b/TRAP/src/Graphics/Buffers/VertexBufferLayout.h
@@ -24,7 +24,7 @@ namespace TRAP::Graphics
 	/// </summary>
 	/// <param name="type">Shader data type.</param>
 	/// <returns>Byte size of the shader data type.</returns>
-	uint32_t ShaderDataTypeSize(ShaderDataType type);
+	constexpr uint32_t ShaderDataTypeSize(ShaderDataType type);
 
 	/// <summary>
 	/// Struct used to describe a single vertex attribute.
@@ -98,6 +98,33 @@ namespace TRAP::Graphics
 		std::vector<VertexBufferElement> m_elements;
 		uint32_t m_stride = 0;
 	};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr uint32_t TRAP::Graphics::ShaderDataTypeSize(const ShaderDataType type)
+{
+	switch (type)
+	{
+	case ShaderDataType::Float:  return 4;
+	case ShaderDataType::Float2: return 4 * 2;
+	case ShaderDataType::Float3: return 4 * 3;
+	case ShaderDataType::Float4: return 4 * 4;
+
+	case ShaderDataType::Mat3:   return 4 * 3 * 3;
+	case ShaderDataType::Mat4:   return 4 * 4 * 4;
+
+	case ShaderDataType::Int:    return 4;
+	case ShaderDataType::Int2:   return 4 * 2;
+	case ShaderDataType::Int3:   return 4 * 3;
+	case ShaderDataType::Int4:   return 4 * 4;
+
+	case ShaderDataType::Bool:   return 1;
+
+	default:
+		TRAP_ASSERT(false, "Unknown shader data type!");
+		return 0;
+	}
 }
 
 #endif /*TRAP_VERTEXBUFFERLAYOUT_H*/

--- a/TRAP/src/Graphics/Cameras/Orthographic/OrthographicCameraController.cpp
+++ b/TRAP/src/Graphics/Cameras/Orthographic/OrthographicCameraController.cpp
@@ -239,7 +239,7 @@ const TRAP::Graphics::OrthographicCameraBounds& TRAP::Graphics::OrthographicCame
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::Graphics::OrthographicCameraController::OnMouseScroll(Events::MouseScrollEvent& e)
+bool TRAP::Graphics::OrthographicCameraController::OnMouseScroll(const Events::MouseScrollEvent& e)
 {
 	TP_PROFILE_FUNCTION();
 
@@ -254,7 +254,7 @@ bool TRAP::Graphics::OrthographicCameraController::OnMouseScroll(Events::MouseSc
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::Graphics::OrthographicCameraController::OnFrameBufferResize(Events::FrameBufferResizeEvent& e)
+bool TRAP::Graphics::OrthographicCameraController::OnFrameBufferResize(const Events::FrameBufferResizeEvent& e)
 {
 	TP_PROFILE_FUNCTION();
 

--- a/TRAP/src/Graphics/Cameras/Orthographic/OrthographicCameraController.h
+++ b/TRAP/src/Graphics/Cameras/Orthographic/OrthographicCameraController.h
@@ -25,7 +25,7 @@ namespace TRAP::Graphics
 		float GetHeight() const;
 	};
 
-class OrthographicCameraController
+	class OrthographicCameraController
 	{
 	public:
 		/// <summary>
@@ -142,7 +142,7 @@ class OrthographicCameraController
 		/// </sumary>
 		/// <param name="e">Mouse scroll event.</param>
 		/// <returns>False.</returns>
-		bool OnMouseScroll(Events::MouseScrollEvent& e);
+		bool OnMouseScroll(const Events::MouseScrollEvent& e);
 		/// <summary>
 		/// Event handler for framebuffer resize event.
 		///
@@ -150,7 +150,7 @@ class OrthographicCameraController
 		/// </sumary>
 		/// <param name="e">Framebuffer resize event.</param>
 		/// <returns>False.</returns>
-		bool OnFrameBufferResize(Events::FrameBufferResizeEvent& e);
+		bool OnFrameBufferResize(const Events::FrameBufferResizeEvent& e);
 
 		float m_aspectRatio;
 		float m_zoomLevel = 1.0f;

--- a/TRAP/src/Graphics/Renderer.cpp
+++ b/TRAP/src/Graphics/Renderer.cpp
@@ -53,7 +53,7 @@ void TRAP::Graphics::Renderer::Shutdown()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Graphics::Renderer::GetTitle()
+std::string TRAP::Graphics::Renderer::GetTitle()
 {
 	return RendererAPI::GetRenderer()->GetTitle();
 }

--- a/TRAP/src/Graphics/Renderer.h
+++ b/TRAP/src/Graphics/Renderer.h
@@ -30,7 +30,7 @@ namespace TRAP::Graphics
 		/// Example when using Vulkan: "[Vulkan 1.1.108]"
 		/// </summary>
 		/// <returns>Renderer title.</returns>
-		static const std::string& GetTitle();
+		static std::string GetTitle();
 		/// <summary>
 		/// Retrieve the frames per second.
 		/// </summary>

--- a/TRAP/src/Graphics/Renderer2D.cpp
+++ b/TRAP/src/Graphics/Renderer2D.cpp
@@ -190,32 +190,32 @@ void TRAP::Graphics::Renderer2D::EndScene()
 	TP_PROFILE_FUNCTION();
 
 	const uint32_t dataSize = (s_data.QuadVertexBufferPtr - s_data.QuadVertexBufferBase) * sizeof(QuadVertex);
-	if (dataSize)
+	if(!dataSize)
+		return;
+
+	//Update Vertices
+	s_data.QuadVertexBuffer->SetData(reinterpret_cast<float*>(s_data.QuadVertexBufferBase), dataSize);
+	s_data.QuadVertexBuffer->AwaitLoading();
+
+	//Use dynamic shader resources
+	for(uint32_t i = 0; i < Renderer2DData::MaxTextureSlots; ++i)
 	{
-		//Update Vertices
-		s_data.QuadVertexBuffer->SetData(reinterpret_cast<float*>(s_data.QuadVertexBufferBase), dataSize);
-		s_data.QuadVertexBuffer->AwaitLoading();
-
-		//Use dynamic shader resources
-		for(uint32_t i = 0; i < Renderer2DData::MaxTextureSlots; ++i)
-		{
-		    if(!s_data.TextureSlots[i])
-				s_data.TextureSlots[i] = s_data.WhiteTexture.get();
-		}
-		s_data.TextureShader->UseTextures(1, 1, s_data.TextureSlots);
-		s_data.TextureShader->UseUBO(1, 0, s_data.CameraUniformBuffer.get());
-
-		//Use Vertex & Index Buffer
-		s_data.QuadVertexBuffer->Use();
-		s_data.QuadIndexBuffer->Use();
-
-		//Use Shader
-		s_data.TextureShader->Use();
-
-		RenderCommand::DrawIndexed(s_data.QuadIndexCount);
-
-		s_data.Stats.DrawCalls++;
+		if(!s_data.TextureSlots[i])
+			s_data.TextureSlots[i] = s_data.WhiteTexture.get();
 	}
+	s_data.TextureShader->UseTextures(1, 1, s_data.TextureSlots);
+	s_data.TextureShader->UseUBO(1, 0, s_data.CameraUniformBuffer.get());
+
+	//Use Vertex & Index Buffer
+	s_data.QuadVertexBuffer->Use();
+	s_data.QuadIndexBuffer->Use();
+
+	//Use Shader
+	s_data.TextureShader->Use();
+
+	RenderCommand::DrawIndexed(s_data.QuadIndexCount);
+
+	s_data.Stats.DrawCalls++;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/Renderer2D.cpp
+++ b/TRAP/src/Graphics/Renderer2D.cpp
@@ -189,8 +189,7 @@ void TRAP::Graphics::Renderer2D::EndScene()
 {
 	TP_PROFILE_FUNCTION();
 
-	const uint32_t dataSize = static_cast<uint32_t>(reinterpret_cast<uint8_t*>(s_data.QuadVertexBufferPtr) -
-		                                            reinterpret_cast<uint8_t*>(s_data.QuadVertexBufferBase));
+	const uint32_t dataSize = (s_data.QuadVertexBufferPtr - s_data.QuadVertexBufferBase) * sizeof(QuadVertex);
 	if (dataSize)
 	{
 		//Update Vertices

--- a/TRAP/src/Graphics/Renderer2D.cpp
+++ b/TRAP/src/Graphics/Renderer2D.cpp
@@ -108,7 +108,7 @@ void TRAP::Graphics::Renderer2D::Init()
 	                                                   sizeof(Renderer2DData::UniformCamera),
 		                                               UpdateFrequency::Dynamic);
 
-	s_data.TextureShader = Shader::CreateFromSource("Renderer2D", Embed::Renderer2DShader);
+	s_data.TextureShader = Shader::CreateFromSource("Renderer2D", std::string(Embed::Renderer2DShader));
 	const Scope<Image> whiteImage = Image::LoadFromMemory(2, 2, Image::ColorFormat::RGBA,
 	                                                      std::vector<uint8_t>{255, 255, 255, 255,
 																			   255, 255, 255, 255,

--- a/TRAP/src/Graphics/Shaders/Shader.cpp
+++ b/TRAP/src/Graphics/Shaders/Shader.cpp
@@ -324,9 +324,7 @@ bool TRAP::Graphics::Shader::CheckSPIRVMagicNumber(const std::filesystem::path& 
 	//0x07230203
 
 	uint32_t magicNumber = 0;
-	file.read(reinterpret_cast<char*>(&magicNumber), sizeof(uint32_t)); //Number of SubShaders
-	file.read(reinterpret_cast<char*>(&magicNumber), sizeof(uint32_t)); //Size of the current SubShader in uint32_ts
-	file.read(reinterpret_cast<char*>(&magicNumber), sizeof(uint32_t)); //Type of the current SubShader
+	file.seekg(sizeof(uint32_t) * 3, std::ios::cur); //Skip 3 uint32_ts
 	file.read(reinterpret_cast<char*>(&magicNumber), sizeof(uint32_t)); //SPIRV Magic Number
 	file.close();
 

--- a/TRAP/src/Graphics/Shaders/Shader.cpp
+++ b/TRAP/src/Graphics/Shaders/Shader.cpp
@@ -1,7 +1,7 @@
 #include "TRAPPCH.h"
 #include "Shader.h"
 
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Graphics/API/Vulkan/Objects/VulkanShader.h"
 #include "Utils/String/String.h"
 
@@ -66,13 +66,13 @@ bool TRAP::Graphics::Shader::Reload()
 
 	if (!isSPIRV)
 	{
-		const auto loadedData = FS::ReadTextFile(m_filepath);
+		const auto loadedData = FileSystem::ReadTextFile(m_filepath);
 		if(loadedData)
 			glslSource = *loadedData;
 	}
 	else
 	{
-		const auto loadedData = FS::ReadFile(m_filepath);
+		const auto loadedData = FileSystem::ReadFile(m_filepath);
 		if(loadedData)
 			SPIRVSource = Convert8To32(*loadedData);
 	}
@@ -202,7 +202,7 @@ TRAP::Scope<TRAP::Graphics::Shader> TRAP::Graphics::Shader::CreateFromFile(const
 		//Hot reloading
 		if(TRAP::Application::IsHotReloadingEnabled())
 		{
-			const auto folderPath = FS::GetFolderPath(filePath);
+			const auto folderPath = FileSystem::GetFolderPath(filePath);
 			if(folderPath)
 				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(*folderPath);
 		}
@@ -228,7 +228,7 @@ TRAP::Scope<TRAP::Graphics::Shader> TRAP::Graphics::Shader::CreateFromFile(const
 
 	RendererAPI::BinaryShaderDesc desc{};
 	Scope<Shader> failShader = nullptr;
-	const auto name = FS::GetFileName(filePath);
+	const auto name = FileSystem::GetFileName(filePath);
 	if(!name)
 	{
 		TRAP_ASSERT(false, "Name is empty!");
@@ -248,7 +248,7 @@ TRAP::Scope<TRAP::Graphics::Shader> TRAP::Graphics::Shader::CreateFromFile(const
 		//Hot reloading
 		if(TRAP::Application::IsHotReloadingEnabled())
 		{
-			const auto folderPath = FS::GetFolderPath(filePath);
+			const auto folderPath = FileSystem::GetFolderPath(filePath);
 			if(folderPath)
 				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(*folderPath);
 		}
@@ -309,7 +309,7 @@ TRAP::Scope<TRAP::Graphics::Shader> TRAP::Graphics::Shader::CreateFromSource(con
 bool TRAP::Graphics::Shader::CheckSPIRVMagicNumber(const std::filesystem::path& filePath)
 {
 	//Check SPIRV Magic Number
-	if (!FS::FileOrFolderExists(filePath))
+	if (!FileSystem::FileOrFolderExists(filePath))
 		return false;
 
 	std::ifstream file(filePath, std::ios::binary);
@@ -797,7 +797,7 @@ TRAP::Graphics::RendererAPI::BinaryShaderDesc TRAP::Graphics::Shader::LoadSPIRV(
 
 bool TRAP::Graphics::Shader::IsFileEndingSupported(const std::filesystem::path& filePath)
 {
-	const auto fileEnding = FS::GetFileEnding(filePath);
+	const auto fileEnding = FileSystem::GetFileEnding(filePath);
 	if(!fileEnding)
 		return false;
 
@@ -840,13 +840,13 @@ bool TRAP::Graphics::Shader::PreInit(const std::string& name, const std::filesys
 
 		if (!isSPIRV)
 		{
-			const auto loadedData = FS::ReadTextFile(filePath);
+			const auto loadedData = FileSystem::ReadTextFile(filePath);
 			if(loadedData)
 				glslSource = *loadedData;
 		}
 		else
 		{
-			const auto loadedData = FS::ReadFile(filePath);
+			const auto loadedData = FileSystem::ReadFile(filePath);
 			if(loadedData)
 				SPIRVSource = Convert8To32(*loadedData);
 		}

--- a/TRAP/src/Graphics/Shaders/Shader.cpp
+++ b/TRAP/src/Graphics/Shaders/Shader.cpp
@@ -286,7 +286,7 @@ TRAP::Scope<TRAP::Graphics::Shader> TRAP::Graphics::Shader::CreateFromSource(con
 		return nullptr;
 	}
 
-	RendererAPI::BinaryShaderDesc desc = ConvertGLSLToSPIRV(shaders, shaderStages);
+	const RendererAPI::BinaryShaderDesc desc = ConvertGLSLToSPIRV(shaders, shaderStages);
 	if (desc.Stages == RendererAPI::ShaderStage::None)
 		return nullptr;
 
@@ -360,13 +360,13 @@ bool TRAP::Graphics::Shader::PreProcessGLSL(const std::string& glslSource,
 											const std::vector<Macro>* userMacros)
 {
 	RendererAPI::ShaderStage currentShaderStage = RendererAPI::ShaderStage::None;
-	std::vector<std::string> lines = Utils::String::GetLines(glslSource);
+	const std::vector<std::string> lines = Utils::String::GetLines(glslSource);
 
 	//Go through every line of the shader source
 	for(std::size_t i = 0; i < lines.size(); ++i)
 	{
 		//Optimization lines converted to lower case
-		std::string lowerLine = Utils::String::ToLower(lines[i]);
+		const std::string lowerLine = Utils::String::ToLower(lines[i]);
 
 		//Search for a shader type tag
 		if(Utils::String::StartsWith(lowerLine, "#shader"))
@@ -415,7 +415,7 @@ bool TRAP::Graphics::Shader::PreProcessGLSL(const std::string& glslSource,
 				{RendererAPI::ShaderStage::RayTracing, 6}
 			};
 
-			auto it = stageToIndex.find(currentShaderStage);
+			const auto it = stageToIndex.find(currentShaderStage);
 			if(it != stageToIndex.end())
 			{
 				if(currentShaderStage == RendererAPI::ShaderStage::RayTracing)

--- a/TRAP/src/Graphics/Shaders/Shader.cpp
+++ b/TRAP/src/Graphics/Shaders/Shader.cpp
@@ -316,7 +316,7 @@ bool TRAP::Graphics::Shader::CheckSPIRVMagicNumber(const std::filesystem::path& 
 
 	if(!file.is_open())
 	{
-		TP_ERROR(Log::FileSystemPrefix, "Couldn't open file: ", filePath.generic_u8string());
+		TP_ERROR(Log::FileSystemPrefix, "Couldn't open file: ", filePath.u8string());
 		return false;
 	}
 
@@ -814,7 +814,7 @@ bool TRAP::Graphics::Shader::IsFileEndingSupported(const std::filesystem::path& 
 
 	if(!supportedFormat)
 	{
-		TP_ERROR(Log::ShaderPrefix, "File: \"", filePath.generic_u8string(), "\" suffix is not supported!");
+		TP_ERROR(Log::ShaderPrefix, "File: \"", filePath.u8string(), "\" suffix is not supported!");
 		TP_WARN(Log::ShaderPrefix, "Skipping unrecognized file");
 		return false;
 	}

--- a/TRAP/src/Graphics/Shaders/Shader.cpp
+++ b/TRAP/src/Graphics/Shaders/Shader.cpp
@@ -372,22 +372,22 @@ bool TRAP::Graphics::Shader::PreProcessGLSL(const std::string& glslSource,
 		if(Utils::String::StartsWith(lowerLine, "#shader"))
 		{
 			//Detect shader type
-			if (Utils::String::FindToken(lowerLine, "vertex"))
+			if (lowerLine.find("vertex") != std::string::npos)
 				currentShaderStage = RendererAPI::ShaderStage::Vertex;
-			else if (Utils::String::FindToken(lowerLine, "fragment") ||
-				     Utils::String::FindToken(lowerLine, "pixel"))
+			else if (lowerLine.find("fragment") != std::string::npos ||
+				     lowerLine.find("pixel") != std::string::npos)
 				currentShaderStage = RendererAPI::ShaderStage::Fragment;
-			else if (Utils::String::FindToken(lowerLine, "geometry"))
+			else if (lowerLine.find("geometry") != std::string::npos)
 				currentShaderStage = RendererAPI::ShaderStage::Geometry;
-			else if (Utils::String::FindToken(lowerLine, "tessellation"))
+			else if (lowerLine.find("tessellation") != std::string::npos)
 			{
 				//Either Control or Evaluation
-				if (Utils::String::FindToken(lowerLine, "control"))
+				if (lowerLine.find("control") != std::string::npos)
 					currentShaderStage = RendererAPI::ShaderStage::TessellationControl;
-				else if (Utils::String::FindToken(lowerLine, "evaluation"))
+				else if (lowerLine.find("evaluation") != std::string::npos)
 					currentShaderStage = RendererAPI::ShaderStage::TessellationEvaluation;
 			}
-			else if (Utils::String::FindToken(lowerLine, "compute"))
+			else if (lowerLine.find("compute") != std::string::npos)
 				currentShaderStage = RendererAPI::ShaderStage::Compute;
 			//TODO RayTracing Shaders i.e. "RayGen" "AnyHit" "ClosestHit" "Miss" "Intersection" ("Callable")
 
@@ -400,7 +400,7 @@ bool TRAP::Graphics::Shader::PreProcessGLSL(const std::string& glslSource,
 
 			shaderStages |= currentShaderStage;
 		}
-		else if(Utils::String::FindToken(lowerLine, "#version")) //Check for unnecessary "#version" define
+		else if(lowerLine.find("#version") != std::string::npos) //Check for unnecessary "#version" define
 			TP_WARN(Log::ShaderGLSLPrefix, "Found tag: \"", lines[i], "\" this is unnecessary! Skipping line: ", i);
 		else if(currentShaderStage != RendererAPI::ShaderStage::None) //Add shader code to detected shader stage
 		{

--- a/TRAP/src/Graphics/Shaders/Shader.cpp
+++ b/TRAP/src/Graphics/Shaders/Shader.cpp
@@ -122,7 +122,7 @@ bool TRAP::Graphics::Shader::Reload()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Graphics::Shader::GetName() const
+std::string TRAP::Graphics::Shader::GetName() const
 {
 	TP_PROFILE_FUNCTION();
 
@@ -131,7 +131,7 @@ const std::string& TRAP::Graphics::Shader::GetName() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::filesystem::path& TRAP::Graphics::Shader::GetFilePath() const
+std::filesystem::path TRAP::Graphics::Shader::GetFilePath() const
 {
 	TP_PROFILE_FUNCTION();
 

--- a/TRAP/src/Graphics/Shaders/Shader.h
+++ b/TRAP/src/Graphics/Shaders/Shader.h
@@ -128,7 +128,7 @@ namespace TRAP::Graphics
 		/// <param name="texture">Texture to use.</param>
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseTexture(uint32_t set, uint32_t binding, TRAP::Graphics::Texture* const texture,
-		                        Window* window = nullptr) = 0;
+		                        Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Use multiple textures with this shader on the given window.
 		/// </summary>
@@ -138,7 +138,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseTextures(uint32_t set, uint32_t binding,
 		                         const std::vector<TRAP::Graphics::Texture*>& textures,
-								 Window* window = nullptr) = 0;
+								 Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Use sampler with this shader on the given window.
 		/// </summary>
@@ -147,7 +147,7 @@ namespace TRAP::Graphics
 		/// <param name="sampler">Sampler to use.</param>
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseSampler(uint32_t set, uint32_t binding, TRAP::Graphics::Sampler* const sampler,
-		                        Window* window = nullptr) = 0;
+		                        Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Use multiple samplers with this shader on the given window.
 		/// </summary>
@@ -157,7 +157,7 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseSamplers(uint32_t set, uint32_t binding,
 		                         const std::vector<TRAP::Graphics::Sampler*>& samplers,
-								 Window* window = nullptr) = 0;
+								 Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Use uniform buffer object with this shader on the given window.
 		/// </summary>
@@ -168,7 +168,7 @@ namespace TRAP::Graphics
 		/// <param name="offset">Offset of the UBO.</param>
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseUBO(uint32_t set, uint32_t binding, TRAP::Graphics::UniformBuffer* const uniformBuffer,
-							uint64_t size = 0, uint64_t offset = 0, Window* window = nullptr) = 0;
+							uint64_t size = 0, uint64_t offset = 0, Window* window = nullptr) const = 0;
 		/// <summary>
 		/// Use shader storage buffer object with this shader on the given window.
 		/// </summary>
@@ -178,7 +178,7 @@ namespace TRAP::Graphics
 		/// <param name="size">Size of the SSBO.</param>
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseSSBO(uint32_t set, uint32_t binding, TRAP::Graphics::StorageBuffer* const storageBuffer,
-							 uint64_t size = 0, Window* window = nullptr) = 0;
+							 uint64_t size = 0, Window* window = nullptr) const = 0;
 
 		/// <summary>
 		/// Retrieve the shaders thread count per work group.

--- a/TRAP/src/Graphics/Shaders/Shader.h
+++ b/TRAP/src/Graphics/Shaders/Shader.h
@@ -77,13 +77,13 @@ namespace TRAP::Graphics
 		/// Retrieve the name of the shader.
 		/// </summary>
 		/// <returns>Name of the shader.</returns>
-		const std::string& GetName() const;
+		std::string GetName() const;
 
 		/// <summary>
 		/// Retrieve the file path of the shader.
 		/// </summary>
 		/// <returns>File path of the shader.</returns>
-		const std::filesystem::path& GetFilePath() const;
+		std::filesystem::path GetFilePath() const;
 
 		/// <summary>
 		/// Retrieve the shader stages of the shader.

--- a/TRAP/src/Graphics/Shaders/ShaderManager.cpp
+++ b/TRAP/src/Graphics/Shaders/ShaderManager.cpp
@@ -176,7 +176,7 @@ TRAP::Graphics::Shader* TRAP::Graphics::ShaderManager::Reload(const std::string&
 		}
 
 		TP_WARN(Log::ShaderManagerPrefix, "Couldn't find shader: \"",
-		        std::filesystem::path(nameOrPath).generic_u8string(), "\" to reload.");
+		        std::filesystem::path(nameOrPath).u8string(), "\" to reload.");
 	}
 
 	return nullptr;

--- a/TRAP/src/Graphics/Shaders/ShaderManager.cpp
+++ b/TRAP/src/Graphics/Shaders/ShaderManager.cpp
@@ -1,7 +1,7 @@
 #include "TRAPPCH.h"
 #include "ShaderManager.h"
 
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -166,7 +166,7 @@ TRAP::Graphics::Shader* TRAP::Graphics::ShaderManager::Reload(const std::string&
 	{
 		for (const auto& [name, shader] : Shaders)
 		{
-			if (FS::IsPathEquivalent(nameOrPath, shader->GetFilePath()))
+			if (FileSystem::IsPathEquivalent(nameOrPath, shader->GetFilePath()))
 			{
 				if(shader->Reload())
 					TP_INFO(Log::ShaderManagerPrefix, "Reloaded: \"", nameOrPath, "\"");
@@ -236,7 +236,7 @@ bool TRAP::Graphics::ShaderManager::ExistsPath(const std::filesystem::path& path
 {
 	for(const auto& [name, shader] : Shaders)
 	{
-		if (FS::IsPathEquivalent(shader->GetFilePath(), path))
+		if (FileSystem::IsPathEquivalent(shader->GetFilePath(), path))
 			return true;
 	}
 

--- a/TRAP/src/Graphics/Textures/Texture.cpp
+++ b/TRAP/src/Graphics/Textures/Texture.cpp
@@ -1073,7 +1073,7 @@ TRAP::Scope<TRAP::Image> TRAP::Graphics::Texture::Rotate90CounterClockwise(const
 	{
 		std::vector<float> rotated(static_cast<std::size_t>(img->GetWidth()) * img->GetHeight() *
 								   static_cast<std::size_t>(img->GetColorFormat()));
-		std::memcpy(rotated.data(), img->GetPixelData(), img->GetPixelDataSize());
+		memcpy(rotated.data(), img->GetPixelData(), img->GetPixelDataSize());
 		for(uint32_t x = 0; x < img->GetWidth(); ++x)
 		{
 			for(uint32_t y = 0; y < img->GetHeight(); ++y)
@@ -1099,7 +1099,7 @@ TRAP::Scope<TRAP::Image> TRAP::Graphics::Texture::Rotate90CounterClockwise(const
 	if(img->GetBitsPerChannel() == 16)
 	{
 		std::vector<uint16_t> rotated(static_cast<std::size_t>(img->GetWidth()) * img->GetHeight() * static_cast<std::size_t>(img->GetColorFormat()));
-		std::memcpy(rotated.data(), img->GetPixelData(), img->GetPixelDataSize());
+		memcpy(rotated.data(), img->GetPixelData(), img->GetPixelDataSize());
 		for(uint32_t x = 0; x < img->GetWidth(); ++x)
 		{
 			for(uint32_t y = 0; y < img->GetHeight(); ++y)
@@ -1125,7 +1125,7 @@ TRAP::Scope<TRAP::Image> TRAP::Graphics::Texture::Rotate90CounterClockwise(const
 
 	std::vector<uint8_t> rotated(static_cast<std::size_t>(img->GetWidth()) * img->GetHeight() *
 								 static_cast<std::size_t>(img->GetColorFormat()));
-	std::memcpy(rotated.data(), img->GetPixelData(), img->GetPixelDataSize());
+	memcpy(rotated.data(), img->GetPixelData(), img->GetPixelDataSize());
 	for(uint32_t x = 0; x < img->GetWidth(); ++x)
 	{
 		for(uint32_t y = 0; y < img->GetHeight(); ++y)

--- a/TRAP/src/Graphics/Textures/Texture.cpp
+++ b/TRAP/src/Graphics/Textures/Texture.cpp
@@ -14,7 +14,8 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromFiles(st
 
 	if(name.empty())
 	{
-		TP_ERROR(Log::TexturePrefix, "Invalid name!");
+		TRAP_ASSERT(false, "Name is empty!");
+		TP_ERROR(Log::TexturePrefix, "Name is empty!");
 		return nullptr;
 	}
 
@@ -31,10 +32,11 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromFiles(st
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				if(path.empty())
+				const auto folderPath = FS::GetFolderPath(path);
+				if(!folderPath)
 					continue;
 
-				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(FS::GetFolderPath(path));
+				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(*folderPath);
 			}
 		}
 
@@ -96,10 +98,11 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromFile(std
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				if(path.empty())
+				const auto folderPath = FS::GetFolderPath(path);
+				if(!folderPath)
 					continue;
 
-				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(FS::GetFolderPath(path));
+				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(*folderPath);
 			}
 		}
 
@@ -141,7 +144,13 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromFile(std
 
 	TP_PROFILE_FUNCTION();
 
-	const std::string name = FS::GetFileName(filepath);
+	const auto name = FS::GetFileName(filepath);
+	if(!name)
+	{
+		TRAP_ASSERT(false, "Name is empty!");
+		TP_ERROR(Log::TexturePrefix, "Name is empty!");
+		return nullptr;
+	}
 
 	TRAP::Scope<Texture> texture = nullptr;
 
@@ -149,17 +158,18 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromFile(std
 	{
 	case RenderAPI::Vulkan:
 	{
-		texture = TRAP::MakeScope<API::VulkanTexture>(std::move(name), std::move(filepath), type, cubeFormat);
+		texture = TRAP::MakeScope<API::VulkanTexture>(std::move(*name), std::move(filepath), type, cubeFormat);
 
 		//Hot Reloading
 		if(TRAP::Application::IsHotReloadingEnabled())
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				if(path.empty())
+				const auto folderPath = FS::GetFolderPath(path);
+				if(!folderPath)
 					continue;
 
-				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(FS::GetFolderPath(path));
+				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(*folderPath);
 			}
 		}
 
@@ -250,10 +260,11 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromImages(s
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				if(path.empty())
+				const auto folderPath = FS::GetFolderPath(path);
+				if(!folderPath)
 					continue;
 
-				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(FS::GetFolderPath(path));
+				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(*folderPath);
 			}
 		}
 
@@ -340,10 +351,11 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromImage(st
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				if(path.empty())
+				const auto folderPath = FS::GetFolderPath(path);
+				if(!folderPath)
 					continue;
 
-				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(FS::GetFolderPath(path));
+				TRAP::Application::GetHotReloadingFileWatcher()->AddFolder(*folderPath);
 			}
 		}
 

--- a/TRAP/src/Graphics/Textures/Texture.cpp
+++ b/TRAP/src/Graphics/Textures/Texture.cpp
@@ -801,15 +801,16 @@ void TRAP::Graphics::Texture::Update(const void* data, const uint32_t sizeInByte
 	updateDesc.MipLevel = mipLevel;
 	updateDesc.ArrayLayer = arrayLayer;
 	TRAP::Graphics::RendererAPI::GetResourceLoader()->BeginUpdateResource(updateDesc);
-	if(updateDesc.DstRowStride == updateDesc.SrcRowStride) //Single memcpy is enough
-		memcpy(updateDesc.MappedData, data, updateDesc.RowCount * updateDesc.SrcRowStride);
+	if(updateDesc.DstRowStride == updateDesc.SrcRowStride) //Single copy is enough
+		std::copy_n(static_cast<const uint8_t*>(data), updateDesc.RowCount * updateDesc.SrcRowStride,
+		            static_cast<uint8_t*>(updateDesc.MappedData));
 	else //Needs row by row copy
 	{
 		for(std::size_t r = 0; r < updateDesc.RowCount; ++r)
 		{
-			memcpy(updateDesc.MappedData + r * updateDesc.DstRowStride,
-				   static_cast<const uint8_t*>(data) + r * updateDesc.SrcRowStride,
-				   updateDesc.SrcRowStride);
+			std::copy_n(static_cast<const uint8_t*>(data) + r * updateDesc.SrcRowStride,
+			            updateDesc.SrcRowStride,
+						static_cast<uint8_t*>(updateDesc.MappedData) + r * updateDesc.DstRowStride);
 		}
 	}
 	TRAP::Graphics::RendererAPI::GetResourceLoader()->EndUpdateResource(updateDesc, &m_syncToken);
@@ -1073,7 +1074,7 @@ TRAP::Scope<TRAP::Image> TRAP::Graphics::Texture::Rotate90CounterClockwise(const
 	{
 		std::vector<float> rotated(static_cast<std::size_t>(img->GetWidth()) * img->GetHeight() *
 								   static_cast<std::size_t>(img->GetColorFormat()));
-		memcpy(rotated.data(), img->GetPixelData(), img->GetPixelDataSize());
+		std::copy_n(static_cast<const uint8_t*>(img->GetPixelData()), img->GetPixelDataSize(), rotated.begin());
 		for(uint32_t x = 0; x < img->GetWidth(); ++x)
 		{
 			for(uint32_t y = 0; y < img->GetHeight(); ++y)
@@ -1099,7 +1100,7 @@ TRAP::Scope<TRAP::Image> TRAP::Graphics::Texture::Rotate90CounterClockwise(const
 	if(img->GetBitsPerChannel() == 16)
 	{
 		std::vector<uint16_t> rotated(static_cast<std::size_t>(img->GetWidth()) * img->GetHeight() * static_cast<std::size_t>(img->GetColorFormat()));
-		memcpy(rotated.data(), img->GetPixelData(), img->GetPixelDataSize());
+		std::copy_n(static_cast<const uint8_t*>(img->GetPixelData()), img->GetPixelDataSize(), rotated.begin());
 		for(uint32_t x = 0; x < img->GetWidth(); ++x)
 		{
 			for(uint32_t y = 0; y < img->GetHeight(); ++y)
@@ -1125,7 +1126,7 @@ TRAP::Scope<TRAP::Image> TRAP::Graphics::Texture::Rotate90CounterClockwise(const
 
 	std::vector<uint8_t> rotated(static_cast<std::size_t>(img->GetWidth()) * img->GetHeight() *
 								 static_cast<std::size_t>(img->GetColorFormat()));
-	memcpy(rotated.data(), img->GetPixelData(), img->GetPixelDataSize());
+	std::copy_n(static_cast<const uint8_t*>(img->GetPixelData()), img->GetPixelDataSize(), rotated.begin());
 	for(uint32_t x = 0; x < img->GetWidth(); ++x)
 	{
 		for(uint32_t y = 0; y < img->GetHeight(); ++y)

--- a/TRAP/src/Graphics/Textures/Texture.cpp
+++ b/TRAP/src/Graphics/Textures/Texture.cpp
@@ -616,7 +616,7 @@ bool TRAP::Graphics::Texture::Reload()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Graphics::Texture::GetName() const
+std::string TRAP::Graphics::Texture::GetName() const
 {
 	return m_name;
 }

--- a/TRAP/src/Graphics/Textures/Texture.cpp
+++ b/TRAP/src/Graphics/Textures/Texture.cpp
@@ -2,7 +2,7 @@
 #include "Texture.h"
 
 #include "Application.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Graphics/API/Vulkan/Objects/VulkanTexture.h"
 #include "Graphics/API/Objects/Queue.h"
 
@@ -32,7 +32,7 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromFiles(st
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				const auto folderPath = FS::GetFolderPath(path);
+				const auto folderPath = FileSystem::GetFolderPath(path);
 				if(!folderPath)
 					continue;
 
@@ -98,7 +98,7 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromFile(std
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				const auto folderPath = FS::GetFolderPath(path);
+				const auto folderPath = FileSystem::GetFolderPath(path);
 				if(!folderPath)
 					continue;
 
@@ -144,7 +144,7 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromFile(std
 
 	TP_PROFILE_FUNCTION();
 
-	const auto name = FS::GetFileName(filepath);
+	const auto name = FileSystem::GetFileName(filepath);
 	if(!name)
 	{
 		TRAP_ASSERT(false, "Name is empty!");
@@ -165,7 +165,7 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromFile(std
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				const auto folderPath = FS::GetFolderPath(path);
+				const auto folderPath = FileSystem::GetFolderPath(path);
 				if(!folderPath)
 					continue;
 
@@ -260,7 +260,7 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromImages(s
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				const auto folderPath = FS::GetFolderPath(path);
+				const auto folderPath = FileSystem::GetFolderPath(path);
 				if(!folderPath)
 					continue;
 
@@ -351,7 +351,7 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromImage(st
 		{
 			for(const std::filesystem::path& path : texture->m_filepaths)
 			{
-				const auto folderPath = FS::GetFolderPath(path);
+				const auto folderPath = FileSystem::GetFolderPath(path);
 				if(!folderPath)
 					continue;
 

--- a/TRAP/src/Graphics/Textures/Texture.cpp
+++ b/TRAP/src/Graphics/Textures/Texture.cpp
@@ -212,7 +212,7 @@ TRAP::Scope<TRAP::Graphics::Texture> TRAP::Graphics::Texture::CreateFromImages(s
 	TP_PROFILE_FUNCTION();
 
 	//Validation that images have same size and format
-	Image::ColorFormat format = imgs[0]->GetColorFormat();
+	const Image::ColorFormat format = imgs[0]->GetColorFormat();
 	if(std::none_of(imgs.cbegin(), imgs.cend(),
 	   [&](const Image* img) {return img->GetColorFormat() != format ||
 	                                 img->GetBitsPerChannel() != imgs[0]->GetBitsPerPixel() ||
@@ -899,109 +899,6 @@ bool TRAP::Graphics::Texture::ValidateLimits(const RendererAPI::TextureDesc& des
     }
 
     return true;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Graphics::API::ImageFormat TRAP::Graphics::Texture::ColorFormatBitsPerPixelToImageFormat(const Image::ColorFormat colorFormat,
-	                             											                   const uint32_t bpp)
-{
-	if(colorFormat == Image::ColorFormat::GrayScale)
-	{
-		if(bpp == 8)
-			return API::ImageFormat::R8_UNORM;
-		if(bpp == 16)
-			return API::ImageFormat::R16_UNORM;
-		if(bpp == 32)
-			return API::ImageFormat::R32_SFLOAT;
-
-		TRAP_ASSERT(false, "Invalid bits per pixel & color format combination provided!");
-		return API::ImageFormat::Undefined;
-	}
-	if(colorFormat == Image::ColorFormat::GrayScaleAlpha)
-	{
-		if(bpp == 16)
-			return API::ImageFormat::R8G8_UNORM;
-		if(bpp == 32)
-		    return API::ImageFormat::R16G16_UNORM;
-		if(bpp == 64)
-		    return API::ImageFormat::R32G32_SFLOAT;
-
-		TRAP_ASSERT(false, "Invalid bits per pixel & color format combination provided!");
-		return API::ImageFormat::Undefined;
-	}
-	if(colorFormat == Image::ColorFormat::RGB)
-	{
-		TRAP_ASSERT(false, "Color format RGB is not allowed on empty textures as GPU needs an alpha channel!");
-		return API::ImageFormat::Undefined;
-	}
-	if(colorFormat == Image::ColorFormat::RGBA)
-	{
-		if(bpp == 32)
-			return API::ImageFormat::R8G8B8A8_UNORM;
-		if(bpp == 64)
-			return API::ImageFormat::R16G16B16A16_UNORM;
-		if(bpp == 128)
-			return API::ImageFormat::R32G32B32A32_SFLOAT;
-
-		TRAP_ASSERT(false, "Invalid bits per pixel & color format combination provided!");
-		return API::ImageFormat::Undefined;
-	}
-
-	TRAP_ASSERT(false, "Invalid color format provided!");
-	return API::ImageFormat::Undefined;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Image::ColorFormat TRAP::Graphics::Texture::ImageFormatToColorFormat(const API::ImageFormat imageFormat)
-{
-	switch(imageFormat)
-	{
-	case API::ImageFormat::R8_UNORM:
-	case API::ImageFormat::R16_UNORM:
-	case API::ImageFormat::R32_SFLOAT:
-		return Image::ColorFormat::GrayScale;
-
-	case API::ImageFormat::R8G8_UNORM:
-	case API::ImageFormat::R16G16_UNORM:
-	case API::ImageFormat::R32G32_SFLOAT:
-		return Image::ColorFormat::GrayScaleAlpha;
-
-	case API::ImageFormat::R8G8B8A8_UNORM:
-	case API::ImageFormat::R16G16B16A16_UNORM:
-	case API::ImageFormat::R32G32B32A32_SFLOAT:
-		return Image::ColorFormat::RGBA;
-
-	default:
-		return Image::ColorFormat::NONE;
-	}
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-uint32_t TRAP::Graphics::Texture::GetBitsPerChannelFromImageFormat(const API::ImageFormat imageFormat)
-{
-	switch(imageFormat)
-	{
-	case API::ImageFormat::R8_UNORM:
-	case API::ImageFormat::R8G8_UNORM:
-	case API::ImageFormat::R8G8B8A8_UNORM:
-		return 8;
-
-	case API::ImageFormat::R16_UNORM:
-	case API::ImageFormat::R16G16_UNORM:
-	case API::ImageFormat::R16G16B16A16_UNORM:
-		return 16;
-
-	case API::ImageFormat::R32_SFLOAT:
-	case API::ImageFormat::R32G32_SFLOAT:
-	case API::ImageFormat::R32G32B32A32_SFLOAT:
-		return 32;
-
-	default:
-		return 0;
-	}
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/Textures/Texture.h
+++ b/TRAP/src/Graphics/Textures/Texture.h
@@ -155,7 +155,7 @@ namespace TRAP::Graphics
 		/// Retrieve the name of the texture.
 		/// </summary>
 		/// <returns>Name of the texture.</returns>
-		const std::string& GetName() const;
+		std::string GetName() const;
 		/// <summary>
 		/// Retrieve the texture type.
 		/// </summary>
@@ -282,7 +282,7 @@ namespace TRAP::Graphics
 		/// Set the texture name.
 		/// </summary>
 		/// <param name="name">Name for the texture.</param>
-        virtual void SetTextureName(const std::string& name) const = 0;
+        virtual void SetTextureName(const std::string_view name) const = 0;
 
 		/// <summary>
 		/// Retrieve whether the texture owns the image data.

--- a/TRAP/src/Graphics/Textures/Texture.h
+++ b/TRAP/src/Graphics/Textures/Texture.h
@@ -334,19 +334,19 @@ namespace TRAP::Graphics
 		/// <param name="colorFormat">Color format.</param>
 		/// <param name="bpp">Bits per pixel.</param>
 		/// <returns>Image format.</returns>
-		static API::ImageFormat ColorFormatBitsPerPixelToImageFormat(Image::ColorFormat colorFormat, uint32_t bpp);
+		static constexpr API::ImageFormat ColorFormatBitsPerPixelToImageFormat(Image::ColorFormat colorFormat, uint32_t bpp);
 		/// <summary>
 		/// Convert image format to color format.
 		/// </summary>
 		/// <param name="imageFormat">Image format.</param>
 		/// <returns>Color format.</returns>
-		static Image::ColorFormat ImageFormatToColorFormat(API::ImageFormat imageFormat);
+		static constexpr Image::ColorFormat ImageFormatToColorFormat(API::ImageFormat imageFormat);
 		/// <summary>
 		/// Retrieve bits per channel from image format.
 		/// </summary>
 		/// <param name="imageFormat">Image format.</param>
 		/// <returns>Bits per channel.</returns>
-		static uint32_t GetBitsPerChannelFromImageFormat(API::ImageFormat imageFormat);
+		static constexpr uint32_t GetBitsPerChannelFromImageFormat(API::ImageFormat imageFormat);
 		/// <summary>
 		/// Rotate image 90 degrees clockwise.
 		/// </summary>
@@ -399,8 +399,8 @@ std::array<TRAP::Scope<TRAP::Image>, 6> TRAP::Graphics::Texture::SplitImageFromC
 		cxLimit = 3;
 		cyLimit = 4;
 	}
-	uint32_t faceWidth = image->GetWidth() / cxLimit;
-	uint32_t faceHeight = image->GetHeight() / cyLimit;
+	const uint32_t faceWidth = image->GetWidth() / cxLimit;
+	const uint32_t faceHeight = image->GetHeight() / cyLimit;
 
 	std::array<std::vector<T>, 6> cubeTextureData;
 	for(auto& i : cubeTextureData)
@@ -514,5 +514,107 @@ std::array<TRAP::Scope<TRAP::Image>, 6> TRAP::Graphics::Texture::SplitImageFromC
 	return images;
 }
 
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Graphics::API::ImageFormat TRAP::Graphics::Texture::ColorFormatBitsPerPixelToImageFormat(const Image::ColorFormat colorFormat,
+	                             											                             const uint32_t bpp)
+{
+	if(colorFormat == Image::ColorFormat::GrayScale)
+	{
+		if(bpp == 8)
+			return API::ImageFormat::R8_UNORM;
+		if(bpp == 16)
+			return API::ImageFormat::R16_UNORM;
+		if(bpp == 32)
+			return API::ImageFormat::R32_SFLOAT;
+
+		TRAP_ASSERT(false, "Invalid bits per pixel & color format combination provided!");
+		return API::ImageFormat::Undefined;
+	}
+	if(colorFormat == Image::ColorFormat::GrayScaleAlpha)
+	{
+		if(bpp == 16)
+			return API::ImageFormat::R8G8_UNORM;
+		if(bpp == 32)
+		    return API::ImageFormat::R16G16_UNORM;
+		if(bpp == 64)
+		    return API::ImageFormat::R32G32_SFLOAT;
+
+		TRAP_ASSERT(false, "Invalid bits per pixel & color format combination provided!");
+		return API::ImageFormat::Undefined;
+	}
+	if(colorFormat == Image::ColorFormat::RGB)
+	{
+		TRAP_ASSERT(false, "Color format RGB is not allowed on empty textures as GPU needs an alpha channel!");
+		return API::ImageFormat::Undefined;
+	}
+	if(colorFormat == Image::ColorFormat::RGBA)
+	{
+		if(bpp == 32)
+			return API::ImageFormat::R8G8B8A8_UNORM;
+		if(bpp == 64)
+			return API::ImageFormat::R16G16B16A16_UNORM;
+		if(bpp == 128)
+			return API::ImageFormat::R32G32B32A32_SFLOAT;
+
+		TRAP_ASSERT(false, "Invalid bits per pixel & color format combination provided!");
+		return API::ImageFormat::Undefined;
+	}
+
+	TRAP_ASSERT(false, "Invalid color format provided!");
+	return API::ImageFormat::Undefined;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Image::ColorFormat TRAP::Graphics::Texture::ImageFormatToColorFormat(const API::ImageFormat imageFormat)
+{
+	switch(imageFormat)
+	{
+	case API::ImageFormat::R8_UNORM:
+	case API::ImageFormat::R16_UNORM:
+	case API::ImageFormat::R32_SFLOAT:
+		return Image::ColorFormat::GrayScale;
+
+	case API::ImageFormat::R8G8_UNORM:
+	case API::ImageFormat::R16G16_UNORM:
+	case API::ImageFormat::R32G32_SFLOAT:
+		return Image::ColorFormat::GrayScaleAlpha;
+
+	case API::ImageFormat::R8G8B8A8_UNORM:
+	case API::ImageFormat::R16G16B16A16_UNORM:
+	case API::ImageFormat::R32G32B32A32_SFLOAT:
+		return Image::ColorFormat::RGBA;
+
+	default:
+		return Image::ColorFormat::NONE;
+	}
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr uint32_t TRAP::Graphics::Texture::GetBitsPerChannelFromImageFormat(const API::ImageFormat imageFormat)
+{
+	switch(imageFormat)
+	{
+	case API::ImageFormat::R8_UNORM:
+	case API::ImageFormat::R8G8_UNORM:
+	case API::ImageFormat::R8G8B8A8_UNORM:
+		return 8;
+
+	case API::ImageFormat::R16_UNORM:
+	case API::ImageFormat::R16G16_UNORM:
+	case API::ImageFormat::R16G16B16A16_UNORM:
+		return 16;
+
+	case API::ImageFormat::R32_SFLOAT:
+	case API::ImageFormat::R32G32_SFLOAT:
+	case API::ImageFormat::R32G32B32A32_SFLOAT:
+		return 32;
+
+	default:
+		return 0;
+	}
+}
 
 #endif /*TRAP_TEXTURE_H*/

--- a/TRAP/src/Graphics/Textures/TextureManager.cpp
+++ b/TRAP/src/Graphics/Textures/TextureManager.cpp
@@ -309,7 +309,7 @@ TRAP::Graphics::Texture* TRAP::Graphics::TextureManager::Reload(const std::strin
 		}
 
 		TP_WARN(Log::TextureManagerPrefix, "Couldn't find texture: \"",
-		        std::filesystem::path(nameOrPath).generic_u8string(), "\" to reload.");
+		        std::filesystem::path(nameOrPath).u8string(), "\" to reload.");
 	}
 
 	return nullptr;

--- a/TRAP/src/Graphics/Textures/TextureManager.cpp
+++ b/TRAP/src/Graphics/Textures/TextureManager.cpp
@@ -215,8 +215,10 @@ TRAP::Graphics::Texture* TRAP::Graphics::TextureManager::Get(const std::string& 
 	TP_PROFILE_FUNCTION();
 
 	if(Exists(name))
+	{
 		if (Textures[name]->GetType() == textureType)
 				return Textures[name].get();
+	}
 
 	if (textureType == TextureType::Texture2D)
 		return Get("Fallback2D", TextureType::Texture2D);

--- a/TRAP/src/Graphics/Textures/TextureManager.cpp
+++ b/TRAP/src/Graphics/Textures/TextureManager.cpp
@@ -1,7 +1,7 @@
 #include "TRAPPCH.h"
 #include "TextureManager.h"
 #include "Texture.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 std::unordered_map<std::string, TRAP::Scope<TRAP::Graphics::Texture>> Textures;
 
@@ -282,7 +282,7 @@ TRAP::Graphics::Texture* TRAP::Graphics::TextureManager::Reload(const std::strin
 		{
 			if (texture->GetType() == TextureType::Texture2D)
 			{
-				if (FS::IsPathEquivalent(nameOrPath, texture->GetFilePath()))
+				if (FileSystem::IsPathEquivalent(nameOrPath, texture->GetFilePath()))
 				{
 					if(texture->Reload())
 						TP_INFO(Log::TextureManagerPrefix, "Reloaded: \"", nameOrPath, "\"");
@@ -297,7 +297,7 @@ TRAP::Graphics::Texture* TRAP::Graphics::TextureManager::Reload(const std::strin
 					if (texture->GetFilePaths()[i].empty())
 						continue;
 
-					if (FS::IsPathEquivalent(nameOrPath, texture->GetFilePaths()[i]))
+					if (FileSystem::IsPathEquivalent(nameOrPath, texture->GetFilePaths()[i]))
 					{
 						if(texture->Reload())
 							TP_INFO(Log::TextureManagerPrefix, "Reloaded: \"", nameOrPath, "\"");
@@ -371,7 +371,7 @@ bool TRAP::Graphics::TextureManager::ExistsPath(const std::filesystem::path& pat
 	{
 		if (texture->GetType() == TextureType::Texture2D)
 		{
-			if (FS::IsPathEquivalent(texture->GetFilePath(), path))
+			if (FileSystem::IsPathEquivalent(texture->GetFilePath(), path))
 				return true;
 		}
 		else if(texture->GetType() == TextureType::TextureCube)
@@ -379,7 +379,7 @@ bool TRAP::Graphics::TextureManager::ExistsPath(const std::filesystem::path& pat
 			const std::array<std::filesystem::path, 6> imageFilePaths = texture->GetFilePaths();
 			for(const auto& filePath : imageFilePaths)
 			{
-				if (FS::IsPathEquivalent(filePath, path))
+				if (FileSystem::IsPathEquivalent(filePath, path))
 					return true;
 			}
 		}

--- a/TRAP/src/ImageLoader/Bitmap/BMPImage.cpp
+++ b/TRAP/src/ImageLoader/Bitmap/BMPImage.cpp
@@ -2,7 +2,7 @@
 #include "BMPImage.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Maths/Math.h"
 #include "Utils/ByteSwap.h"
 #include "Utils/Utils.h"
@@ -15,7 +15,7 @@ TRAP::INTERNAL::BMPImage::BMPImage(std::filesystem::path filepath)
 
 	TP_DEBUG(Log::ImageBMPPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/Bitmap/BMPImage.cpp
+++ b/TRAP/src/ImageLoader/Bitmap/BMPImage.cpp
@@ -13,7 +13,7 @@ TRAP::INTERNAL::BMPImage::BMPImage(std::filesystem::path filepath)
 
 	m_filepath = std::move(filepath);
 
-	TP_DEBUG(Log::ImageBMPPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
+	TP_DEBUG(Log::ImageBMPPrefix, "Loading image: \"", m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -21,7 +21,7 @@ TRAP::INTERNAL::BMPImage::BMPImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImageBMPPrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImageBMPPrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImageBMPPrefix, "Using default image!");
 		return;
 	}

--- a/TRAP/src/ImageLoader/Bitmap/BMPImage.cpp
+++ b/TRAP/src/ImageLoader/Bitmap/BMPImage.cpp
@@ -34,7 +34,7 @@ TRAP::INTERNAL::BMPImage::BMPImage(std::filesystem::path filepath)
 
 	//File uses little-endian
 	//Convert to machines endian
-	bool needSwap = Utils::GetEndian() != Utils::Endian::Little;
+	const bool needSwap = Utils::GetEndian() != Utils::Endian::Little;
 	if (needSwap)
 	{
 		Utils::Memory::SwapBytes(header.MagicNumber);
@@ -179,7 +179,7 @@ TRAP::INTERNAL::BMPImage::BMPImage(std::filesystem::path filepath)
 	    4 - (((m_bitsPerPixel / 8) * m_width) % 4) != 4) //Padding
 	{
 		imageData.resize(static_cast<std::size_t>(m_width) * m_height * (m_bitsPerPixel / 8));
-		uint32_t padding = 4 - (((m_bitsPerPixel / 8) * m_width) % 4);
+		const uint32_t padding = 4 - (((m_bitsPerPixel / 8) * m_width) % 4);
 		uint32_t offset = 0;
 		for (uint32_t j = 0; j < m_height; j++)
 		{
@@ -335,10 +335,10 @@ TRAP::INTERNAL::BMPImage::BMPImage(std::filesystem::path filepath)
 			uint32_t index = 0;
 			for (uint32_t i = 0; i < m_width * m_height * m_bitsPerPixel / 8 - 1;)
 			{
-				uint32_t value = static_cast<uint32_t>(imageData[i]) +
-					            (static_cast<uint32_t>(imageData[i + 1]) << 8) +
-					            (static_cast<uint32_t>(imageData[i + 2]) << 16) +
-					            (static_cast<uint32_t>(imageData[i + 3]) << 24);
+				const uint32_t value = static_cast<uint32_t>(imageData[i]) +
+					                   (static_cast<uint32_t>(imageData[i + 1]) << 8) +
+					                   (static_cast<uint32_t>(imageData[i + 2]) << 16) +
+					                   (static_cast<uint32_t>(imageData[i + 3]) << 24);
 
 				data[index++] = Make8Bits(ApplyBitField(value, bitFields[0]), bitFields[0].Span);
 				data[index++] = Make8Bits(ApplyBitField(value, bitFields[1]), bitFields[1].Span);
@@ -366,8 +366,8 @@ TRAP::INTERNAL::BMPImage::BMPImage(std::filesystem::path filepath)
 			uint32_t index = 0;
 			for (uint32_t i = 0; i < m_width * m_height * m_bitsPerPixel / 8 - 1;)
 			{
-				uint16_t value = static_cast<uint16_t>(imageData[i]) +
-								 static_cast<uint16_t>(imageData[i + 1] << 8);
+				const uint16_t value = static_cast<uint16_t>(imageData[i]) +
+								       static_cast<uint16_t>(imageData[i + 1] << 8);
 
 				data[index++] = Make8Bits(ApplyBitField(value, bitFields[0]), bitFields[0].Span);
 				data[index++] = Make8Bits(ApplyBitField(value, bitFields[1]), bitFields[1].Span);
@@ -509,7 +509,7 @@ uint32_t TRAP::INTERNAL::BMPImage::ApplyBitField(const uint32_t x, BitField& bit
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::INTERNAL::BMPImage::DecodeRLE8(std::vector<uint8_t>& compressedImageData,
-	std::vector<uint8_t>* colorTable)
+	                                      std::vector<uint8_t>* colorTable)
 {
 	int32_t x = 0, y = 0;
 	uint8_t t = 0, r = 0;

--- a/TRAP/src/ImageLoader/Image.cpp
+++ b/TRAP/src/ImageLoader/Image.cpp
@@ -1,7 +1,7 @@
 #include "TRAPPCH.h"
 #include "Image.h"
 
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Utils/String/String.h"
 
 #include "PortableMaps/PGMImage.h"
@@ -229,7 +229,7 @@ TRAP::Scope<TRAP::Image> TRAP::Image::LoadFromFile(const std::filesystem::path& 
 		return MakeScope<INTERNAL::CustomImage>(filepath, 32, 32, ColorFormat::RGBA, std::vector<uint8_t>{ Embed::DefaultImageData.begin(), Embed::DefaultImageData.end() });
 	}
 
-	const auto fileEnding = FS::GetFileEnding(filepath);
+	const auto fileEnding = FileSystem::GetFileEnding(filepath);
 	const std::string fileFormat = Utils::String::ToLower(*fileEnding);
 
 	Scope<Image> result;
@@ -310,7 +310,7 @@ bool TRAP::Image::IsSupportedImageFile(const std::filesystem::path& filepath)
 {
 	TP_PROFILE_FUNCTION();
 
-	const auto fileEnding = FS::GetFileEnding(filepath);
+	const auto fileEnding = FileSystem::GetFileEnding(filepath);
 	if(!fileEnding)
 		return false;
 

--- a/TRAP/src/ImageLoader/Image.h
+++ b/TRAP/src/ImageLoader/Image.h
@@ -340,7 +340,7 @@ std::vector<T> TRAP::Image::FlipX(const uint32_t width, const uint32_t height, c
 
 	std::vector<T> newData{};
 	uint32_t stride = 0;
-	uint32_t multiplier = static_cast<uint32_t>(format);
+	const uint32_t multiplier = static_cast<uint32_t>(format);
 
 	newData.assign(data, data + static_cast<uint64_t>(width) * static_cast<uint64_t>(height) * multiplier);
 	stride = height * multiplier;
@@ -384,7 +384,7 @@ std::vector<T> TRAP::Image::FlipY(const uint32_t width, const uint32_t height, c
 
 	std::vector<T> newData{};
 	uint32_t stride = 0;
-	uint32_t multiplier = static_cast<uint32_t>(format);
+	const uint32_t multiplier = static_cast<uint32_t>(format);
 
 	newData.assign(data, data + static_cast<uint64_t>(width) * static_cast<uint64_t>(height) * multiplier);
 	stride = width * multiplier;

--- a/TRAP/src/ImageLoader/PortableMaps/PAMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PAMImage.cpp
@@ -2,7 +2,7 @@
 #include "PAMImage.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Utils/ByteSwap.h"
 #include "Utils/Utils.h"
 
@@ -14,7 +14,7 @@ TRAP::INTERNAL::PAMImage::PAMImage(std::filesystem::path filepath)
 
 	TP_DEBUG(Log::ImagePAMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/PortableMaps/PAMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PAMImage.cpp
@@ -12,7 +12,7 @@ TRAP::INTERNAL::PAMImage::PAMImage(std::filesystem::path filepath)
 
 	m_filepath = std::move(filepath);
 
-	TP_DEBUG(Log::ImagePAMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
+	TP_DEBUG(Log::ImagePAMPrefix, "Loading image: \"", m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -20,7 +20,7 @@ TRAP::INTERNAL::PAMImage::PAMImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImagePAMPrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImagePAMPrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImagePAMPrefix, "Using default image!");
 		return;
 	}

--- a/TRAP/src/ImageLoader/PortableMaps/PFMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PFMImage.cpp
@@ -57,8 +57,8 @@ TRAP::INTERNAL::PFMImage::PFMImage(std::filesystem::path filepath)
 	m_height = header.Height;
 
 	//Determine endianness
-	bool isFileLittleEndian = (header.ByteOrder < 0.0f); //If true little-endian is used else if false big-endian is used
-	bool needSwap = isFileLittleEndian != static_cast<bool>(Utils::GetEndian());
+	const bool isFileLittleEndian = (header.ByteOrder < 0.0f); //If true little-endian is used else if false big-endian is used
+	const bool needSwap = isFileLittleEndian != static_cast<bool>(Utils::GetEndian());
 
 	file.ignore(256, '\n'); //Skip ahead to the pixel data
 

--- a/TRAP/src/ImageLoader/PortableMaps/PFMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PFMImage.cpp
@@ -13,7 +13,7 @@ TRAP::INTERNAL::PFMImage::PFMImage(std::filesystem::path filepath)
 	m_filepath = std::move(filepath);
 	m_isHDR = true;
 
-	TP_DEBUG(Log::ImagePFMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
+	TP_DEBUG(Log::ImagePFMPrefix, "Loading image: \"", m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -21,7 +21,7 @@ TRAP::INTERNAL::PFMImage::PFMImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImagePFMPrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImagePFMPrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImagePFMPrefix, "Using default image!");
 		return;
 	}

--- a/TRAP/src/ImageLoader/PortableMaps/PFMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PFMImage.cpp
@@ -2,7 +2,7 @@
 #include "PFMImage.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Utils/ByteSwap.h"
 #include "Utils/Utils.h"
 
@@ -15,7 +15,7 @@ TRAP::INTERNAL::PFMImage::PFMImage(std::filesystem::path filepath)
 
 	TP_DEBUG(Log::ImagePFMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/PortableMaps/PGMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PGMImage.cpp
@@ -13,7 +13,7 @@ TRAP::INTERNAL::PGMImage::PGMImage(std::filesystem::path filepath)
 	m_filepath = std::move(filepath);
 	m_colorFormat = ColorFormat::GrayScale;
 
-	TP_DEBUG(Log::ImagePGMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
+	TP_DEBUG(Log::ImagePGMPrefix, "Loading image: \"", m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -21,7 +21,7 @@ TRAP::INTERNAL::PGMImage::PGMImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImagePGMPrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImagePGMPrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImagePGMPrefix, "Using default image!");
 		return;
 	}

--- a/TRAP/src/ImageLoader/PortableMaps/PGMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PGMImage.cpp
@@ -2,7 +2,7 @@
 #include "PGMImage.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Utils/ByteSwap.h"
 #include "Utils/Utils.h"
 
@@ -15,7 +15,7 @@ TRAP::INTERNAL::PGMImage::PGMImage(std::filesystem::path filepath)
 
 	TP_DEBUG(Log::ImagePGMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/PortableMaps/PNMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PNMImage.cpp
@@ -12,7 +12,7 @@ TRAP::INTERNAL::PNMImage::PNMImage(std::filesystem::path filepath)
 
 	m_filepath = std::move(filepath);
 
-	TP_DEBUG(Log::ImagePNMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
+	TP_DEBUG(Log::ImagePNMPrefix, "Loading image: \"", m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -20,7 +20,7 @@ TRAP::INTERNAL::PNMImage::PNMImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImagePNMPrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImagePNMPrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImagePNMPrefix, "Using default image!");
 		return;
 	}

--- a/TRAP/src/ImageLoader/PortableMaps/PNMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PNMImage.cpp
@@ -2,7 +2,7 @@
 #include "PNMImage.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Utils/ByteSwap.h"
 #include "Utils/Utils.h"
 
@@ -14,7 +14,7 @@ TRAP::INTERNAL::PNMImage::PNMImage(std::filesystem::path filepath)
 
 	TP_DEBUG(Log::ImagePNMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/PortableMaps/PPMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PPMImage.cpp
@@ -13,7 +13,7 @@ TRAP::INTERNAL::PPMImage::PPMImage(std::filesystem::path filepath)
 	m_filepath = std::move(filepath);
 	m_colorFormat = ColorFormat::RGB;
 
-	TP_DEBUG(Log::ImagePPMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
+	TP_DEBUG(Log::ImagePPMPrefix, "Loading image: \"", m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -21,7 +21,7 @@ TRAP::INTERNAL::PPMImage::PPMImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImagePPMPrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImagePPMPrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImagePPMPrefix, "Using default image!");
 		return;
 	}

--- a/TRAP/src/ImageLoader/PortableMaps/PPMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PPMImage.cpp
@@ -139,11 +139,11 @@ void TRAP::INTERNAL::PPMImage::Save(const Image* const img, const std::filesyste
 	std::vector<uint8_t> pixelData;
 	if(img->GetColorFormat() == ColorFormat::RGBA)
 	{
-		pixelData = ConvertRGBAToRGB<uint8_t>(img->GetWidth(), img->GetHeight(), img->GetColorFormat(), reinterpret_cast<const uint8_t*>(img->GetPixelData()));
+		pixelData = ConvertRGBAToRGB<uint8_t>(img->GetWidth(), img->GetHeight(), img->GetColorFormat(), static_cast<const uint8_t*>(img->GetPixelData()));
 		file.write(reinterpret_cast<const char*>(pixelData.data()), static_cast<std::streamsize>(pixelData.size()));
 	}
 	else
-		file.write(reinterpret_cast<const char*>(img->GetPixelData()), static_cast<std::streamsize>(img->GetPixelDataSize()));
+		file.write(static_cast<const char*>(img->GetPixelData()), static_cast<std::streamsize>(img->GetPixelDataSize()));
 
 	file.close();
 }

--- a/TRAP/src/ImageLoader/PortableMaps/PPMImage.cpp
+++ b/TRAP/src/ImageLoader/PortableMaps/PPMImage.cpp
@@ -2,7 +2,7 @@
 #include "PPMImage.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Utils/ByteSwap.h"
 #include "Utils/Utils.h"
 
@@ -15,7 +15,7 @@ TRAP::INTERNAL::PPMImage::PPMImage(std::filesystem::path filepath)
 
 	TP_DEBUG(Log::ImagePPMPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/PortableNetworkGraphics/PNGImage.cpp
+++ b/TRAP/src/ImageLoader/PortableNetworkGraphics/PNGImage.cpp
@@ -48,7 +48,7 @@ TRAP::INTERNAL::PNGImage::PNGImage(std::filesystem::path filepath)
 	}
 
 	//File uses big-endian
-	bool needSwap = Utils::GetEndian() != Utils::Endian::Big;
+	const bool needSwap = Utils::GetEndian() != Utils::Endian::Big;
 
 	//Load Chunk
 	Data data{};
@@ -315,7 +315,7 @@ uint64_t TRAP::INTERNAL::PNGImage::GetPixelDataSize() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-static std::array<std::string, 11> UnusedChunks
+static const std::array<std::string, 11> UnusedChunks
 {
 	"cHRM", "gAMA", "iCCP", "hIST", "pHYs", "sPLT", "tIME", "iTXt", "tEXt", "zTXt", "eXIf"
 };
@@ -331,7 +331,7 @@ bool TRAP::INTERNAL::PNGImage::ProcessChunk(NextChunk& nextChunk, std::ifstream&
 
 	if (alreadyLoaded.IHDR)
 	{
-		bool unusedChunk = std::any_of(UnusedChunks.begin(), UnusedChunks.end(), [&nextChunk](const std::string_view magicNum)
+		const bool unusedChunk = std::any_of(UnusedChunks.begin(), UnusedChunks.end(), [&nextChunk](const std::string_view magicNum)
 		{
 			return magicNum == nextChunk.MagicNumber;
 		});
@@ -406,7 +406,7 @@ bool TRAP::INTERNAL::PNGImage::ProcessIHDR(std::ifstream& file, Data& data, cons
 		Utils::Memory::SwapBytes(ihdrChunk.Height);
 	}
 
-	std::array<uint8_t, 17> CRCData
+	const std::array<uint8_t, 17> CRCData
 	{
 		'I', 'H', 'D', 'R',
 		reinterpret_cast<uint8_t*>(&ihdrChunk.Width)[3], reinterpret_cast<uint8_t*>(&ihdrChunk.Width)[2],
@@ -417,7 +417,7 @@ bool TRAP::INTERNAL::PNGImage::ProcessIHDR(std::ifstream& file, Data& data, cons
 		ihdrChunk.InterlaceMethod
 	};
 
-	std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
+	const std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
 	if (crc[0] != ihdrChunk.CRC[0] && crc[1] != ihdrChunk.CRC[1] && crc[2] != ihdrChunk.CRC[2] &&
 	    crc[3] != ihdrChunk.CRC[3])
 	{
@@ -485,9 +485,9 @@ bool TRAP::INTERNAL::PNGImage::ProcesssRGB(std::ifstream& file)
 	const uint8_t renderingIntent = static_cast<uint8_t>(file.get());
 	file.read(reinterpret_cast<char*>(CRC.data()), CRC.size());
 
-	std::array<uint8_t, 5> CRCData{ 's', 'R', 'G', 'B', renderingIntent };
+	const std::array<uint8_t, 5> CRCData{ 's', 'R', 'G', 'B', renderingIntent };
 
-	std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
+	const std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
 	if (crc[0] != CRC[0] && crc[1] != CRC[1] && crc[2] != CRC[2] && crc[3] != CRC[3])
 	{
 		TP_ERROR(Log::ImagePNGPrefix, "sRGB CRC: ", Utils::Hash::ConvertHashToString(CRC), " is wrong!");
@@ -543,9 +543,9 @@ bool TRAP::INTERNAL::PNGImage::ProcesstRNS(std::ifstream& file, const uint32_t l
 		const uint8_t grayAlpha2 = static_cast<uint8_t>(file.get());
 		file.read(reinterpret_cast<char*>(CRC.data()), CRC.size());
 
-		std::array<uint8_t, 6> CRCData{ 't', 'R', 'N', 'S', grayAlpha1, grayAlpha2 };
+		const std::array<uint8_t, 6> CRCData{ 't', 'R', 'N', 'S', grayAlpha1, grayAlpha2 };
 
-		std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
+		const std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
 		if (crc[0] != CRC[0] && crc[1] != CRC[1] && crc[2] != CRC[2] && crc[3] != CRC[3])
 		{
 			TP_ERROR(Log::ImagePNGPrefix, "tRNS CRC: ", Utils::Hash::ConvertHashToString(CRC), " is wrong!");
@@ -567,7 +567,7 @@ bool TRAP::INTERNAL::PNGImage::ProcesstRNS(std::ifstream& file, const uint32_t l
 		const uint8_t blueAlpha2 = static_cast<uint8_t>(file.get());
 		file.read(reinterpret_cast<char*>(CRC.data()), CRC.size());
 
-		std::array<uint8_t, 10> CRCData
+		const std::array<uint8_t, 10> CRCData
 		{
 			't', 'R', 'N', 'S',
 			redAlpha1, redAlpha2,
@@ -575,7 +575,7 @@ bool TRAP::INTERNAL::PNGImage::ProcesstRNS(std::ifstream& file, const uint32_t l
 			blueAlpha1, blueAlpha2
 		};
 
-		std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
+		const std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
 		if (crc[0] != CRC[0] && crc[1] != CRC[1] && crc[2] != CRC[2] && crc[3] != CRC[3])
 		{
 			TP_ERROR(Log::ImagePNGPrefix, "tRNS CRC: ", Utils::Hash::ConvertHashToString(CRC), " is wrong!");
@@ -602,7 +602,7 @@ bool TRAP::INTERNAL::PNGImage::ProcesstRNS(std::ifstream& file, const uint32_t l
 		for (uint32_t i = 0; i < paletteAlpha.size(); i++)
 			CRCData[i + 4] = paletteAlpha[i];
 
-		std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
+		const std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
 		if (crc[0] != CRC[0] && crc[1] != CRC[1] && crc[2] != CRC[2] && crc[3] != CRC[3])
 		{
 			TP_ERROR(Log::ImagePNGPrefix, "tRNS CRC: ", Utils::Hash::ConvertHashToString(CRC), " is wrong!");
@@ -668,7 +668,7 @@ bool TRAP::INTERNAL::PNGImage::ProcessPLTE(std::ifstream& file, Data& data, cons
 		CRCData[j++ + 4] = i.Blue;
 	}
 
-	std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
+	const std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
 	if (crc[0] != CRC[0] && crc[1] != CRC[1] && crc[2] != CRC[2] && crc[3] != CRC[3])
 	{
 		TP_ERROR(Log::ImagePNGPrefix, "PLTE CRC: ", Utils::Hash::ConvertHashToString(CRC), " is wrong!");
@@ -698,7 +698,7 @@ bool TRAP::INTERNAL::PNGImage::ProcessIDAT(std::ifstream& file, Data& data, cons
 	for (uint32_t i = 0; i < compressedData.size(); i++)
 		CRCData[i + 4] = compressedData[i];
 
-	std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
+	const std::array<uint8_t, 4> crc = Utils::Hash::CRC32(CRCData.data(), CRCData.size());
 	if (crc[0] != CRC[0] && crc[1] != CRC[1] && crc[2] != CRC[2] && crc[3] != CRC[3])
 	{
 		TP_ERROR(Log::ImagePNGPrefix, "IDAT CRC: ", Utils::Hash::ConvertHashToString(CRC), " is wrong!");
@@ -857,7 +857,7 @@ bool TRAP::INTERNAL::PNGImage::DecompressData(uint8_t* source, const int sourceL
 		return false;
 	}
 
-	uint8_t* buf = &source[sourceLength - 4];
+	const uint8_t* buf = &source[sourceLength - 4];
 	const std::array<uint8_t, 4> adler32 =
 	{
 		buf[0],
@@ -865,7 +865,7 @@ bool TRAP::INTERNAL::PNGImage::DecompressData(uint8_t* source, const int sourceL
 		buf[2],
 		buf[3]
 	};
-	std::array<uint8_t, 4> checksum = Utils::Hash::Adler32(destination, destinationLength);
+	const std::array<uint8_t, 4> checksum = Utils::Hash::Adler32(destination, destinationLength);
 
 	if (checksum[0] != adler32[0] && checksum[1] != adler32[1] && checksum[2] != adler32[2] &&
 	    checksum[3] != adler32[3])
@@ -883,11 +883,11 @@ bool TRAP::INTERNAL::PNGImage::DecompressData(uint8_t* source, const int sourceL
 //-------------------------------------------------------------------------------------------------------------------//
 
 bool TRAP::INTERNAL::PNGImage::UnFilterScanline(uint8_t* recon,
-	const uint8_t* scanline,
-	const uint8_t* precon,
-	const std::size_t byteWidth,
-	const uint8_t filterType,
-	const std::size_t length)
+	                                            const uint8_t* scanline,
+	                                            const uint8_t* precon,
+	                                            const std::size_t byteWidth,
+	                                            const uint8_t filterType,
+	                                            const std::size_t length)
 {
 	//For PNG Filter Method 0
 	//UnFilter a PNG Image Scanline by Scanline.
@@ -1030,7 +1030,7 @@ bool TRAP::INTERNAL::PNGImage::UnFilter(uint8_t* out, const uint8_t* in, const u
 	//width and height are image dimensions or dimensions of reduced image, bitsPerPixel is bits per pixel
 	//in and out are allowed to be the same memory address
 	//(but are not the same size since in has the extra filter Bytes)
-	uint8_t* prevLine = nullptr;
+	const uint8_t* prevLine = nullptr;
 
 	//byteWidth is used for filtering, is 1 when bpp < 8, number of bytes per pixel otherwise
 	const std::size_t byteWidth = (bitsPerPixel + 7u) / 8u;
@@ -1121,8 +1121,10 @@ bool TRAP::INTERNAL::PNGImage::PostProcessScanlines(uint8_t* out, uint8_t* in, c
 		Adam7GetPassValues(passW, passH, filterPassStart, paddedPassStart, passStart, width, height, bitsPerPixel);
 
 		for (uint32_t i = 0; i != 7; ++i)
+		{
 			if (!UnFilter(&in[paddedPassStart[i]], &in[filterPassStart[i]], passW[i], passH[i], bitsPerPixel))
 				return false;
+		}
 
 		Adam7DeInterlace(out, in, width, height, bitsPerPixel);
 	}
@@ -1138,13 +1140,13 @@ constexpr std::array<uint32_t, 7> ADAM7_DX = { 8, 8, 4, 4, 2, 2, 1 }; /*X delta 
 constexpr std::array<uint32_t, 7> ADAM7_DY = { 8, 8, 8, 4, 4, 2, 2 }; /*Y delta values*/
 
 void TRAP::INTERNAL::PNGImage::Adam7GetPassValues(std::array<uint32_t, 7>& passW,
-	std::array<uint32_t, 7>& passH,
-	std::array<std::size_t, 8>& filterPassStart,
-	std::array<std::size_t, 8>& paddedPassStart,
-	std::array<std::size_t, 8>& passStart,
-	const uint32_t width,
-	const uint32_t height,
-	const uint32_t bitsPerPixel)
+	                                              std::array<uint32_t, 7>& passH,
+	                                              std::array<std::size_t, 8>& filterPassStart,
+	                                              std::array<std::size_t, 8>& paddedPassStart,
+	                                              std::array<std::size_t, 8>& passStart,
+	                                              const uint32_t width,
+	                                              const uint32_t height,
+	                                              const uint32_t bitsPerPixel)
 {
 	//"padded" is only relevant if bitsPerPixel is less than 8 and a scanline or image does not end at a full byte
 

--- a/TRAP/src/ImageLoader/PortableNetworkGraphics/PNGImage.cpp
+++ b/TRAP/src/ImageLoader/PortableNetworkGraphics/PNGImage.cpp
@@ -2,7 +2,7 @@
 #include "PNGImage.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Maths/Math.h"
 #include "Utils/ByteSwap.h"
 #include "Utils/Utils.h"
@@ -19,7 +19,7 @@ TRAP::INTERNAL::PNGImage::PNGImage(std::filesystem::path filepath)
 
 	TP_DEBUG(Log::ImagePNGPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/PortableNetworkGraphics/PNGImage.cpp
+++ b/TRAP/src/ImageLoader/PortableNetworkGraphics/PNGImage.cpp
@@ -59,8 +59,7 @@ TRAP::INTERNAL::PNGImage::PNGImage(std::filesystem::path filepath)
 		while (nextChunk.MagicNumber != "IEND")
 		{
 			file.read(reinterpret_cast<char*>(&nextChunk.Length), sizeof(uint32_t));
-			file.read(reinterpret_cast<char*>(nextChunk.MagicNumber.data()),
-			          static_cast<std::streamsize>(nextChunk.MagicNumber.size()));
+			file.read(nextChunk.MagicNumber.data(), static_cast<std::streamsize>(nextChunk.MagicNumber.size()));
 			if (needSwap)
 				Utils::Memory::SwapBytes(nextChunk.Length);
 

--- a/TRAP/src/ImageLoader/PortableNetworkGraphics/PNGImage.cpp
+++ b/TRAP/src/ImageLoader/PortableNetworkGraphics/PNGImage.cpp
@@ -17,7 +17,7 @@ TRAP::INTERNAL::PNGImage::PNGImage(std::filesystem::path filepath)
 
 	m_filepath = std::move(filepath);
 
-	TP_DEBUG(Log::ImagePNGPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
+	TP_DEBUG(Log::ImagePNGPrefix, "Loading image: \"", m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -25,7 +25,7 @@ TRAP::INTERNAL::PNGImage::PNGImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImagePNGPrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImagePNGPrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImagePNGPrefix, "Using default image!");
 		return;
 	}

--- a/TRAP/src/ImageLoader/QuiteOKImage/QOIImage.cpp
+++ b/TRAP/src/ImageLoader/QuiteOKImage/QOIImage.cpp
@@ -63,7 +63,7 @@ TRAP::INTERNAL::QOIImage::QOIImage(std::filesystem::path filepath)
     }
 
 	//Height and width uses big-endian
-	bool needSwap = Utils::GetEndian() != Utils::Endian::Big;
+	const bool needSwap = Utils::GetEndian() != Utils::Endian::Big;
 
     //Convert to machines endian
     if(needSwap)

--- a/TRAP/src/ImageLoader/QuiteOKImage/QOIImage.cpp
+++ b/TRAP/src/ImageLoader/QuiteOKImage/QOIImage.cpp
@@ -30,9 +30,16 @@ TRAP::INTERNAL::QOIImage::QOIImage(std::filesystem::path filepath)
 		return;
 	}
 
-    file.seekg(0, std::ios::end);
-    const std::size_t fileSize = file.tellg();
-    file.seekg(0);
+    const auto size = FileSystem::GetFileOrFolderSize(filepath);
+    std::size_t fileSize;
+    if(size)
+        fileSize = *size;
+    else //Fallback
+    {
+        file.seekg(0, std::ios::end);
+        fileSize = file.tellg();
+        file.seekg(0);
+    }
 
     if(fileSize < sizeof(Header) + EndMarker.size())
     {

--- a/TRAP/src/ImageLoader/QuiteOKImage/QOIImage.cpp
+++ b/TRAP/src/ImageLoader/QuiteOKImage/QOIImage.cpp
@@ -2,7 +2,7 @@
 #include "QOIImage.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Utils/ByteSwap.h"
 #include "Utils/Utils.h"
 #include "ImageLoader/Image.h"
@@ -19,7 +19,7 @@ TRAP::INTERNAL::QOIImage::QOIImage(std::filesystem::path filepath)
 
 	TP_DEBUG(Log::ImageQOIPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/QuiteOKImage/QOIImage.cpp
+++ b/TRAP/src/ImageLoader/QuiteOKImage/QOIImage.cpp
@@ -17,7 +17,7 @@ TRAP::INTERNAL::QOIImage::QOIImage(std::filesystem::path filepath)
 
 	m_filepath = std::move(filepath);
 
-	TP_DEBUG(Log::ImageQOIPrefix, "Loading image: \"", m_filepath.generic_u8string(), "\"");
+	TP_DEBUG(Log::ImageQOIPrefix, "Loading image: \"", m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -25,7 +25,7 @@ TRAP::INTERNAL::QOIImage::QOIImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImageQOIPrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImageQOIPrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImageQOIPrefix, "Using default image!");
 		return;
 	}
@@ -36,7 +36,7 @@ TRAP::INTERNAL::QOIImage::QOIImage(std::filesystem::path filepath)
 
     if(fileSize < sizeof(Header) + EndMarker.size())
     {
-        TP_ERROR(Log::ImageQOIPrefix, "File size is too small: ", m_filepath.generic_u8string(), "!");
+        TP_ERROR(Log::ImageQOIPrefix, "File size is too small: ", m_filepath.u8string(), "!");
         TP_WARN(Log::ImageQOIPrefix, "Using default image!");
         return;
     }

--- a/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
+++ b/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
@@ -58,12 +58,12 @@ TRAP::INTERNAL::RadianceImage::RadianceImage(std::filesystem::path filepath)
 		return;
 	}
 
-	char signOne = static_cast<char>(file.get());
-	char axisOne = static_cast<char>(file.get());
+	const char signOne = static_cast<char>(file.get());
+	const char axisOne = static_cast<char>(file.get());
 	file >> m_width;
 	file.ignore();
-	char signTwo = static_cast<char>(file.get());
-	char axisTwo = static_cast<char>(file.get());
+	const char signTwo = static_cast<char>(file.get());
+	const char axisTwo = static_cast<char>(file.get());
 	file >> m_height;
 	file.ignore();
 

--- a/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
+++ b/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
@@ -236,7 +236,7 @@ bool TRAP::INTERNAL::RadianceImage::OldDecrunch(std::vector<std::array<uint8_t, 
 		{
 			for(int32_t i = scanline[0 + scanlineIndex][E] << rshift; i > 0; i--)
 			{
-				std::memcpy(&scanline[0 + scanlineIndex][0], &scanline[-1 + scanlineIndex][0], 4);
+				memcpy(&scanline[0 + scanlineIndex][0], &scanline[-1 + scanlineIndex][0], 4);
 				scanlineIndex++;
 				length--;
 			}

--- a/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
+++ b/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
@@ -16,7 +16,7 @@ TRAP::INTERNAL::RadianceImage::RadianceImage(std::filesystem::path filepath)
 	m_colorFormat = ColorFormat::RGB;
 
 	TP_DEBUG(Log::ImageRadiancePrefix, "Loading image: \"",
-	         m_filepath.generic_u8string(), "\"");
+	         m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -24,7 +24,7 @@ TRAP::INTERNAL::RadianceImage::RadianceImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImageRadiancePrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImageRadiancePrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImageRadiancePrefix, "Using default image!");
 		return;
 	}

--- a/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
+++ b/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
@@ -3,7 +3,7 @@
 
 #include "Application.h"
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 TRAP::INTERNAL::RadianceImage::RadianceImage(std::filesystem::path filepath)
 	: eMax(-127), eMin(127)
@@ -18,7 +18,7 @@ TRAP::INTERNAL::RadianceImage::RadianceImage(std::filesystem::path filepath)
 	TP_DEBUG(Log::ImageRadiancePrefix, "Loading image: \"",
 	         m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
+++ b/TRAP/src/ImageLoader/RadianceHDR/RadianceImage.cpp
@@ -236,7 +236,7 @@ bool TRAP::INTERNAL::RadianceImage::OldDecrunch(std::vector<std::array<uint8_t, 
 		{
 			for(int32_t i = scanline[0 + scanlineIndex][E] << rshift; i > 0; i--)
 			{
-				memcpy(&scanline[0 + scanlineIndex][0], &scanline[-1 + scanlineIndex][0], 4);
+				std::copy_n(&scanline[-1 + scanlineIndex][0], 4, &scanline[0 + scanlineIndex][0]);
 				scanlineIndex++;
 				length--;
 			}

--- a/TRAP/src/ImageLoader/TARGA/TGAImage.cpp
+++ b/TRAP/src/ImageLoader/TARGA/TGAImage.cpp
@@ -31,13 +31,13 @@ TRAP::INTERNAL::TGAImage::TGAImage(std::filesystem::path filepath)
 	header.IDLength = static_cast<uint8_t>(file.get());
 	header.ColorMapType = static_cast<uint8_t>(file.get());
 	header.ImageType = static_cast<uint8_t>(file.get());
-	file.read(reinterpret_cast<char*>(&header.ColorMapOffset), 2);
-	file.read(reinterpret_cast<char*>(&header.NumOfColorMaps), 2);
+	file.read(reinterpret_cast<char*>(&header.ColorMapOffset), sizeof(uint16_t));
+	file.read(reinterpret_cast<char*>(&header.NumOfColorMaps), sizeof(uint16_t));
 	header.ColorMapDepth = static_cast<uint8_t>(file.get());
-	file.read(reinterpret_cast<char*>(&header.XOffset), 2);
-	file.read(reinterpret_cast<char*>(&header.YOffset), 2);
-	file.read(reinterpret_cast<char*>(&header.Width), 2);
-	file.read(reinterpret_cast<char*>(&header.Height), 2);
+	file.read(reinterpret_cast<char*>(&header.XOffset), sizeof(uint16_t));
+	file.read(reinterpret_cast<char*>(&header.YOffset), sizeof(uint16_t));
+	file.read(reinterpret_cast<char*>(&header.Width), sizeof(uint16_t));
+	file.read(reinterpret_cast<char*>(&header.Height), sizeof(uint16_t));
 	header.BitsPerPixel = static_cast<uint8_t>(file.get());
 	header.ImageDescriptor = static_cast<uint8_t>(file.get());
 

--- a/TRAP/src/ImageLoader/TARGA/TGAImage.cpp
+++ b/TRAP/src/ImageLoader/TARGA/TGAImage.cpp
@@ -2,7 +2,7 @@
 #include "TGAImage.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 #include "Utils/ByteSwap.h"
 #include "Utils/Utils.h"
 
@@ -14,7 +14,7 @@ TRAP::INTERNAL::TGAImage::TGAImage(std::filesystem::path filepath)
 	TP_DEBUG(Log::ImageTGAPrefix, "Loading image: \"",
 	         m_filepath.generic_u8string(), "\"");
 
-	if (!FS::FileOrFolderExists(m_filepath))
+	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
 
 	std::ifstream file(m_filepath, std::ios::binary);

--- a/TRAP/src/ImageLoader/TARGA/TGAImage.cpp
+++ b/TRAP/src/ImageLoader/TARGA/TGAImage.cpp
@@ -110,7 +110,7 @@ TRAP::INTERNAL::TGAImage::TGAImage(std::filesystem::path filepath)
 	}
 	if(header.ImageType == 9 || header.ImageType == 11 || header.ImageType == 10) //All RLE formats
 	{
-		uint32_t currentPosition = static_cast<uint32_t>(file.tellg()); //Store current position in file
+		const uint32_t currentPosition = static_cast<uint32_t>(file.tellg()); //Store current position in file
 		file.seekg(0, std::ios::end); //Go to the end of file
 		uint32_t pixelDataSize = static_cast<uint32_t>(file.tellg()) - currentPosition;
 		file.seekg(-18, std::ios::end); //Check if there is a footer

--- a/TRAP/src/ImageLoader/TARGA/TGAImage.cpp
+++ b/TRAP/src/ImageLoader/TARGA/TGAImage.cpp
@@ -12,7 +12,7 @@ TRAP::INTERNAL::TGAImage::TGAImage(std::filesystem::path filepath)
 
 	m_filepath = std::move(filepath);
 	TP_DEBUG(Log::ImageTGAPrefix, "Loading image: \"",
-	         m_filepath.generic_u8string(), "\"");
+	         m_filepath.u8string(), "\"");
 
 	if (!FileSystem::FileOrFolderExists(m_filepath))
 		return;
@@ -20,7 +20,7 @@ TRAP::INTERNAL::TGAImage::TGAImage(std::filesystem::path filepath)
 	std::ifstream file(m_filepath, std::ios::binary);
 	if (!file.is_open())
 	{
-		TP_ERROR(Log::ImageTGAPrefix, "Couldn't open file path: ", m_filepath.generic_u8string(), "!");
+		TP_ERROR(Log::ImageTGAPrefix, "Couldn't open file path: ", m_filepath.u8string(), "!");
 		TP_WARN(Log::ImageTGAPrefix, "Using default image!");
 		return;
 	}

--- a/TRAP/src/Input/Input.cpp
+++ b/TRAP/src/Input/Input.cpp
@@ -813,7 +813,7 @@ bool TRAP::Input::ParseMapping(Mapping& mapping, const std::string& str)
 		std::string Name;
 		MapElement* Element = nullptr;
 	};
-	std::array<Fields, 22> fields =
+	const std::array<Fields, 22> fields =
 	{
 		{
 			{"platform", nullptr},
@@ -841,7 +841,7 @@ bool TRAP::Input::ParseMapping(Mapping& mapping, const std::string& str)
 		}
 	};
 
-	std::vector<std::string> splittedString = Utils::String::SplitString(str, ',');
+	const std::vector<std::string> splittedString = Utils::String::SplitString(str, ',');
 
 	if(splittedString.empty())
 	{
@@ -877,7 +877,7 @@ bool TRAP::Input::ParseMapping(Mapping& mapping, const std::string& str)
 
 	for (uint8_t i = 2; i < splittedString.size();) //Start after Mapping Name
 	{
-		std::vector<std::string> splittedField = Utils::String::SplitString(splittedString[i] + ':', ':');
+		const std::vector<std::string> splittedField = Utils::String::SplitString(splittedString[i] + ':', ':');
 		if (splittedField.empty())
 		{
 			TP_ERROR(Log::InputControllerPrefix, "Field can't be empty! Mapping: ", splittedString[1]);
@@ -1065,15 +1065,17 @@ bool TRAP::Input::GetMappedControllerButton(Controller controller, ControllerBut
 	if (!PollController(controller, PollMode::Buttons))
 		return false;
 
-	ControllerInternal* con = &s_controllerInternal[static_cast<uint32_t>(controller)];
+	const ControllerInternal* con = &s_controllerInternal[static_cast<uint32_t>(controller)];
 
 	if (!con->mapping)
 		return false;
 
 	const MapElement* e = &con->mapping->Buttons[static_cast<uint8_t>(button)];
 	if (e->Index < con->ButtonCount)
+	{
 		if (e->Type == 2) //Button
 			return con->Buttons[e->Index];
+	}
 	if (e->Type == 1) //Axis
 	{
 		const float value = con->Axes[e->Index] * static_cast<float>(e->AxisScale) +
@@ -1100,12 +1102,12 @@ bool TRAP::Input::GetMappedControllerButton(Controller controller, ControllerBut
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-float TRAP::Input::GetMappedControllerAxis(Controller controller, ControllerAxis axis)
+float TRAP::Input::GetMappedControllerAxis(const Controller controller, const ControllerAxis axis)
 {
 	if(!PollController(controller, PollMode::Axes))
 		return 0.0f;
 
-	ControllerInternal* con = &s_controllerInternal[static_cast<uint32_t>(controller)];
+	const ControllerInternal* con = &s_controllerInternal[static_cast<uint32_t>(controller)];
 
 	if(!con->mapping)
 		return 0.0f;
@@ -1132,12 +1134,12 @@ float TRAP::Input::GetMappedControllerAxis(Controller controller, ControllerAxis
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Input::ControllerDPad TRAP::Input::GetMappedControllerDPad(Controller controller, const uint32_t dpad)
+TRAP::Input::ControllerDPad TRAP::Input::GetMappedControllerDPad(const Controller controller, const uint32_t dpad)
 {
 	if(!PollController(controller, PollMode::All))
 		return ControllerDPad::Centered;
 
-	ControllerInternal* con = &s_controllerInternal[static_cast<uint32_t>(controller)];
+	const ControllerInternal* con = &s_controllerInternal[static_cast<uint32_t>(controller)];
 
 	if (!con->mapping)
 		return ControllerDPad::Centered;

--- a/TRAP/src/Input/Input.h
+++ b/TRAP/src/Input/Input.h
@@ -892,7 +892,7 @@ namespace TRAP
 		/// </summary>
 		/// <param name="path">Path to the controller file.</param>
 		/// <returns>True if the controller was opened successfully, false otherwise.</returns>
-		static bool OpenControllerDeviceLinux(std::string path);
+		static bool OpenControllerDeviceLinux(std::filesystem::path path);
 		/// <summary>
 		/// Poll state of absolute axes for the specified controller.
 		/// </summary>
@@ -925,7 +925,7 @@ namespace TRAP
 			int32_t FD = 0;
 			bool VibrationSupported = false;
 			int16_t CurrentVibration = -1;
-			std::string Path{};
+			std::filesystem::path Path{};
 			std::array<int32_t, KEY_CNT - BTN_MISC> KeyMap{};
 			std::array<int32_t, ABS_CNT> ABSMap{};
 			std::array<input_absinfo, ABS_CNT> ABSInfo{};

--- a/TRAP/src/Input/Input.h
+++ b/TRAP/src/Input/Input.h
@@ -892,7 +892,7 @@ namespace TRAP
 		/// </summary>
 		/// <param name="path">Path to the controller file.</param>
 		/// <returns>True if the controller was opened successfully, false otherwise.</returns>
-		static bool OpenControllerDeviceLinux(const std::string& path);
+		static bool OpenControllerDeviceLinux(std::string path);
 		/// <summary>
 		/// Poll state of absolute axes for the specified controller.
 		/// </summary>

--- a/TRAP/src/Input/LinuxInput.cpp
+++ b/TRAP/src/Input/LinuxInput.cpp
@@ -43,14 +43,14 @@ TRAP::Input::ControllerLinuxLibrary TRAP::Input::s_linuxController{};
 
 bool TRAP::Input::InitController()
 {
-	const char* dirName = "/dev/input";
+	constexpr std::string_view dirName = "/dev/input";
 
 	s_linuxController.INotify = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
 	if(s_linuxController.INotify > 0)
 	{
 		//HACK: Register for IN_ATTRIB to get notified when udev is done
 		//This works well in practice but the true way is libudev
-		s_linuxController.Watch = inotify_add_watch(s_linuxController.INotify, dirName,
+		s_linuxController.Watch = inotify_add_watch(s_linuxController.INotify, dirName.data(),
 		                                            IN_CREATE | IN_ATTRIB | IN_DELETE);
 	}
 
@@ -63,7 +63,7 @@ bool TRAP::Input::InitController()
 
 	int32_t count = 0;
 
-	DIR* dir = opendir(dirName);
+	DIR* dir = opendir(dirName.data());
 	if(dir)
 	{
 		dirent* entry = nullptr;
@@ -75,7 +75,7 @@ bool TRAP::Input::InitController()
 			if (regexec(&s_linuxController.Regex, entry->d_name, 1, &match, 0) != 0)
 				continue;
 
-			std::string path = dirName;
+			std::string path = std::string(dirName);
 			path += '/';
 			path += entry->d_name;
 

--- a/TRAP/src/Input/LinuxInput.cpp
+++ b/TRAP/src/Input/LinuxInput.cpp
@@ -186,7 +186,7 @@ TRAP::Input::ControllerBatteryStatus TRAP::Input::GetControllerBatteryStatusInte
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Attempt to open the specified controller device
-bool TRAP::Input::OpenControllerDeviceLinux(const std::string& path)
+bool TRAP::Input::OpenControllerDeviceLinux(const std::string path)
 {
 	for(uint8_t cID = 0; cID <= static_cast<uint8_t>(Controller::Sixteen); cID++)
 	{
@@ -296,7 +296,7 @@ bool TRAP::Input::OpenControllerDeviceLinux(const std::string& path)
 		return false;
 	}
 
-	LinuxCon.Path = path;
+	LinuxCon.Path = std::move(path);
 	con->LinuxCon = LinuxCon;
 
 	PollABSStateLinux(con);

--- a/TRAP/src/Input/LinuxInput.cpp
+++ b/TRAP/src/Input/LinuxInput.cpp
@@ -36,6 +36,7 @@ Modified by: Jan "GamesTrap" Schuerkamp
 #include "Window/WindowingAPI.h"
 #include "ControllerMappings.h"
 #include "Utils/Utils.h"
+#include "Utils/String/String.h"
 
 TRAP::Input::ControllerLinuxLibrary TRAP::Input::s_linuxController{};
 
@@ -66,7 +67,7 @@ bool TRAP::Input::InitController()
 	DIR* dir = opendir(dirName.data());
 	if(dir)
 	{
-		dirent* entry = nullptr;
+		const dirent* entry = nullptr;
 
 		while((entry = readdir(dir)))
 		{
@@ -75,9 +76,7 @@ bool TRAP::Input::InitController()
 			if (regexec(&s_linuxController.Regex, entry->d_name, 1, &match, 0) != 0)
 				continue;
 
-			std::string path = std::string(dirName);
-			path += '/';
-			path += entry->d_name;
+			const std::filesystem::path path = std::filesystem::path(dirName) / entry->d_name;
 
 			if (OpenControllerDeviceLinux(path))
 				count++;
@@ -117,7 +116,7 @@ void TRAP::Input::ShutdownController()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Input::SetControllerVibrationInternal(Controller controller, float leftMotor, float rightMotor)
+void TRAP::Input::SetControllerVibrationInternal(Controller controller, const float leftMotor, const float rightMotor)
 {
 	if(!PollController(controller, PollMode::Presence))
 		return;
@@ -178,7 +177,7 @@ void TRAP::Input::SetControllerVibrationInternal(Controller controller, float le
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Input::ControllerBatteryStatus TRAP::Input::GetControllerBatteryStatusInternal(Controller)
+TRAP::Input::ControllerBatteryStatus TRAP::Input::GetControllerBatteryStatusInternal(Controller /*controller*/)
 {
 	return ControllerBatteryStatus::Wired;
 }
@@ -186,7 +185,7 @@ TRAP::Input::ControllerBatteryStatus TRAP::Input::GetControllerBatteryStatusInte
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Attempt to open the specified controller device
-bool TRAP::Input::OpenControllerDeviceLinux(const std::string path)
+bool TRAP::Input::OpenControllerDeviceLinux(const std::filesystem::path path)
 {
 	for(uint8_t cID = 0; cID <= static_cast<uint8_t>(Controller::Sixteen); cID++)
 	{
@@ -197,19 +196,19 @@ bool TRAP::Input::OpenControllerDeviceLinux(const std::string path)
 	}
 
 	ControllerLinux LinuxCon = {};
-	LinuxCon.FD = open(path.data(), O_RDWR | O_NONBLOCK); //O_RDWR is needed for vibrations
+	LinuxCon.FD = open(path.c_str(), O_RDWR | O_NONBLOCK); //O_RDWR is needed for vibrations
 	if(LinuxCon.FD != -1)
 		LinuxCon.VibrationSupported = true;
 
 	if(errno == EACCES)
-		LinuxCon.FD = open(path.data(), O_RDONLY | O_NONBLOCK);
+		LinuxCon.FD = open(path.c_str(), O_RDONLY | O_NONBLOCK);
 
 	if (LinuxCon.FD == -1)
 		return false;
 
-	std::array<char, (EV_CNT + 7) / 8> EVBits{};
-	std::array<char, (KEY_CNT + 7) / 8> keyBits{};
-	std::array<char, (ABS_CNT + 7) / 8> ABSBits{};
+	const std::array<char, (EV_CNT + 7) / 8> EVBits{};
+	const std::array<char, (KEY_CNT + 7) / 8> keyBits{};
+	const std::array<char, (ABS_CNT + 7) / 8> ABSBits{};
 	input_id ID{};
 
 	if (ioctl(LinuxCon.FD, EVIOCGBIT(0, EVBits.size()), EVBits.data()) < 0 ||
@@ -217,7 +216,7 @@ bool TRAP::Input::OpenControllerDeviceLinux(const std::string path)
 		ioctl(LinuxCon.FD, EVIOCGBIT(EV_ABS, ABSBits.size()), ABSBits.data()) < 0 ||
 		ioctl(LinuxCon.FD, EVIOCGID, &ID) < 0)
 	{
-		TP_ERROR(Log::InputControllerLinuxPrefix, "Could not query input device: ", Utils::GetStrError(), "!");
+		TP_ERROR(Log::InputControllerLinuxPrefix, "Could not query input device: ", Utils::String::GetStrError(), "!");
 		close(LinuxCon.FD);
 		return false;
 	}
@@ -327,7 +326,7 @@ void TRAP::Input::CloseController(Controller controller)
 
 	close(con->LinuxCon.FD);
 
-	bool connected = con->Connected;
+	const bool connected = con->Connected;
 
 	if(connected)
 	{
@@ -371,8 +370,7 @@ void TRAP::Input::DetectControllerConnectionLinux()
 		if (regexec(&s_linuxController.Regex, e->name, 1, &match, 0) != 0)
 			continue;
 
-		std::string path = "/dev/input/";
-		path += e->name;
+		const std::filesystem::path path = std::filesystem::path("/dev/input") / e->name;
 
 		if (e->mask & (IN_CREATE | IN_ATTRIB))
 			OpenControllerDeviceLinux(path);
@@ -447,7 +445,7 @@ void TRAP::Input::PollABSStateLinux(ControllerInternal* con)
 		if (con->LinuxCon.ABSMap[code] < 0)
 			continue;
 
-		input_absinfo* info = &con->LinuxCon.ABSInfo[code];
+		const input_absinfo* info = &con->LinuxCon.ABSInfo[code];
 
 		if (ioctl(con->LinuxCon.FD, EVIOCGABS(code), info) < 0)
 			continue;
@@ -465,7 +463,7 @@ void TRAP::Input::HandleABSEventLinux(ControllerInternal* con, int32_t code, int
 
 	if (code >= ABS_HAT0X && code <= ABS_HAT3Y)
 	{
-		static const std::array<std::array<uint8_t, 3>, 3> stateMap =
+		static constexpr std::array<std::array<uint8_t, 3>, 3> stateMap =
 		{
 			{
 				{

--- a/TRAP/src/Input/LinuxInput.cpp
+++ b/TRAP/src/Input/LinuxInput.cpp
@@ -364,7 +364,7 @@ void TRAP::Input::DetectControllerConnectionLinux()
 	while(size > offset)
 	{
 		regmatch_t match;
-		const inotify_event* e = reinterpret_cast<const inotify_event*>(&buffer[offset]);
+		const inotify_event* e = reinterpret_cast<const inotify_event*>(&buffer[offset]); //Must use reinterpret_cast because of flexible array member
 
 		offset += static_cast<ssize_t>(sizeof(inotify_event)) + e->len;
 

--- a/TRAP/src/Input/WindowsInput.cpp
+++ b/TRAP/src/Input/WindowsInput.cpp
@@ -65,7 +65,7 @@ bool TRAP::Input::InitController()
 	{
 		if (!s_xinput.Instance)
 		{
-			std::array<std::string, 5> names =
+			const std::array<std::string, 5> names =
 			{
 				"xinput1_4.dll",
 				"xinput1_3.dll",
@@ -138,7 +138,7 @@ void TRAP::Input::UpdateControllerGUID(std::string& guid)
 {
 	if (std::string_view(guid.data() + 20) == "504944564944")
 	{
-		std::string original = guid;
+		const std::string original = guid;
 
 		guid = "03000000" + std::string(original.begin(), original.begin() + 4) + "0000" +
 		       std::string(original.begin() + 4, original.begin() + 4 + 4) + "000000000000";
@@ -232,7 +232,7 @@ void TRAP::Input::SetControllerVibrationInternal(Controller controller, const fl
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Input::ControllerBatteryStatus TRAP::Input::GetControllerBatteryStatusInternal(Controller controller)
+TRAP::Input::ControllerBatteryStatus TRAP::Input::GetControllerBatteryStatusInternal(const Controller controller)
 {
 	if(!s_controllerInternal[static_cast<uint32_t>(controller)].WinCon.XInput)
 		return ControllerBatteryStatus::Wired;
@@ -260,7 +260,7 @@ TRAP::Input::ControllerBatteryStatus TRAP::Input::GetControllerBatteryStatusInte
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::Input::PollController(Controller controller, const PollMode mode)
+bool TRAP::Input::PollController(const Controller controller, const PollMode mode)
 {
 	ControllerInternal* con = &s_controllerInternal[static_cast<uint32_t>(controller)];
 	if (con->WinCon.Device)
@@ -312,7 +312,7 @@ bool TRAP::Input::PollController(Controller controller, const PollMode mode)
 
 			case TRAP_TYPE_DPAD:
 			{
-				const std::array<uint8_t, 9> states =
+				constexpr std::array<uint8_t, 9> states =
 				{
 					static_cast<uint8_t>(ControllerDPad::Up),
 					static_cast<uint8_t>(ControllerDPad::Right_Up),

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
@@ -106,8 +106,8 @@ void TRAP::ImGuiLayer::OnAttach()
 			TRAP::Graphics::RendererAPI::GetRenderer()
 		);
 
-		VkDescriptorPoolCreateInfo poolInfo = Graphics::API::VulkanInits::DescriptorPoolCreateInfo(m_descriptorPoolSizes,
-		                                                                                           1000);
+		const VkDescriptorPoolCreateInfo poolInfo = Graphics::API::VulkanInits::DescriptorPoolCreateInfo(m_descriptorPoolSizes,
+		                                                                                                 1000);
 		VkCall(vkCreateDescriptorPool(renderer->GetDevice()->GetVkDevice(), &poolInfo, nullptr,
 		                              &m_imguiDescriptorPool));
 
@@ -194,7 +194,7 @@ void TRAP::ImGuiLayer::OnEvent(Events::Event& event)
 {
 	if (m_blockEvents)
 	{
-		ImGuiIO& io = ImGui::GetIO();
+		const ImGuiIO& io = ImGui::GetIO();
 		event.Handled |= event.IsInCategory(Events::EventCategory::Mouse) & io.WantCaptureMouse;
 		event.Handled |= event.IsInCategory(Events::EventCategory::Keyboard) & io.WantCaptureKeyboard;
 	}
@@ -321,9 +321,9 @@ void ImGui::Image(TRAP::Graphics::Texture* image, TRAP::Graphics::Sampler* sampl
 
 	if (TRAP::Graphics::RendererAPI::GetRenderAPI() == TRAP::Graphics::RenderAPI::Vulkan)
 	{
-		auto* vkImage = dynamic_cast<TRAP::Graphics::API::VulkanTexture*>(image);
-		auto* vkSampler = dynamic_cast<TRAP::Graphics::API::VulkanSampler*>(sampler);
-		ImTextureID texID = ImGui_ImplVulkan_AddTexture(vkSampler->GetVkSampler(), vkImage->GetSRVVkImageView(),
+		const auto* vkImage = dynamic_cast<TRAP::Graphics::API::VulkanTexture*>(image);
+		const auto* vkSampler = dynamic_cast<TRAP::Graphics::API::VulkanSampler*>(sampler);
+		const ImTextureID texID = ImGui_ImplVulkan_AddTexture(vkSampler->GetVkSampler(), vkImage->GetSRVVkImageView(),
 		                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 		ImGui::Image(texID, size, uv0, uv1, tint_col, border_col);
 	}
@@ -339,8 +339,8 @@ void ImGui::Image(TRAP::Graphics::Texture* image, const ImVec2& size, const ImVe
 
 	if (TRAP::Graphics::RendererAPI::GetRenderAPI() == TRAP::Graphics::RenderAPI::Vulkan)
 	{
-		auto* vkImage = dynamic_cast<TRAP::Graphics::API::VulkanTexture*>(image);
-		ImTextureID texID = ImGui_ImplVulkan_AddTexture(TRAP::Graphics::API::VulkanRenderer::s_NullDescriptors->DefaultSampler->GetVkSampler(),
+		const auto* vkImage = dynamic_cast<TRAP::Graphics::API::VulkanTexture*>(image);
+		const ImTextureID texID = ImGui_ImplVulkan_AddTexture(TRAP::Graphics::API::VulkanRenderer::s_NullDescriptors->DefaultSampler->GetVkSampler(),
 		                                                      vkImage->GetSRVVkImageView(),
 		                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 		ImGui::Image(texID, size, uv0, uv1, tint_col, border_col);

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
@@ -26,7 +26,7 @@
 #include "Graphics/API/Vulkan/Objects/VulkanPipelineCache.h"
 #include "Graphics/API/Vulkan/Objects/VulkanTexture.h"
 #include "Graphics/API/Vulkan/Objects/VulkanSampler.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -52,7 +52,7 @@ void TRAP::ImGuiLayer::OnAttach()
 	io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable; //Enable Multi-Viewport / Platform Windows
 
 	//Set imgui.ini path
-	const auto docsFolder = TRAP::FS::GetGameDocumentsFolderPath();
+	const auto docsFolder = TRAP::FileSystem::GetGameDocumentsFolderPath();
 	if(docsFolder)
 		m_imguiIniPath = (*docsFolder / "imgui.ini").generic_u8string();
 	else //Fallback
@@ -111,7 +111,7 @@ void TRAP::ImGuiLayer::OnAttach()
 		VkCall(vkCreateDescriptorPool(renderer->GetDevice()->GetVkDevice(), &poolInfo, nullptr,
 		                              &m_imguiDescriptorPool));
 
-		const auto tempFolder = TRAP::FS::GetGameTempFolderPath();
+		const auto tempFolder = TRAP::FileSystem::GetGameTempFolderPath();
 		if(tempFolder)
 		{
 			TRAP::Graphics::RendererAPI::PipelineCacheLoadDesc cacheDesc{};
@@ -166,7 +166,7 @@ void TRAP::ImGuiLayer::OnDetach()
 	{
 		TP_TRACE(Log::ImGuiPrefix, "Vulkan shutdown...");
 		Graphics::RendererAPI::GetRenderer()->WaitIdle();
-		const auto tempFolder = TRAP::FS::GetGameTempFolderPath();
+		const auto tempFolder = TRAP::FileSystem::GetGameTempFolderPath();
 		if(tempFolder)
 			m_imguiPipelineCache->Save(*tempFolder / "ImGui.cache");
 		m_imguiPipelineCache.reset();

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
@@ -54,7 +54,7 @@ void TRAP::ImGuiLayer::OnAttach()
 	//Set imgui.ini path
 	const auto docsFolder = TRAP::FileSystem::GetGameDocumentsFolderPath();
 	if(docsFolder)
-		m_imguiIniPath = (*docsFolder / "imgui.ini").generic_u8string();
+		m_imguiIniPath = (*docsFolder / "imgui.ini").u8string();
 	else //Fallback
 		m_imguiIniPath = "imgui.ini";
 	io.IniFilename = m_imguiIniPath.c_str();

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
@@ -65,12 +65,11 @@ void TRAP::ImGuiLayer::OnAttach()
 		scaleFactor = contentScale.x;
 
 	ImFontConfig fontConfig;
-	fontConfig.FontDataOwnedByAtlas = false;
-	//While looking like UB Casting const uint8_t* to void* in this instance is okay because the memory will only be copied by ImGui because of the above line
-	io.Fonts->AddFontFromMemoryTTF(reinterpret_cast<void*>(const_cast<uint8_t*>(Embed::OpenSansBoldTTFData.data())),
+	fontConfig.FontDataOwnedByAtlas = false; //This makes the const_cast below safe.
+	io.Fonts->AddFontFromMemoryTTF(const_cast<uint8_t*>(Embed::OpenSansBoldTTFData.data()),
 	                               static_cast<int32_t>(Embed::OpenSansBoldTTFData.size()),
 								   scaleFactor * 18.0f, &fontConfig);
-	io.FontDefault = io.Fonts->AddFontFromMemoryTTF(reinterpret_cast<void*>(const_cast<uint8_t*>(Embed::OpenSansTTFData.data())),
+	io.FontDefault = io.Fonts->AddFontFromMemoryTTF(const_cast<uint8_t*>(Embed::OpenSansTTFData.data()),
 	                                                static_cast<int32_t>(Embed::OpenSansTTFData.size()),
 													scaleFactor * 18.0f, &fontConfig);
 

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.h
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.h
@@ -78,7 +78,7 @@ namespace TRAP
 		TRAP::Ref<TRAP::Graphics::PipelineCache> m_imguiPipelineCache;
 		VkDescriptorPool m_imguiDescriptorPool;
 
-		std::vector<VkDescriptorPoolSize> m_descriptorPoolSizes =
+		const std::vector<VkDescriptorPoolSize> m_descriptorPoolSizes =
 		{
 			{ VK_DESCRIPTOR_TYPE_SAMPLER, 1000 },
 			{ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1000 },

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
@@ -1083,7 +1083,7 @@ bool ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info, VkRenderPass render_
 
     // Setup backend capabilities flags
     ImGui_ImplVulkan_Data* bd = IM_NEW(ImGui_ImplVulkan_Data)();
-    io.BackendRendererUserData = reinterpret_cast<void*>(bd);
+    io.BackendRendererUserData = bd;
     io.BackendRendererName = "TRAP_Vulkan";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
     io.BackendFlags |= ImGuiBackendFlags_RendererHasViewports;  // We can create multi-viewports on the Renderer side (optional)
@@ -1721,7 +1721,8 @@ static void ImGui_ImplVulkan_CreateWindow(ImGuiViewport* viewport)
 
     // Create surface
     ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
-    VkResult err = static_cast<VkResult>(platform_io.Platform_CreateVkSurface(viewport, reinterpret_cast<ImU64>(v->Instance), static_cast<const void*>(v->Allocator), reinterpret_cast<ImU64*>(&wd->Surface)));
+    const ImU64 instance = TRAP::Utils::BitCast<VkInstance, ImU64>(v->Instance);
+    const VkResult err = static_cast<VkResult>(platform_io.Platform_CreateVkSurface(viewport, instance, static_cast<const void*>(v->Allocator), reinterpret_cast<ImU64*>(&wd->Surface)));
     check_vk_result(err);
 
     // Check for WSI support

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
@@ -474,8 +474,8 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
         for (int n = 0; n < draw_data->CmdListsCount; n++)
         {
             const ImDrawList* cmd_list = draw_data->CmdLists[n];
-            memcpy(vtx_dst, cmd_list->VtxBuffer.Data, cmd_list->VtxBuffer.Size * sizeof(ImDrawVert));
-            memcpy(idx_dst, cmd_list->IdxBuffer.Data, cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx));
+            std::copy_n(cmd_list->VtxBuffer.Data, cmd_list->VtxBuffer.Size, vtx_dst);
+            std::copy_n(cmd_list->IdxBuffer.Data, cmd_list->IdxBuffer.Size, idx_dst);
             vtx_dst += cmd_list->VtxBuffer.Size;
             idx_dst += cmd_list->IdxBuffer.Size;
         }
@@ -658,7 +658,7 @@ bool ImGui_ImplVulkan_CreateFontsTexture(VkCommandBuffer command_buffer)
         char* map = nullptr;
         err = vkMapMemory(v->Device, bd->UploadBufferMemory, 0, upload_size, 0, reinterpret_cast<void**>(&map));
         check_vk_result(err);
-        memcpy(map, pixels, upload_size);
+        std::copy_n(pixels, upload_size, map);
         VkMappedMemoryRange range{};
         range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
         range.memory = bd->UploadBufferMemory;
@@ -1816,7 +1816,7 @@ static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
         }
         {
             ImVec4 clear_color = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
-            memcpy(&wd->ClearValue.color.float32[0], &clear_color, 4 * sizeof(float));
+            std::copy_n(&clear_color.x, 4, &wd->ClearValue.color.float32[0]);
 
             VkRenderPassBeginInfo info = {};
             info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
@@ -317,8 +317,8 @@ static ImGui_ImplVulkan_Data* ImGui_ImplVulkan_GetBackendData()
 
 static uint32_t ImGui_ImplVulkan_MemoryType(VkMemoryPropertyFlags properties, uint32_t type_bits)
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
 
     VkPhysicalDeviceMemoryProperties prop;
     vkGetPhysicalDeviceMemoryProperties(v->PhysicalDevice, &prop);
@@ -335,10 +335,10 @@ static uint32_t ImGui_ImplVulkan_MemoryType(VkMemoryPropertyFlags properties, ui
 
 static void check_vk_result(VkResult err)
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     if (!bd)
         return;
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
     if (v->CheckVkResultFn)
         v->CheckVkResultFn(err);
 }
@@ -349,7 +349,7 @@ static void CreateOrResizeBuffer(VkBuffer& buffer, VkDeviceMemory& buffer_memory
                                  size_t new_size, VkBufferUsageFlagBits usage)
 {
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
     VkResult err;
 
     if (buffer != VK_NULL_HANDLE)
@@ -357,7 +357,7 @@ static void CreateOrResizeBuffer(VkBuffer& buffer, VkDeviceMemory& buffer_memory
     if (buffer_memory != VK_NULL_HANDLE)
         vkFreeMemory(v->Device, buffer_memory, v->Allocator);
 
-    VkDeviceSize vertex_buffer_size_aligned = ((new_size - 1) / bd->BufferMemoryAlignment + 1) * bd->BufferMemoryAlignment;
+    const VkDeviceSize vertex_buffer_size_aligned = ((new_size - 1) / bd->BufferMemoryAlignment + 1) * bd->BufferMemoryAlignment;
     VkBufferCreateInfo buffer_info = {};
     buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
     buffer_info.size = vertex_buffer_size_aligned;
@@ -387,7 +387,7 @@ static void ImGui_ImplVulkan_SetupRenderState(ImDrawData* draw_data, VkPipeline 
                                               VkCommandBuffer command_buffer,
                                               ImGui_ImplVulkanH_FrameRenderBuffers* rb, int fb_width, int fb_height)
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
 
     // Bind pipeline
     {
@@ -397,8 +397,8 @@ static void ImGui_ImplVulkan_SetupRenderState(ImDrawData* draw_data, VkPipeline 
     // Bind Vertex And Index Buffer:
     if (draw_data->TotalVtxCount > 0)
     {
-        VkBuffer vertex_buffers = rb->VertexBuffer;
-        VkDeviceSize vertex_offset = 0;
+        const VkBuffer vertex_buffers = rb->VertexBuffer;
+        const VkDeviceSize vertex_offset = 0;
         vkCmdBindVertexBuffers(command_buffer, 0, 1, &vertex_buffers, &vertex_offset);
         vkCmdBindIndexBuffer(command_buffer, rb->IndexBuffer, 0, sizeof(ImDrawIdx) == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32);
     }
@@ -418,8 +418,8 @@ static void ImGui_ImplVulkan_SetupRenderState(ImDrawData* draw_data, VkPipeline 
     // Setup scale and translation:
     // Our visible imgui space lies from draw_data->DisplayPps (top left) to draw_data->DisplayPos+data_data->DisplaySize (bottom right). DisplayPos is (0,0) for single viewport apps.
     {
-        std::array<float, 2> scale{2.0f / draw_data->DisplaySize.x, 2.0f / draw_data->DisplaySize.y};
-        std::array<float, 2> translate{-1.0f - draw_data->DisplayPos.x * scale[0], -1.0f - draw_data->DisplayPos.y * scale[1]};
+        const std::array<float, 2> scale{2.0f / draw_data->DisplaySize.x, 2.0f / draw_data->DisplaySize.y};
+        const std::array<float, 2> translate{-1.0f - draw_data->DisplayPos.x * scale[0], -1.0f - draw_data->DisplayPos.y * scale[1]};
         vkCmdPushConstants(command_buffer, bd->PipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, sizeof(float) * 0, sizeof(float) * 2, scale.data());
         vkCmdPushConstants(command_buffer, bd->PipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, sizeof(float) * 2, sizeof(float) * 2, translate.data());
     }
@@ -431,13 +431,13 @@ static void ImGui_ImplVulkan_SetupRenderState(ImDrawData* draw_data, VkPipeline 
 void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer command_buffer, VkPipeline pipeline)
 {
     // Avoid rendering when minimized, scale coordinates for retina displays (screen coordinates != framebuffer coordinates)
-    int fb_width = static_cast<int32_t>(draw_data->DisplaySize.x * draw_data->FramebufferScale.x);
-    int fb_height = static_cast<int32_t>(draw_data->DisplaySize.y * draw_data->FramebufferScale.y);
+    const int fb_width = static_cast<int32_t>(draw_data->DisplaySize.x * draw_data->FramebufferScale.x);
+    const int fb_height = static_cast<int32_t>(draw_data->DisplaySize.y * draw_data->FramebufferScale.y);
     if (fb_width <= 0 || fb_height <= 0)
         return;
 
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
     if (pipeline == VK_NULL_HANDLE)
         pipeline = bd->Pipeline;
 
@@ -459,8 +459,8 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
     if (draw_data->TotalVtxCount > 0)
     {
         // Create or resize the vertex/index buffers
-        size_t vertex_size = draw_data->TotalVtxCount * sizeof(ImDrawVert);
-        size_t index_size = draw_data->TotalIdxCount * sizeof(ImDrawIdx);
+        const size_t vertex_size = draw_data->TotalVtxCount * sizeof(ImDrawVert);
+        const size_t index_size = draw_data->TotalIdxCount * sizeof(ImDrawIdx);
         if (rb->VertexBuffer == VK_NULL_HANDLE || rb->VertexBufferSize < vertex_size)
             CreateOrResizeBuffer(rb->VertexBuffer, rb->VertexBufferMemory, rb->VertexBufferSize, vertex_size, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
         if (rb->IndexBuffer == VK_NULL_HANDLE || rb->IndexBufferSize < index_size)
@@ -498,8 +498,8 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
     ImGui_ImplVulkan_SetupRenderState(draw_data, pipeline, command_buffer, rb, fb_width, fb_height);
 
     // Will project scissor/clipping rectangles into framebuffer space
-    ImVec2 clip_off = draw_data->DisplayPos;         // (0,0) unless using multi-viewports
-    ImVec2 clip_scale = draw_data->FramebufferScale; // (1,1) unless using retina display which are often (2,2)
+    const ImVec2 clip_off = draw_data->DisplayPos;         // (0,0) unless using multi-viewports
+    const ImVec2 clip_scale = draw_data->FramebufferScale; // (1,1) unless using retina display which are often (2,2)
 
     // Render command lists
     // (Because we merged all buffers into a single one, we maintain our own offset into them)
@@ -568,7 +568,7 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
     // If you use VK_DYNAMIC_STATE_VIEWPORT or VK_DYNAMIC_STATE_SCISSOR you are responsible for settings the values before rendering.
     // In theory we should aim to backup/restore those values but I am not sure this is possible.
     // We perform a call to vkCmdSetScissor() to set back a full viewport which is likely to fix things for 99% users but technically this is not perfect. (See github #4644)
-    VkRect2D scissor = { { 0, 0 }, { static_cast<uint32_t>(fb_width), static_cast<uint32_t>(fb_height) } };
+    const VkRect2D scissor = { { 0, 0 }, { static_cast<uint32_t>(fb_width), static_cast<uint32_t>(fb_height) } };
     vkCmdSetScissor(command_buffer, 0, 1, &scissor);
 }
 
@@ -576,14 +576,14 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
 
 bool ImGui_ImplVulkan_CreateFontsTexture(VkCommandBuffer command_buffer)
 {
-    ImGuiIO& io = ImGui::GetIO();
+    const ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
 
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
-    size_t upload_size = width * height * 4 * sizeof(char);
+    const size_t upload_size = width * height * 4 * sizeof(char);
 
     VkResult err;
 
@@ -718,8 +718,8 @@ bool ImGui_ImplVulkan_CreateFontsTexture(VkCommandBuffer command_buffer)
 
 void ImGui_ImplVulkan_DestroyFontsTexture()
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
 
 	if(bd->FontImage)
 		vkDestroyImage(v->Device, bd->FontImage, nullptr);
@@ -741,7 +741,7 @@ void ImGui_ImplVulkan_UploadFontsTexture()
     TRAP::Graphics::CommandBuffer* cmd = winData.GraphicCommandPools[winData.ImageIndex]->AllocateCommandBuffer(false);
     cmd->Begin();
     ImGui_ImplVulkan_CreateFontsTexture(dynamic_cast<TRAP::Graphics::API::VulkanCommandBuffer*>
-        (cmd)->GetVkCommandBuffer());
+                                        (cmd)->GetVkCommandBuffer());
     cmd->End();
 
     TRAP::Ref<TRAP::Graphics::Fence> submitFence = TRAP::Graphics::Fence::Create();
@@ -766,7 +766,7 @@ static void ImGui_ImplVulkan_CreateShaderModules(VkDevice device, const VkAlloca
         vert_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
         vert_info.codeSize = sizeof(__glsl_shader_vert_spv);
         vert_info.pCode = static_cast<uint32_t*>(__glsl_shader_vert_spv);
-        VkResult err = vkCreateShaderModule(device, &vert_info, allocator, &bd->ShaderModuleVert);
+        const VkResult err = vkCreateShaderModule(device, &vert_info, allocator, &bd->ShaderModuleVert);
         check_vk_result(err);
     }
     if (bd->ShaderModuleFrag == VK_NULL_HANDLE)
@@ -775,7 +775,7 @@ static void ImGui_ImplVulkan_CreateShaderModules(VkDevice device, const VkAlloca
         frag_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
         frag_info.codeSize = sizeof(__glsl_shader_frag_spv);
         frag_info.pCode = static_cast<uint32_t*>(__glsl_shader_frag_spv);
-        VkResult err = vkCreateShaderModule(device, &frag_info, allocator, &bd->ShaderModuleFrag);
+        const VkResult err = vkCreateShaderModule(device, &frag_info, allocator, &bd->ShaderModuleFrag);
         check_vk_result(err);
     }
 }
@@ -800,7 +800,7 @@ static void ImGui_ImplVulkan_CreateFontSampler(VkDevice device, const VkAllocati
     info.minLod = -1000;
     info.maxLod = 1000;
     info.maxAnisotropy = 1.0f;
-    VkResult err = vkCreateSampler(device, &info, allocator, &bd->FontSampler);
+    const VkResult err = vkCreateSampler(device, &info, allocator, &bd->FontSampler);
     check_vk_result(err);
 }
 
@@ -813,7 +813,7 @@ static void ImGui_ImplVulkan_CreateDescriptorSetLayout(VkDevice device, const Vk
         return;
 
     ImGui_ImplVulkan_CreateFontSampler(device, allocator);
-    VkSampler sampler = bd->FontSampler;
+    const VkSampler sampler = bd->FontSampler;
     VkDescriptorSetLayoutBinding binding{};
     binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     binding.descriptorCount = 1;
@@ -823,7 +823,7 @@ static void ImGui_ImplVulkan_CreateDescriptorSetLayout(VkDevice device, const Vk
     info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
     info.bindingCount = 1;
     info.pBindings = &binding;
-    VkResult err = vkCreateDescriptorSetLayout(device, &info, allocator, &bd->DescriptorSetLayout);
+    const VkResult err = vkCreateDescriptorSetLayout(device, &info, allocator, &bd->DescriptorSetLayout);
     check_vk_result(err);
 }
 
@@ -841,14 +841,14 @@ static void ImGui_ImplVulkan_CreatePipelineLayout(VkDevice device, const VkAlloc
     push_constants.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
     push_constants.offset = sizeof(float) * 0;
     push_constants.size = sizeof(float) * 4;
-    VkDescriptorSetLayout set_layout = bd->DescriptorSetLayout;
+    const VkDescriptorSetLayout set_layout = bd->DescriptorSetLayout;
     VkPipelineLayoutCreateInfo layout_info = {};
     layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
     layout_info.setLayoutCount = 1;
     layout_info.pSetLayouts = &set_layout;
     layout_info.pushConstantRangeCount = 1;
     layout_info.pPushConstantRanges = &push_constants;
-    VkResult err = vkCreatePipelineLayout(device, &layout_info, allocator, &bd->PipelineLayout);
+    const VkResult err = vkCreatePipelineLayout(device, &layout_info, allocator, &bd->PipelineLayout);
     check_vk_result(err);
 }
 
@@ -859,7 +859,7 @@ static void ImGui_ImplVulkan_CreatePipeline(VkDevice device, const VkAllocationC
                                             VkSampleCountFlagBits MSAASamples, VkPipeline* pipeline,
                                             uint32_t subpass)
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     ImGui_ImplVulkan_CreateShaderModules(device, allocator);
 
     std::array<VkPipelineShaderStageCreateInfo, 2> stage{};
@@ -935,7 +935,7 @@ static void ImGui_ImplVulkan_CreatePipeline(VkDevice device, const VkAllocationC
     blend_info.attachmentCount = 1;
     blend_info.pAttachments = &color_attachment;
 
-    std::array<VkDynamicState, 2> dynamic_states{ VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    const std::array<VkDynamicState, 2> dynamic_states{ VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
     VkPipelineDynamicStateCreateInfo dynamic_state = {};
     dynamic_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
     dynamic_state.dynamicStateCount = static_cast<uint32_t>(dynamic_states.size());
@@ -959,7 +959,7 @@ static void ImGui_ImplVulkan_CreatePipeline(VkDevice device, const VkAllocationC
     info.layout = bd->PipelineLayout;
     info.renderPass = renderPass;
     info.subpass = subpass;
-    VkResult err = vkCreateGraphicsPipelines(device, pipelineCache, 1, &info, allocator, pipeline);
+    const VkResult err = vkCreateGraphicsPipelines(device, pipelineCache, 1, &info, allocator, pipeline);
     check_vk_result(err);
 }
 
@@ -968,7 +968,7 @@ static void ImGui_ImplVulkan_CreatePipeline(VkDevice device, const VkAllocationC
 bool ImGui_ImplVulkan_CreateDeviceObjects()
 {
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
     VkResult err;
 
     if (!bd->FontSampler)
@@ -990,7 +990,7 @@ bool ImGui_ImplVulkan_CreateDeviceObjects()
 
     if (!bd->DescriptorSetLayout)
     {
-        VkSampler sampler = bd->FontSampler;
+        const VkSampler sampler = bd->FontSampler;
         VkDescriptorSetLayoutBinding binding{};
         binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
         binding.descriptorCount = 1;
@@ -1022,7 +1022,7 @@ bool ImGui_ImplVulkan_CreateDeviceObjects()
         push_constants.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
         push_constants.offset = sizeof(float) * 0;
         push_constants.size = sizeof(float) * 4;
-        VkDescriptorSetLayout set_layout = bd->DescriptorSetLayout;
+        const VkDescriptorSetLayout set_layout = bd->DescriptorSetLayout;
         VkPipelineLayoutCreateInfo layout_info = {};
         layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
         layout_info.setLayoutCount = 1;
@@ -1043,7 +1043,7 @@ bool ImGui_ImplVulkan_CreateDeviceObjects()
 void ImGui_ImplVulkan_DestroyFontUploadObjects()
 {
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
     if (bd->UploadBuffer)
     {
         vkDestroyBuffer(v->Device, bd->UploadBuffer, v->Allocator);
@@ -1061,7 +1061,7 @@ void ImGui_ImplVulkan_DestroyFontUploadObjects()
 void ImGui_ImplVulkan_DestroyDeviceObjects()
 {
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
     ImGui_ImplVulkanH_DestroyAllViewportsRenderBuffers(v->Device, v->Allocator);
     ImGui_ImplVulkan_DestroyFontUploadObjects();
 
@@ -1146,7 +1146,7 @@ void ImGui_ImplVulkan_Shutdown()
 
 void ImGui_ImplVulkan_NewFrame()
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     IM_ASSERT(bd != nullptr && "Did you call ImGui_ImplVulkan_Init()?");
     IM_UNUSED(bd);
 }
@@ -1161,8 +1161,8 @@ void ImGui_ImplVulkan_SetMinImageCount(uint32_t min_image_count)
         return;
 
     IM_ASSERT(0); // FIXME-VIEWPORT: Unsupported. Need to recreate all swap chains!
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
-    VkResult err = vkDeviceWaitIdle(v->Device);
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const VkResult err = vkDeviceWaitIdle(v->Device);
     check_vk_result(err);
     ImGui_ImplVulkanH_DestroyAllViewportsRenderBuffers(v->Device, v->Allocator);
 
@@ -1337,7 +1337,7 @@ void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, V
                                              int w, int h, uint32_t min_image_count)
 {
     VkResult err;
-    VkSwapchainKHR old_swapchain = wd->Swapchain;
+    const VkSwapchainKHR old_swapchain = wd->Swapchain;
     wd->Swapchain = VK_NULL_HANDLE;
     err = vkDeviceWaitIdle(device);
     check_vk_result(err);
@@ -1457,7 +1457,7 @@ void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, V
         //Secondary viewports in multi-viewport mode may want to create their own pipelines.
         //This fixes the RenderPass incompatibility coming from the bd->RenderPass
         //which was first passed on to ImGui_ImplVulkan_Init().
-        ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+        const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
         ImGui_ImplVulkan_CreatePipeline(device, allocator, VK_NULL_HANDLE, wd->RenderPass, VK_SAMPLE_COUNT_1_BIT, &wd->Pipeline, bd->Subpass);
     }
 
@@ -1471,7 +1471,7 @@ void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, V
         info.components.g = VK_COMPONENT_SWIZZLE_G;
         info.components.b = VK_COMPONENT_SWIZZLE_B;
         info.components.a = VK_COMPONENT_SWIZZLE_A;
-        VkImageSubresourceRange image_range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+        const VkImageSubresourceRange image_range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
         info.subresourceRange = image_range;
         for (uint32_t i = 0; i < wd->ImageCount; i++)
         {
@@ -1615,8 +1615,8 @@ ImTextureID ImGui_ImplVulkan_AddTexture(VkSampler sampler, VkImageView imageView
         vulkanDetails.ImageView = imageView;
         vulkanDetails.ImageLayout = imageLayout;
 
-        ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-        ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+        const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+        const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
         VkDescriptorSet descriptorSet;
 
         // Create Descriptor Set:
@@ -1626,7 +1626,7 @@ ImTextureID ImGui_ImplVulkan_AddTexture(VkSampler sampler, VkImageView imageView
             allocInfo.descriptorPool = v->DescriptorPool;
             allocInfo.descriptorSetCount = 1;
             allocInfo.pSetLayouts = &bd->DescriptorSetLayout;
-            VkResult err = vkAllocateDescriptorSets(v->Device, &allocInfo, &descriptorSet);
+            const VkResult err = vkAllocateDescriptorSets(v->Device, &allocInfo, &descriptorSet);
             check_vk_result(err);
         }
 
@@ -1642,8 +1642,8 @@ ImTextureID ImGui_ImplVulkan_AddTexture(VkSampler sampler, VkImageView imageView
 ImTextureID ImGui_ImplVulkan_UpdateTextureInfo(VkDescriptorSet descriptorSet, VkSampler sampler,
                                                VkImageView imageView, VkImageLayout imageLayout)
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
 
     // Update Descriptor Set:
     {
@@ -1699,7 +1699,7 @@ void ImGui_ImplVulkan_SetMSAASamples(const VkSampleCountFlagBits sampleCount)
 
 void ImGui_ImplVulkanH_DestroyAllViewportsRenderBuffers(VkDevice device, const VkAllocationCallbacks* allocator)
 {
-    ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
+    const ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
     for (int n = 0; n < platform_io.Viewports.Size; n++)
     {
         if (ImGui_ImplVulkan_ViewportData* vd = static_cast<ImGui_ImplVulkan_ViewportData*>(platform_io.Viewports[n]->RendererUserData))
@@ -1715,11 +1715,11 @@ void ImGui_ImplVulkanH_DestroyAllViewportsRenderBuffers(VkDevice device, const V
 
 static void ImGui_ImplVulkan_CreateWindow(ImGuiViewport* viewport)
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     ImGui_ImplVulkan_ViewportData* vd = IM_NEW(ImGui_ImplVulkan_ViewportData)();
     viewport->RendererUserData = vd;
     ImGui_ImplVulkanH_Window* wd = &vd->Window;
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
 
     // Create surface
     ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
@@ -1742,7 +1742,7 @@ static void ImGui_ImplVulkan_CreateWindow(ImGuiViewport* viewport)
 
     // Select Present Mode
     // FIXME-VULKAN: Even thought mailbox seems to get us maximum framerate with a single window, it halves framerate with a second window etc. (w/ Nvidia and SDK 1.82.1)
-    std::array<VkPresentModeKHR, 3> present_modes{ VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_FIFO_KHR };
+    const std::array<VkPresentModeKHR, 3> present_modes{ VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_FIFO_KHR };
     wd->PresentMode = ImGui_ImplVulkanH_SelectPresentMode(v->PhysicalDevice, wd->Surface, present_modes.data(), static_cast<int32_t>(present_modes.size()));
 
     // Create SwapChain, RenderPass, Framebuffer, etc.
@@ -1756,10 +1756,10 @@ static void ImGui_ImplVulkan_CreateWindow(ImGuiViewport* viewport)
 static void ImGui_ImplVulkan_DestroyWindow(ImGuiViewport* viewport)
 {
     // The main viewport (owned by the application) will always have RendererUserData == nullptr since we didn't create the data for it.
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     if (ImGui_ImplVulkan_ViewportData* vd = static_cast<ImGui_ImplVulkan_ViewportData*>(viewport->RendererUserData))
     {
-        ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+        const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
         if (vd->WindowOwned)
             ImGui_ImplVulkanH_DestroyWindow(v->Instance, v->Device, &vd->Window, v->Allocator);
         ImGui_ImplVulkanH_DestroyWindowRenderBuffers(v->Device, &vd->RenderBuffers, v->Allocator);
@@ -1772,11 +1772,11 @@ static void ImGui_ImplVulkan_DestroyWindow(ImGuiViewport* viewport)
 
 static void ImGui_ImplVulkan_SetWindowSize(ImGuiViewport* viewport, ImVec2 size)
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     ImGui_ImplVulkan_ViewportData* vd = static_cast<ImGui_ImplVulkan_ViewportData*>(viewport->RendererUserData);
     if (vd == nullptr) // This is nullptr for the main viewport (which is left to the user/app to handle)
         return;
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
     vd->Window.ClearEnable = (viewport->Flags & ImGuiViewportFlags_NoRendererClear) ? false : true;
     ImGui_ImplVulkanH_CreateOrResizeWindow(v->Instance, v->PhysicalDevice, v->Device, &vd->Window, v->QueueFamily, v->Allocator, (int)size.x, (int)size.y, v->MinImageCount);
 }
@@ -1785,14 +1785,14 @@ static void ImGui_ImplVulkan_SetWindowSize(ImGuiViewport* viewport, ImVec2 size)
 
 static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     ImGui_ImplVulkan_ViewportData* vd = static_cast<ImGui_ImplVulkan_ViewportData*>(viewport->RendererUserData);
     ImGui_ImplVulkanH_Window* wd = &vd->Window;
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
     VkResult err;
 
-    ImGui_ImplVulkanH_Frame* fd = &wd->Frames[wd->FrameIndex];
-    ImGui_ImplVulkanH_FrameSemaphores* fsd = &wd->FrameSemaphores[wd->SemaphoreIndex];
+    const ImGui_ImplVulkanH_Frame* fd = &wd->Frames[wd->FrameIndex];
+    const ImGui_ImplVulkanH_FrameSemaphores* fsd = &wd->FrameSemaphores[wd->SemaphoreIndex];
     {
         {
           err = vkAcquireNextImageKHR(v->Device, wd->Swapchain, UINT64_MAX, fsd->ImageAcquiredSemaphore, VK_NULL_HANDLE, &wd->FrameIndex);
@@ -1816,7 +1816,7 @@ static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
             check_vk_result(err);
         }
         {
-            ImVec4 clear_color = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
+            const ImVec4 clear_color = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
             std::copy_n(&clear_color.x, 4, &wd->ClearValue.color.float32[0]);
 
             VkRenderPassBeginInfo info = {};
@@ -1836,7 +1836,7 @@ static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
     {
         vkCmdEndRenderPass(fd->CommandBuffer);
         {
-            VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            const VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
             VkSubmitInfo info = {};
             info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
             info.waitSemaphoreCount = 1;
@@ -1861,15 +1861,15 @@ static void ImGui_ImplVulkan_RenderWindow(ImGuiViewport* viewport, void*)
 
 static void ImGui_ImplVulkan_SwapBuffers(ImGuiViewport* viewport, void*)
 {
-    ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
+    const ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     ImGui_ImplVulkan_ViewportData* vd = static_cast<ImGui_ImplVulkan_ViewportData*>(viewport->RendererUserData);
     ImGui_ImplVulkanH_Window* wd = &vd->Window;
-    ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+    const ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
 
     VkResult err;
-    uint32_t present_index = wd->FrameIndex;
+    const uint32_t present_index = wd->FrameIndex;
 
-    ImGui_ImplVulkanH_FrameSemaphores* fsd = &wd->FrameSemaphores[wd->SemaphoreIndex];
+    const ImGui_ImplVulkanH_FrameSemaphores* fsd = &wd->FrameSemaphores[wd->SemaphoreIndex];
     VkPresentInfoKHR info = {};
     info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
     info.waitSemaphoreCount = 1;

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
@@ -1723,8 +1723,7 @@ static void ImGui_ImplVulkan_CreateWindow(ImGuiViewport* viewport)
 
     // Create surface
     ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
-    const ImU64 instance = TRAP::Utils::BitCast<VkInstance, ImU64>(v->Instance);
-    const VkResult err = static_cast<VkResult>(platform_io.Platform_CreateVkSurface(viewport, instance, static_cast<const void*>(v->Allocator), reinterpret_cast<ImU64*>(&wd->Surface)));
+    const VkResult err = static_cast<VkResult>(platform_io.Platform_CreateVkSurface(viewport, TRAP::Utils::BitCast<VkInstance, ImU64>(v->Instance), static_cast<const void*>(v->Allocator), reinterpret_cast<ImU64*>(&wd->Surface)));
     check_vk_result(err);
 
     // Check for WSI support

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
@@ -450,7 +450,7 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
         wrb->Index = 0;
         wrb->Count = v->ImageCount;
         wrb->FrameRenderBuffers = static_cast<ImGui_ImplVulkanH_FrameRenderBuffers*>(IM_ALLOC(sizeof(ImGui_ImplVulkanH_FrameRenderBuffers) * wrb->Count));
-        memset(wrb->FrameRenderBuffers, 0, sizeof(ImGui_ImplVulkanH_FrameRenderBuffers) * wrb->Count);
+        std::fill_n(wrb->FrameRenderBuffers, wrb->Count, ImGui_ImplVulkanH_FrameRenderBuffers());
     }
     IM_ASSERT(wrb->Count == v->ImageCount);
     wrb->Index = (wrb->Index + 1) % wrb->Count;
@@ -1410,8 +1410,8 @@ void ImGui_ImplVulkanH_CreateWindowSwapChain(VkPhysicalDevice physical_device, V
         IM_ASSERT(wd->Frames == nullptr);
         wd->Frames = static_cast<ImGui_ImplVulkanH_Frame*>(IM_ALLOC(sizeof(ImGui_ImplVulkanH_Frame) * wd->ImageCount));
         wd->FrameSemaphores = static_cast<ImGui_ImplVulkanH_FrameSemaphores*>(IM_ALLOC(sizeof(ImGui_ImplVulkanH_FrameSemaphores) * wd->ImageCount));
-        memset(wd->Frames, 0, sizeof(wd->Frames[0]) * wd->ImageCount);
-        memset(wd->FrameSemaphores, 0, sizeof(wd->FrameSemaphores[0]) * wd->ImageCount);
+        std::fill_n(wd->Frames, wd->ImageCount, ImGui_ImplVulkanH_Frame());
+        std::fill_n(wd->FrameSemaphores, wd->ImageCount, ImGui_ImplVulkanH_FrameSemaphores());
         for (uint32_t i = 0; i < wd->ImageCount; i++)
             wd->Frames[i].Backbuffer = backbuffers[i];
     }

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
@@ -1721,7 +1721,7 @@ static void ImGui_ImplVulkan_CreateWindow(ImGuiViewport* viewport)
 
     // Create surface
     ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
-    VkResult err = static_cast<VkResult>(platform_io.Platform_CreateVkSurface(viewport, reinterpret_cast<ImU64>(v->Instance), reinterpret_cast<const void*>(v->Allocator), reinterpret_cast<ImU64*>(&wd->Surface)));
+    VkResult err = static_cast<VkResult>(platform_io.Platform_CreateVkSurface(viewport, reinterpret_cast<ImU64>(v->Instance), static_cast<const void*>(v->Allocator), reinterpret_cast<ImU64*>(&wd->Surface)));
     check_vk_result(err);
 
     // Check for WSI support

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
@@ -123,7 +123,7 @@ struct ImGui_ImplVulkan_ViewportData
     ImGui_ImplVulkanH_Window                Window;             // Used by secondary viewports only
     ImGui_ImplVulkanH_WindowRenderBuffers   RenderBuffers;      // Used by all viewports
 
-    ImGui_ImplVulkan_ViewportData()         { WindowOwned = false; memset(&RenderBuffers, 0, sizeof(RenderBuffers)); }
+    ImGui_ImplVulkan_ViewportData()         { WindowOwned = false; RenderBuffers = {}; }
     ~ImGui_ImplVulkan_ViewportData()        { }
 };
 
@@ -157,10 +157,12 @@ struct ImGui_ImplVulkan_Data
     ImGui_ImplVulkanH_WindowRenderBuffers MainWindowRenderBuffers;
 
     ImGui_ImplVulkan_Data()
-    {
-        memset(this, 0, sizeof(*this));
-        BufferMemoryAlignment = 256;
-    }
+        : VulkanInitInfo(), RenderPass(VK_NULL_HANDLE), BufferMemoryAlignment(256), PipelineCreateFlags(),
+          DescriptorSetLayout(VK_NULL_HANDLE), PipelineLayout(VK_NULL_HANDLE), DescriptorSet(VK_NULL_HANDLE),
+          Pipeline(VK_NULL_HANDLE), Subpass(), ShaderModuleVert(VK_NULL_HANDLE), ShaderModuleFrag(VK_NULL_HANDLE),
+          FontSampler(VK_NULL_HANDLE), FontMemory(VK_NULL_HANDLE), FontImage(VK_NULL_HANDLE), FontView(VK_NULL_HANDLE),
+          FontDescriptorSet(VK_NULL_HANDLE), UploadBufferMemory(VK_NULL_HANDLE), UploadBuffer(VK_NULL_HANDLE)
+    {}
 };
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.h
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.h
@@ -161,10 +161,12 @@ struct ImGui_ImplVulkanH_Window
     ImGui_ImplVulkanH_FrameSemaphores*  FrameSemaphores;
 
     ImGui_ImplVulkanH_Window()
+        : Width(), Height(), Swapchain(VK_NULL_HANDLE), Surface(VK_NULL_HANDLE), SurfaceFormat(),
+          PresentMode(static_cast<VkPresentModeKHR>(~0)), RenderPass(VK_NULL_HANDLE),
+          Pipeline(VK_NULL_HANDLE), ClearEnable(true), ClearValue(), FrameIndex(), ImageCount(),
+          SemaphoreIndex(), Frames(nullptr), FrameSemaphores(nullptr)
     {
-        memset(this, 0, sizeof(*this));
-        PresentMode = static_cast<VkPresentModeKHR>(~0); //Ensure we get an error if user doesn't set this.
-        ClearEnable = true;
+        // PresentMode = static_cast<VkPresentModeKHR>(~0); //Ensure we get an error if user doesn't set this.
     }
 };
 

--- a/TRAP/src/Layers/ImGui/ImGuiWindowing.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiWindowing.cpp
@@ -46,7 +46,7 @@ bool TRAP::INTERNAL::ImGuiWindowing::Init(WindowingAPI::InternalWindow* window, 
 
 	//Setup back-end capabilities flags
 	ImGuiTRAPData* bd = IM_NEW(ImGuiTRAPData)();
-	io.BackendPlatformUserData = reinterpret_cast<void*>(bd);
+	io.BackendPlatformUserData = bd;
 	io.BackendPlatformName = "TRAP";
 	io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors; //We can honor GetMouseCursor() values (optional)
 	io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos; //We can honor io.WantSetMousePos requests (optional, rarely used)
@@ -102,7 +102,7 @@ bool TRAP::INTERNAL::ImGuiWindowing::Init(WindowingAPI::InternalWindow* window, 
 
 	//Our mouse update function expect PlatformHandle to be filled for the main viewport
 	ImGuiViewport* mainViewport = ImGui::GetMainViewport();
-	mainViewport->PlatformHandle = reinterpret_cast<void*>(bd->Window);
+	mainViewport->PlatformHandle = bd->Window;
 #ifdef TRAP_PLATFORM_WINDOWS
 	mainViewport->PlatformHandleRaw = WindowingAPI::GetWin32Window(bd->Window);
 #endif
@@ -1020,7 +1020,8 @@ int32_t TRAP::INTERNAL::ImGuiWindowing::CreateVkSurface(ImGuiViewport* viewport,
 	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 	IM_UNUSED(bd);
 	IM_ASSERT(bd->ClientAPI == TRAP::Graphics::RenderAPI::Vulkan);
-	const VkResult err = WindowingAPI::CreateWindowSurface(reinterpret_cast<VkInstance>(vkInstance),
+	const VkInstance instance = Utils::BitCast<const ImU64, const VkInstance>(vkInstance);
+	const VkResult err = WindowingAPI::CreateWindowSurface(instance,
 	                                                       vd->WindowPtr,
 	                                                       static_cast<const VkAllocationCallbacks*>(vkAllocator),
 														   *reinterpret_cast<VkSurfaceKHR*>(outVkSurface));
@@ -1062,7 +1063,7 @@ void TRAP::INTERNAL::ImGuiWindowing::InitPlatformInterface()
 	vd->WindowPtr = bd->Window;
 	vd->WindowOwned = false;
 	main_viewport->PlatformUserData = vd;
-	main_viewport->PlatformHandle = reinterpret_cast<void*>(bd->Window);
+	main_viewport->PlatformHandle = bd->Window;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Layers/ImGui/ImGuiWindowing.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiWindowing.cpp
@@ -959,8 +959,7 @@ void TRAP::INTERNAL::ImGuiWindowing::SetWindowTitle(ImGuiViewport* viewport, con
 
 	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 
-	std::string t(title);
-	WindowingAPI::SetWindowTitle(vd->WindowPtr, t);
+	WindowingAPI::SetWindowTitle(vd->WindowPtr, title);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Layers/ImGui/ImGuiWindowing.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiWindowing.cpp
@@ -244,7 +244,7 @@ void TRAP::INTERNAL::ImGuiWindowing::RestoreCallbacks(WindowingAPI::InternalWind
 void TRAP::INTERNAL::ImGuiWindowing::WindowFocusCallback(const WindowingAPI::InternalWindow* window,
 													     const bool focused)
 {
-	ImGuiTRAPData* bd = GetBackendData();
+	const ImGuiTRAPData* bd = GetBackendData();
 	if (bd->PrevUserCallbackWindowFocus != nullptr && window == bd->Window)
 		bd->PrevUserCallbackWindowFocus(window, focused);
 
@@ -303,7 +303,7 @@ void TRAP::INTERNAL::ImGuiWindowing::CursorPosCallback(const WindowingAPI::Inter
 void TRAP::INTERNAL::ImGuiWindowing::MouseButtonCallback(const WindowingAPI::InternalWindow* window,
                                                          Input::MouseButton mouseButton, const Input::KeyState state)
 {
-	ImGuiTRAPData* bd = GetBackendData();
+	const ImGuiTRAPData* bd = GetBackendData();
 	if (bd->PrevUserCallbackMouseButton != nullptr && window == bd->Window)
 		bd->PrevUserCallbackMouseButton(window, mouseButton, state);
 
@@ -319,7 +319,7 @@ void TRAP::INTERNAL::ImGuiWindowing::MouseButtonCallback(const WindowingAPI::Int
 void TRAP::INTERNAL::ImGuiWindowing::ScrollCallback(const WindowingAPI::InternalWindow* window,
                                                     const double xOffset, const double yOffset)
 {
-	ImGuiTRAPData* bd = GetBackendData();
+	const ImGuiTRAPData* bd = GetBackendData();
 	if (bd->PrevUserCallbackScroll != nullptr && window == bd->Window)
 		bd->PrevUserCallbackScroll(window, xOffset, yOffset);
 
@@ -347,7 +347,7 @@ void TRAP::INTERNAL::ImGuiWindowing::KeyCallback(const WindowingAPI::InternalWin
 	key = TranslateUntranslateKey(key);
 
 	ImGuiIO& io = ImGui::GetIO();
-	ImGuiKey imguiKey = KeyToImGuiKey(key);
+	const ImGuiKey imguiKey = KeyToImGuiKey(key);
 	io.AddKeyEvent(imguiKey, (state == Input::KeyState::Pressed));
 
 	//We don't support the old API
@@ -359,7 +359,7 @@ void TRAP::INTERNAL::ImGuiWindowing::KeyCallback(const WindowingAPI::InternalWin
 void TRAP::INTERNAL::ImGuiWindowing::CharCallback(const WindowingAPI::InternalWindow* window,
                                                   const uint32_t codePoint)
 {
-	ImGuiTRAPData* bd = GetBackendData();
+	const ImGuiTRAPData* bd = GetBackendData();
 	if (bd->PrevUserCallbackChar != nullptr && window == bd->Window)
 		bd->PrevUserCallbackChar(window, codePoint);
 
@@ -540,7 +540,7 @@ TRAP::Input::Key TRAP::INTERNAL::ImGuiWindowing::TranslateUntranslateKey(TRAP::I
 {
 	if(key >= TRAP::Input::Key::KP_0 && key <= TRAP::Input::Key::KP_Equal)
 		return key;
-	std::string keyName = TRAP::Input::GetKeyName(key);
+	const std::string keyName = TRAP::Input::GetKeyName(key);
 	if(!keyName.empty() && keyName[0] != 0 && keyName[1] == 0)
 	{
 		static constexpr std::array<char, 11> charNames{'`', '-', '=', '[', ']', '\\', ',', ';', '\'', '.', '/'};
@@ -550,7 +550,7 @@ TRAP::Input::Key TRAP::INTERNAL::ImGuiWindowing::TranslateUntranslateKey(TRAP::I
 																   TRAP::Input::Key::Comma, TRAP::Input::Key::Semicolon,
 																   TRAP::Input::Key::Apostrophe, TRAP::Input::Key::Period,
 																   TRAP::Input::Key::Slash};
-		auto it = std::find(charNames.cbegin(), charNames.cend(), keyName[0]);
+		const auto it = std::find(charNames.cbegin(), charNames.cend(), keyName[0]);
 		if(keyName[0] >= '0' && keyName[0] <= '9')
 			key = static_cast<TRAP::Input::Key>(static_cast<int32_t>(TRAP::Input::Key::Zero) + (keyName[0] - '0'));
 		else if(keyName[0] >= 'A' && keyName[0] <= 'Z')
@@ -572,7 +572,7 @@ void TRAP::INTERNAL::ImGuiWindowing::UpdateMouseData()
 
 	ImGuiTRAPData* bd = GetBackendData();
 	ImGuiIO& io = ImGui::GetIO();
-	ImGuiPlatformIO& platformIO = ImGui::GetPlatformIO();
+	const ImGuiPlatformIO& platformIO = ImGui::GetPlatformIO();
 
 	ImGuiID mouseViewportID = 0;
 	const ImVec2 mousePosPrev = io.MousePos;
@@ -633,15 +633,15 @@ void TRAP::INTERNAL::ImGuiWindowing::UpdateMouseCursor()
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiIO& io = ImGui::GetIO();
-	ImGuiTRAPData* bd = GetBackendData();
+	const ImGuiIO& io = ImGui::GetIO();
+	const ImGuiTRAPData* bd = GetBackendData();
 	if ((io.ConfigFlags & ImGuiConfigFlags_NoMouseCursorChange) ||
 	    (WindowingAPI::GetCursorMode(bd->Window) == WindowingAPI::CursorMode::Disabled ||
 		 WindowingAPI::GetCursorMode(bd->Window) == WindowingAPI::CursorMode::Hidden))
 		return;
 
 	const ImGuiMouseCursor imguiCursor = ImGui::GetMouseCursor();
-	ImGuiPlatformIO& platformIO = ImGui::GetPlatformIO();
+	const ImGuiPlatformIO& platformIO = ImGui::GetPlatformIO();
 	for(uint32_t n = 0; n < static_cast<uint32_t>(platformIO.Viewports.Size); n++)
 	{
 		WindowingAPI::InternalWindow* windowPtr = static_cast<WindowingAPI::InternalWindow*>
@@ -865,7 +865,7 @@ void TRAP::INTERNAL::ImGuiWindowing::DestroyWindow(ImGuiViewport* viewport)
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiTRAPData* bd = GetBackendData();
+	const ImGuiTRAPData* bd = GetBackendData();
 	if(ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData))
 	{
 		if(vd->WindowOwned)
@@ -893,7 +893,7 @@ void TRAP::INTERNAL::ImGuiWindowing::ShowWindow(ImGuiViewport* viewport)
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
+	const ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 
 	if(viewport->Flags & ImGuiViewportFlags_NoTaskBarIcon)
 		WindowingAPI::HideWindowFromTaskbar(static_cast<WindowingAPI::InternalWindow*>(viewport->PlatformHandle));
@@ -907,7 +907,7 @@ ImVec2 TRAP::INTERNAL::ImGuiWindowing::GetWindowPos(ImGuiViewport* viewport)
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
+	const ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 	int32_t x = 0, y = 0;
 	WindowingAPI::GetWindowPos(vd->WindowPtr, x, y);
 
@@ -931,7 +931,7 @@ ImVec2 TRAP::INTERNAL::ImGuiWindowing::GetWindowSize(ImGuiViewport* viewport)
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
+	const ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 
 	int32_t width = 0, height = 0;
 	WindowingAPI::GetWindowSize(vd->WindowPtr, width, height);
@@ -957,7 +957,7 @@ void TRAP::INTERNAL::ImGuiWindowing::SetWindowTitle(ImGuiViewport* viewport, con
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
+	const ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 
 	WindowingAPI::SetWindowTitle(vd->WindowPtr, title);
 }
@@ -968,7 +968,7 @@ void TRAP::INTERNAL::ImGuiWindowing::SetWindowFocus(ImGuiViewport* viewport)
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
+	const ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 
 	WindowingAPI::FocusWindow(vd->WindowPtr);
 }
@@ -979,7 +979,7 @@ bool TRAP::INTERNAL::ImGuiWindowing::GetWindowFocus(ImGuiViewport* viewport)
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
+	const ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 
 	return WindowingAPI::GetWindowHint(vd->WindowPtr, WindowingAPI::Hint::Focused);
 }
@@ -990,7 +990,7 @@ bool TRAP::INTERNAL::ImGuiWindowing::GetWindowMinimized(ImGuiViewport* viewport)
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
+	const ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 
 	return WindowingAPI::GetWindowHint(vd->WindowPtr, WindowingAPI::Hint::Minimized);
 }
@@ -1001,7 +1001,7 @@ void TRAP::INTERNAL::ImGuiWindowing::SetWindowAlpha(ImGuiViewport* viewport, con
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
+	const ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 
 	WindowingAPI::SetWindowOpacity(vd->WindowPtr, alpha);
 }
@@ -1015,8 +1015,8 @@ int32_t TRAP::INTERNAL::ImGuiWindowing::CreateVkSurface(ImGuiViewport* viewport,
 {
 	TP_PROFILE_FUNCTION();
 
-	ImGuiTRAPData* bd = GetBackendData();
-	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
+	const ImGuiTRAPData* bd = GetBackendData();
+	const ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 	IM_UNUSED(bd);
 	IM_ASSERT(bd->ClientAPI == TRAP::Graphics::RenderAPI::Vulkan);
 	const VkResult err = WindowingAPI::CreateWindowSurface(Utils::BitCast<const ImU64, const VkInstance>(vkInstance),
@@ -1034,7 +1034,7 @@ void TRAP::INTERNAL::ImGuiWindowing::InitPlatformInterface()
 	TP_PROFILE_FUNCTION();
 
 	//Register platform interface (will be coupled with a renderer interface)
-	ImGuiTRAPData* bd = GetBackendData();
+	const ImGuiTRAPData* bd = GetBackendData();
 	ImGuiPlatformIO& platformIO = ImGui::GetPlatformIO();
 	platformIO.Platform_CreateWindow = CreateWindow;
 	platformIO.Platform_DestroyWindow = DestroyWindow;

--- a/TRAP/src/Layers/ImGui/ImGuiWindowing.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiWindowing.cpp
@@ -1020,8 +1020,7 @@ int32_t TRAP::INTERNAL::ImGuiWindowing::CreateVkSurface(ImGuiViewport* viewport,
 	ImGuiViewportDataTRAP* vd = static_cast<ImGuiViewportDataTRAP*>(viewport->PlatformUserData);
 	IM_UNUSED(bd);
 	IM_ASSERT(bd->ClientAPI == TRAP::Graphics::RenderAPI::Vulkan);
-	const VkInstance instance = Utils::BitCast<const ImU64, const VkInstance>(vkInstance);
-	const VkResult err = WindowingAPI::CreateWindowSurface(instance,
+	const VkResult err = WindowingAPI::CreateWindowSurface(Utils::BitCast<const ImU64, const VkInstance>(vkInstance),
 	                                                       vd->WindowPtr,
 	                                                       static_cast<const VkAllocationCallbacks*>(vkAllocator),
 														   *reinterpret_cast<VkSurfaceKHR*>(outVkSurface));

--- a/TRAP/src/Layers/Layer.cpp
+++ b/TRAP/src/Layers/Layer.cpp
@@ -22,7 +22,7 @@ void TRAP::Layer::OnDetach()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Layer::OnUpdate(const Utils::TimeStep&)
+void TRAP::Layer::OnUpdate(const Utils::TimeStep& /*deltaTime*/)
 {
 }
 
@@ -40,7 +40,7 @@ void TRAP::Layer::OnImGuiRender()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Layer::OnEvent(Events::Event&)
+void TRAP::Layer::OnEvent(Events::Event& /*event*/)
 {
 }
 

--- a/TRAP/src/Layers/Layer.cpp
+++ b/TRAP/src/Layers/Layer.cpp
@@ -46,7 +46,7 @@ void TRAP::Layer::OnEvent(Events::Event&)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Layer::GetName() const
+std::string TRAP::Layer::GetName() const
 {
 	return m_DebugName;
 }

--- a/TRAP/src/Layers/Layer.h
+++ b/TRAP/src/Layers/Layer.h
@@ -67,7 +67,7 @@ namespace TRAP
 		/// Retrieve the debug name of the layer.
 		/// </summary>
 		/// <returns>Name of the layer.</returns>
-		const std::string& GetName() const;
+		std::string GetName() const;
 
 	protected:
 		std::string m_DebugName;

--- a/TRAP/src/Log/Log.cpp
+++ b/TRAP/src/Log/Log.cpp
@@ -15,6 +15,14 @@ TRAP::Log::Log()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+TRAP::Log::Log(std::filesystem::path filePath)
+	: m_path(std::move(filePath))
+{
+	m_buffer.reserve(256);
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
 TRAP::Log::~Log()
 {
 	Save();
@@ -29,7 +37,7 @@ const std::filesystem::path& TRAP::Log::GetFilePath() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Log::SetFilePath(std::filesystem::path filePath)
+void TRAP::Log::SetFilePath(const std::filesystem::path& filePath)
 {
 	m_path = std::move(filePath);
 }
@@ -43,7 +51,7 @@ const std::vector<std::pair<TRAP::Log::Level, std::string>>& TRAP::Log::GetBuffe
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Log::Save()
+void TRAP::Log::Save() const
 {
 	TP_PROFILE_FUNCTION();
 
@@ -82,7 +90,7 @@ void TRAP::Log::Clear()
 
 std::string TRAP::Log::GetTimeStamp()
 {
-	std::string timeStamp = TRAP::Utils::String::GetTimeStamp(std::chrono::system_clock::now());
+	const std::string timeStamp = TRAP::Utils::String::GetTimeStamp(std::chrono::system_clock::now());
 	return "[" + timeStamp + ']';
 }
 

--- a/TRAP/src/Log/Log.cpp
+++ b/TRAP/src/Log/Log.cpp
@@ -47,18 +47,25 @@ void TRAP::Log::Save()
 {
 	TP_PROFILE_FUNCTION();
 
-	const std::filesystem::path logFile = FS::GetFolderPath(m_path) / (FS::GetFileName(m_path) + "-" +
-		                                                               GetDateTimeStamp() +
-		                                                               FS::GetFileEnding(m_path));
+	//Build final path and filename
+	const auto folderPath = FS::GetFolderPath(m_path);
+	const auto fileName = FS::GetFileName(m_path);
+	const auto fileEnding = FS::GetFileEnding(m_path);
+	if(!folderPath || !fileName || !fileEnding)
+	{
+		TP_ERROR(LoggerPrefix, "Failed to save: ", m_path.generic_u8string());
+		return;
+	}
+	const std::filesystem::path logFile = *folderPath / ((*fileName) + "-" + GetDateTimeStamp() + *fileEnding);
 
-	TP_INFO(LoggerPrefix, "Saving ", m_path.generic_u8string());
+	TP_INFO(LoggerPrefix, "Saving ", logFile.generic_u8string());
 	std::string output;
 
 	for (const auto& [level, message] : m_buffer)
 		output += message + '\n';
 
 	if(!TRAP::FS::WriteTextFile(logFile, output))
-		TP_ERROR(LoggerPrefix, "Failed to save: ", m_path.generic_u8string());
+		TP_ERROR(LoggerPrefix, "Failed to save: ", logFile.generic_u8string());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Log/Log.cpp
+++ b/TRAP/src/Log/Log.cpp
@@ -1,7 +1,7 @@
 #include "TRAPPCH.h"
 #include "Log.h"
 
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 TRAP::Log TRAP::TRAPLog{};
 
@@ -48,9 +48,9 @@ void TRAP::Log::Save()
 	TP_PROFILE_FUNCTION();
 
 	//Build final path and filename
-	const auto folderPath = FS::GetFolderPath(m_path);
-	const auto fileName = FS::GetFileName(m_path);
-	const auto fileEnding = FS::GetFileEnding(m_path);
+	const auto folderPath = FileSystem::GetFolderPath(m_path);
+	const auto fileName = FileSystem::GetFileName(m_path);
+	const auto fileEnding = FileSystem::GetFileEnding(m_path);
 	if(!folderPath || !fileName || !fileEnding)
 	{
 		TP_ERROR(LoggerPrefix, "Failed to save: ", m_path.generic_u8string());
@@ -64,7 +64,7 @@ void TRAP::Log::Save()
 	for (const auto& [level, message] : m_buffer)
 		output += message + '\n';
 
-	if(!TRAP::FS::WriteTextFile(logFile, output))
+	if(!TRAP::FileSystem::WriteTextFile(logFile, output))
 		TP_ERROR(LoggerPrefix, "Failed to save: ", logFile.generic_u8string());
 }
 

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -25,6 +25,11 @@ namespace TRAP
 		/// </summary>
 		explicit Log();
 		/// <summary>
+		/// Constructor.
+		/// </summary>
+		/// <param name="filePath">Path for the log file.</param>
+		explicit Log(std::filesystem::path filePath);
+		/// <summary>
 		///	Destructor.
 		/// </summary>
 		~Log();
@@ -56,7 +61,7 @@ namespace TRAP
 		///	Logs files are always saved in the format: "<FileName>-YYYY-MM-DDTHH-MM-SS.<FileEnding>"
 		/// </summary>
 		/// <param name="filePath">File path.</param>
-		void SetFilePath(std::filesystem::path filePath);
+		void SetFilePath(const std::filesystem::path& filePath);
 
 		/// <summary>
 		/// Importance levels.
@@ -122,13 +127,13 @@ namespace TRAP
 		/// <summary>
 		/// Save all collected messages to file.
 		/// </summary>
-		void Save();
+		void Save() const;
 		/// <summary>
 		/// Clears all buffered messages.
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w29a2]";
+		inline static constexpr auto WindowVersion =                        "[22w29a3]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -128,7 +128,7 @@ namespace TRAP
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w28b2]";
+		inline static constexpr auto WindowVersion =                        "[22w28b3]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -128,7 +128,7 @@ namespace TRAP
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w28b1]";
+		inline static constexpr auto WindowVersion =                        "[22w28b2]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -128,7 +128,7 @@ namespace TRAP
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w28b3]";
+		inline static constexpr auto WindowVersion =                        "[22w28b4]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -128,7 +128,7 @@ namespace TRAP
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w28b4]";
+		inline static constexpr auto WindowVersion =                        "[22w29a1]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -128,7 +128,7 @@ namespace TRAP
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w29a1]";
+		inline static constexpr auto WindowVersion =                        "[22w29a2]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -128,7 +128,7 @@ namespace TRAP
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w28a1]";
+		inline static constexpr auto WindowVersion =                        "[22w28b1]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Maths/Mat3.h
+++ b/TRAP/src/Maths/Mat3.h
@@ -261,14 +261,14 @@ namespace std
 //Constructors
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T>::Mat(T scalar)
+constexpr TRAP::Math::Mat<3, 3, T>::Mat(const T scalar)
 	: value{ colType(scalar, 0, 0), colType(0, scalar, 0), colType(0, 0, scalar) }
 {}
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T>::Mat(T x0, T y0, T z0,
-	                                    T x1, T y1, T z1,
-	                                    T x2, T y2, T z2)
+constexpr TRAP::Math::Mat<3, 3, T>::Mat(const T x0, const T y0, const T z0,
+	                                    const T x1, const T y1, const T z1,
+	                                    const T x2, const T y2, const T z2)
 	: value{ colType(x0, y0, z0), colType(x1, y1, z1), colType(x2, y2, z2) }
 {}
 
@@ -284,9 +284,9 @@ template<typename T>
 template<typename X1, typename Y1, typename Z1,
 	     typename X2, typename Y2, typename Z2,
 	     typename X3, typename Y3, typename Z3>
-constexpr TRAP::Math::Mat<3, 3, T>::Mat(X1 x1, Y1 y1, Z1 z1,
-	                                    X2 x2, Y2 y2, Z2 z2,
-	                                    X3 x3, Y3 y3, Z3 z3)
+constexpr TRAP::Math::Mat<3, 3, T>::Mat(const X1 x1, const Y1 y1, const Z1 z1,
+	                                    const X2 x2, const Y2 y2, const Z2 z2,
+	                                    const X3 x3, const Y3 y3, const Z3 z3)
 	: value{ colType(x1, y1, z1), colType(x2, y2, z2), colType(x3, y3, z3) }
 {}
 
@@ -352,7 +352,7 @@ constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator=(const Ma
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator+=(U s)
+constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator+=(const U s)
 {
 	this->value[0] += s;
 	this->value[1] += s;
@@ -374,7 +374,7 @@ constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator+=(const M
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator-=(U s)
+constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator-=(const U s)
 {
 	this->value[0] -= s;
 	this->value[1] -= s;
@@ -396,7 +396,7 @@ constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator-=(const M
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator*=(U s)
+constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator*=(const U s)
 {
 	this->value[0] *= s;
 	this->value[1] *= s;
@@ -414,7 +414,7 @@ constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator*=(const M
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator/=(U s)
+constexpr TRAP::Math::Mat<3, 3, T>& TRAP::Math::Mat<3, 3, T>::operator/=(const U s)
 {
 	this->value[0] /= s;
 	this->value[1] /= s;
@@ -509,13 +509,13 @@ constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator-(const Mat<3, 3, T>& m)
 //Binary arithmetic operators
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator+(const Mat<3, 3, T>& m, T scalar)
+constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator+(const Mat<3, 3, T>& m, const T scalar)
 {
 	return Mat<3, 3, T>(m[0] + scalar, m[1] + scalar, m[2] + scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator+(T scalar, const Mat<3, 3, T>& m)
+constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator+(const T scalar, const Mat<3, 3, T>& m)
 {
 	return Mat<3, 3, T>(m[0] + scalar, m[1] + scalar, m[2] + scalar);
 }
@@ -527,13 +527,13 @@ constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator+(const Mat<3, 3, T>& m1,
 }
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator-(const Mat<3, 3, T>& m, T scalar)
+constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator-(const Mat<3, 3, T>& m, const T scalar)
 {
 	return Mat<3, 3, T>(m[0] - scalar, m[1] - scalar, m[2] - scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator-(T scalar, const Mat<3, 3, T>& m)
+constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator-(const T scalar, const Mat<3, 3, T>& m)
 {
 	return Mat<3, 3, T>(scalar - m[0], scalar - m[1], scalar - m[2]);
 }
@@ -545,21 +545,20 @@ constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator-(const Mat<3, 3, T>& m1,
 }
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator*(const Mat<3, 3, T>& m, T scalar)
+constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator*(const Mat<3, 3, T>& m, const T scalar)
 {
 	return Mat<3, 3, T>(m[0] * scalar, m[1] * scalar, m[2] * scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator*(T scalar, const Mat<3, 3, T>& m)
+constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator*(const T scalar, const Mat<3, 3, T>& m)
 {
 	return Mat<3, 3, T>(m[0] * scalar, m[1] * scalar, m[2] * scalar);
 }
 
 template<typename T>
 constexpr typename TRAP::Math::Mat<3, 3, T>::colType TRAP::Math::operator*(const Mat<3, 3, T>& m,
-                                                                 const typename Mat<3, 3, T>::rowType& v
-)
+                                                                           const typename Mat<3, 3, T>::rowType& v)
 {
 	return typename Mat<3, 3, T>::colType(m[0][0] * v.x + m[1][0] * v.y + m[2][0] * v.z,
 		                                  m[0][1] * v.x + m[1][1] * v.y + m[2][1] * v.z,
@@ -568,7 +567,7 @@ constexpr typename TRAP::Math::Mat<3, 3, T>::colType TRAP::Math::operator*(const
 
 template<typename T>
 constexpr typename TRAP::Math::Mat<3, 3, T>::rowType TRAP::Math::operator*(const typename Mat<3, 3, T>::colType& v,
-                                                                 const Mat<3, 3, T>& m)
+                                                                           const Mat<3, 3, T>& m)
 {
 	return typename Mat<3, 3, T>::rowType(m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z,
 		                                  m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z,
@@ -613,27 +612,27 @@ constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator*(const Mat<3, 3, T>& m1,
 }
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator/(const Mat<3, 3, T>& m, T scalar)
+constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator/(const Mat<3, 3, T>& m, const T scalar)
 {
 	return Mat<3, 3, T>(m[0] / scalar, m[1] / scalar, m[2] / scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator/(T scalar, const Mat<3, 3, T>& m)
+constexpr TRAP::Math::Mat<3, 3, T> TRAP::Math::operator/(const T scalar, const Mat<3, 3, T>& m)
 {
 	return Mat<3, 3, T>(scalar / m[0], scalar / m[1], scalar / m[2]);
 }
 
 template<typename T>
 constexpr typename TRAP::Math::Mat<3, 3, T>::colType TRAP::Math::operator/(const Mat<3, 3, T>& m,
-                                                                 const typename Mat<3, 3, T>::rowType& v)
+                                                                           const typename Mat<3, 3, T>::rowType& v)
 {
 	return Inverse(m) * v;
 }
 
 template<typename T>
 constexpr typename TRAP::Math::Mat<3, 3, T>::rowType TRAP::Math::operator/(const typename Mat<3, 3, T>::colType& v,
-                                                                 const Mat<3, 3, T>& m)
+                                                                           const Mat<3, 3, T>& m)
 {
 	return v * Inverse(m);
 }

--- a/TRAP/src/Maths/Mat4.h
+++ b/TRAP/src/Maths/Mat4.h
@@ -290,10 +290,10 @@ template<typename X1, typename Y1, typename Z1, typename W1,
 	     typename X2, typename Y2, typename Z2, typename W2,
 	     typename X3, typename Y3, typename Z3, typename W3,
 	     typename X4, typename Y4, typename Z4, typename W4>
-constexpr TRAP::Math::Mat<4, 4, T>::Mat(X1 x1, Y1 y1, Z1 z1, W1 w1,
-	                                    X2 x2, Y2 y2, Z2 z2, W2 w2,
-	                                    X3 x3, Y3 y3, Z3 z3, W3 w3,
-	                                    X4 x4, Y4 y4, Z4 z4, W4 w4)
+constexpr TRAP::Math::Mat<4, 4, T>::Mat(const X1 x1, const Y1 y1, const Z1 z1, const W1 w1,
+	                                    const X2 x2, const Y2 y2, const Z2 z2, const W2 w2,
+	                                    const X3 x3, const Y3 y3, const Z3 z3, const W3 w3,
+	                                    const X4 x4, const Y4 y4, const Z4 z4, const W4 w4)
 	: value{ colType(x1, y1, z1, w1), colType(x2, y2, z2, w2), colType(x3, y3, z3, w3), colType(x4, y4, z4, w4) }
 {
 	static_assert(std::numeric_limits<X1>::is_iec559 || std::numeric_limits<X1>::is_integer,
@@ -406,7 +406,7 @@ constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator=(const Ma
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator+=(U s)
+constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator+=(const U s)
 {
 	this->value[0] += s;
 	this->value[1] += s;
@@ -430,7 +430,7 @@ constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator+=(const M
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator-=(U s)
+constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator-=(const U s)
 {
 	this->value[0] -= s;
 	this->value[1] -= s;
@@ -454,7 +454,7 @@ constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator-=(const M
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator*=(U s)
+constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator*=(const U s)
 {
 	this->value[0] *= s;
 	this->value[1] *= s;
@@ -473,7 +473,7 @@ constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator*=(const M
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator/=(U s)
+constexpr TRAP::Math::Mat<4, 4, T>& TRAP::Math::Mat<4, 4, T>::operator/=(const U s)
 {
 	this->value[0] /= s;
 	this->value[1] /= s;
@@ -686,14 +686,14 @@ constexpr TRAP::Math::Mat<4, 4, T> TRAP::Math::operator/(const T& scalar, const 
 
 template<typename T>
 constexpr typename TRAP::Math::Mat<4, 4, T>::colType TRAP::Math::operator/(const Mat<4, 4, T>& m,
-                                                                 const typename Mat<4, 4, T>::rowType& v)
+                                                                           const typename Mat<4, 4, T>::rowType& v)
 {
 	return Inverse(m) * v;
 }
 
 template<typename T>
 constexpr typename TRAP::Math::Mat<4, 4, T>::rowType TRAP::Math::operator/(const typename Mat<4, 4, T>::colType& v,
-                                                                 const Mat<4, 4, T>& m)
+                                                                           const Mat<4, 4, T>& m)
 {
 	return v * Inverse(m);
 }

--- a/TRAP/src/Maths/Math.h
+++ b/TRAP/src/Maths/Math.h
@@ -3078,7 +3078,7 @@ namespace TRAP::Math
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-constexpr genType TRAP::Math::Min(genType x, genType y)
+constexpr genType TRAP::Math::Min(const genType x, const genType y)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559 || std::numeric_limits<genType>::is_integer,
 	              "'Min' only accepts floating-point or integer inputs");
@@ -3089,7 +3089,7 @@ constexpr genType TRAP::Math::Min(genType x, genType y)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-constexpr genType TRAP::Math::Max(genType x, genType y)
+constexpr genType TRAP::Math::Max(const genType x, const genType y)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559 || std::numeric_limits<genType>::is_integer,
 	              "'Max' only accepts floating-point or integer inputs");
@@ -3110,7 +3110,7 @@ constexpr int32_t TRAP::Math::Abs(const int32_t x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::Round(genType x)
+genType TRAP::Math::Round(const genType x)
 {
 	return std::round(x);
 }
@@ -3118,7 +3118,7 @@ genType TRAP::Math::Round(genType x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::Trunc(genType x)
+genType TRAP::Math::Trunc(const genType x)
 {
 	return std::trunc(x);
 }
@@ -3126,7 +3126,7 @@ genType TRAP::Math::Trunc(genType x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genFIType>
-constexpr genFIType TRAP::Math::Abs(genFIType x)
+constexpr genFIType TRAP::Math::Abs(const genFIType x)
 {
 	if constexpr (std::numeric_limits<genFIType>::is_signed)
 	{
@@ -3151,7 +3151,7 @@ constexpr TRAP::Math::Vec<L, T> TRAP::Math::Abs(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genFIType>
-constexpr genFIType TRAP::Math::Sign(genFIType x)
+constexpr genFIType TRAP::Math::Sign(const genFIType x)
 {
 	static_assert(std::numeric_limits<genFIType>::is_iec559 ||
 	              (std::numeric_limits<genFIType>::is_signed && std::numeric_limits<genFIType>::is_integer),
@@ -3173,7 +3173,7 @@ constexpr TRAP::Math::Vec<L, T> TRAP::Math::Sign(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Floor(T x)
+T TRAP::Math::Floor(const T x)
 {
 	return std::floor(x);
 }
@@ -3218,13 +3218,13 @@ TRAP::Math::Vec<L, T> TRAP::Math::Round(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::RoundEven(genType x)
+genType TRAP::Math::RoundEven(const genType x)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559, "'RoundEven' only accepts floating-point inputs");
 
-	int32_t integer = static_cast<int32_t>(x);
-	genType integerPart = static_cast<genType>(integer);
-	genType fractionalPart = Fract(x);
+	const int32_t integer = static_cast<int32_t>(x);
+	const genType integerPart = static_cast<genType>(integer);
+	const genType fractionalPart = Fract(x);
 
 	if (fractionalPart > static_cast<genType>(0.5) || fractionalPart < static_cast<genType>(0.5))
 		return std::round(x);
@@ -3250,7 +3250,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::RoundEven(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Ceil(T x)
+T TRAP::Math::Ceil(const T x)
 {
 	return std::ceil(x);
 }
@@ -3269,7 +3269,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Ceil(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::Fract(genType x)
+genType TRAP::Math::Fract(const genType x)
 {
 	return x - Floor(x);
 }
@@ -3285,7 +3285,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Fract(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::Mod(genType x, genType y)
+genType TRAP::Math::Mod(const genType x, const genType y)
 {
 	return x - y * Floor(x / y);
 }
@@ -3309,7 +3309,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Mod(const Vec<L, T>& x, const Vec<L, T>& y)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::Modf(genType x, genType& i)
+genType TRAP::Math::Modf(const genType x, genType& i)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559, "'Modf' only accepts floating-point inputs");
 
@@ -3417,7 +3417,7 @@ constexpr TRAP::Math::Vec<L, T> TRAP::Math::Max(const Vec<L, T>& a, const Vec<L,
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-constexpr genType TRAP::Math::Clamp(genType x, genType minVal, genType maxVal)
+constexpr genType TRAP::Math::Clamp(const genType x, const genType minVal, const genType maxVal)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559 || std::numeric_limits<genType>::is_integer,
 	              "'Clamp' only accepts floating-point or integer inputs");
@@ -3426,7 +3426,7 @@ constexpr genType TRAP::Math::Clamp(genType x, genType minVal, genType maxVal)
 }
 
 template<uint32_t L, typename T>
-constexpr TRAP::Math::Vec<L, T> TRAP::Math::Clamp(const Vec<L, T>& x, T minVal, T maxVal)
+constexpr TRAP::Math::Vec<L, T> TRAP::Math::Clamp(const Vec<L, T>& x, const T minVal, const T maxVal)
 {
 	static_assert(std::numeric_limits<T>::is_iec559 || std::numeric_limits<T>::is_integer,
 	              "'Clamp' only accepts floating-point or integer inputs");
@@ -3487,7 +3487,7 @@ TRAP::Math::Vec<L, uint32_t> TRAP::Math::URound(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genTypeT, typename genTypeU>
-constexpr genTypeT TRAP::Math::Mix(genTypeT x, genTypeT y, genTypeU a)
+constexpr genTypeT TRAP::Math::Mix(const genTypeT x, const genTypeT y, const genTypeU a)
 {
 	if constexpr (std::is_same_v<genTypeU, bool>)
 		return a ? y : x;
@@ -3535,7 +3535,7 @@ constexpr TRAP::Math::Vec<L, T> TRAP::Math::Mix(const Vec<L, T>& x, const Vec<L,
 }
 
 template<typename T>
-TRAP::Math::tQuat<T> TRAP::Math::Mix(const tQuat<T>& x, const tQuat<T>& y, T a)
+TRAP::Math::tQuat<T> TRAP::Math::Mix(const tQuat<T>& x, const tQuat<T>& y, const T a)
 {
 	static_assert(std::numeric_limits<T>::is_iec559, "'mix' only accepts floating-point inputs");
 
@@ -3549,7 +3549,7 @@ TRAP::Math::tQuat<T> TRAP::Math::Mix(const tQuat<T>& x, const tQuat<T>& y, T a)
 		return tQuat<T>(Mix(x.w, y.w, a), Mix(x.x, y.x, a), Mix(x.y, y.y, a), Mix(x.z, y.z, a));
 	}
 
-	T angle = ACos(cosTheta);
+	const T angle = ACos(cosTheta);
 	return (Sin((static_cast<T>(1) - a)* angle)* x + Sin(a * angle) * y) / Sin(angle);
 }
 
@@ -3627,13 +3627,13 @@ constexpr bool TRAP::Math::Not(const bool v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::Step(genType edge, genType x)
+genType TRAP::Math::Step(const genType edge, const genType x)
 {
 	return Mix(static_cast<genType>(1), static_cast<genType>(0), x < edge);
 }
 
 template<uint32_t L, typename T>
-TRAP::Math::Vec<L, T> TRAP::Math::Step(T edge, const Vec<L, T>& x)
+TRAP::Math::Vec<L, T> TRAP::Math::Step(const T edge, const Vec<L, T>& x)
 {
 	return Mix(Vec<L, T>(1), Vec<L, T>(0), LessThan(x, Vec<L, T>(edge)));
 }
@@ -3647,7 +3647,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Step(const Vec<L, T>& edge, const Vec<L, T>& x
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::SmoothStep(genType edge0, genType edge1, genType x)
+genType TRAP::Math::SmoothStep(const genType edge0, const genType edge1, const genType x)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559, "'SmoothStep' only accepts floating-point inputs");
 
@@ -3657,7 +3657,7 @@ genType TRAP::Math::SmoothStep(genType edge0, genType edge1, genType x)
 }
 
 template<uint32_t L, typename T>
-TRAP::Math::Vec<L, T> TRAP::Math::SmoothStep(T edge0, T edge1, const Vec<L, T>& x)
+TRAP::Math::Vec<L, T> TRAP::Math::SmoothStep(const T edge0, const T edge1, const Vec<L, T>& x)
 {
 	static_assert(std::numeric_limits<T>::is_iec559, "'SmoothStep' only accepts floating-point inputs");
 
@@ -3680,7 +3680,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::SmoothStep(const Vec<L, T>& edge0, const Vec<L
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-constexpr bool TRAP::Math::IsNaN(genType x)
+constexpr bool TRAP::Math::IsNaN(const genType x)
 {
 	return x != x;
 }
@@ -3707,7 +3707,7 @@ constexpr TRAP::Math::Vec<4, bool> TRAP::Math::IsNaN(const tQuat<T>& q)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-constexpr bool TRAP::Math::IsInf(genType x)
+constexpr bool TRAP::Math::IsInf(const genType x)
 {
 	return x == std::numeric_limits<genType>::infinity() || x == -std::numeric_limits<genType>::infinity();
 }
@@ -3742,7 +3742,7 @@ genType TRAP::Math::FMA(const genType& a, const genType& b, const genType& c)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::FrExp(genType x, int32_t& exp)
+genType TRAP::Math::FrExp(const genType x, int32_t& exp)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559, "'FrExp' only accepts floating-point inputs");
 
@@ -3784,7 +3784,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::LdExp(const Vec<L, T>& v, const Vec<L, int32_t
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-bool TRAP::Math::IsPowerOfTwo(genType value)
+bool TRAP::Math::IsPowerOfTwo(const genType value)
 {
 	static_assert(std::numeric_limits<genType>::is_integer, "'IsPowerOfTwo' only accepts integer inputs");
 
@@ -3806,7 +3806,7 @@ TRAP::Math::Vec<L, bool> TRAP::Math::IsPowerOfTwo(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::FMod(genType x, genType y)
+genType TRAP::Math::FMod(const genType x, const genType y)
 {
 	return std::fmod(x, y);
 }
@@ -3832,7 +3832,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::FMod(const Vec<L, T>& x, const Vec<L, T>& y)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Lerp(T x, T y, T a)
+T TRAP::Math::Lerp(const T x, const T y, const T a)
 {
 	return Mix(x, y, a);
 }
@@ -3866,7 +3866,7 @@ constexpr TRAP::Math::tQuat<T> TRAP::Math::Lerp(const tQuat<T>& x, const tQuat<T
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Pow(T base, T exponent)
+T TRAP::Math::Pow(const T base, const T exponent)
 {
 	return std::pow(base, exponent);
 }
@@ -3881,7 +3881,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Pow(const Vec<L, T>& base, const Vec<L, T>& ex
 }
 
 template <typename T>
-TRAP::Math::tQuat<T> TRAP::Math::Pow(const tQuat<T>& x, T y)
+TRAP::Math::tQuat<T> TRAP::Math::Pow(const tQuat<T>& x, const T y)
 {
 	//Raising to the power of 0 should yield 1
 	//Needed to prevent a division by 0 error later on
@@ -3889,7 +3889,7 @@ TRAP::Math::tQuat<T> TRAP::Math::Pow(const tQuat<T>& x, T y)
 		return tQuat<T>(1, 0, 0, 0);
 
 	//To deal with non-unit quaternions
-	T magnitude = Sqrt(x.x * x.x + x.y * x.y + x.z * x.z + x.w * x.w);
+	const T magnitude = Sqrt(x.x * x.x + x.y * x.y + x.z * x.z + x.w * x.w);
 
 	T angle;
 	if(Abs(x.w / magnitude) > CosOneOverTwo<T>())
@@ -3898,7 +3898,7 @@ TRAP::Math::tQuat<T> TRAP::Math::Pow(const tQuat<T>& x, T y)
 		//Instead, we use the non-scalar components since Sin() is accurate around 0
 
 		//Prevent a division by 0 error later on
-		T vectorMagnitude = x.x * x.x + x.y * x.y + x.z * x.z;
+		const T vectorMagnitude = x.x * x.x + x.y * x.y + x.z * x.z;
 		//Despite the compiler might say, we actually want to compare vectorMagnitude ti 0.
 		//Here, we could use denorm_int() compiling a project with unsafe maths optimizations
 		//might make the comparison always false, even when vectorMagnitude is 0.
@@ -3916,16 +3916,16 @@ TRAP::Math::tQuat<T> TRAP::Math::Pow(const tQuat<T>& x, T y)
 		angle = ACos(x.w / magnitude);
 	}
 
-	T newAngle = angle * y;
-	T div = Sin(newAngle) / Sin(angle);
-	T mag = Pow(magnitude, y - static_cast<T>(1));
+	const T newAngle = angle * y;
+	const T div = Sin(newAngle) / Sin(angle);
+	const T mag = Pow(magnitude, y - static_cast<T>(1));
 	return tQuat<T>(Cos(newAngle) * magnitude * mag, x.x * div * mag, x.y * div * mag, x.z * div * mag);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Exp(T x)
+T TRAP::Math::Exp(const T x)
 {
 	return std::exp(x);
 }
@@ -3943,7 +3943,7 @@ template <typename T>
 TRAP::Math::tQuat<T> TRAP::Math::Exp(const tQuat<T>& q)
 {
 	Vec<3, T> u(q.x, q.y, q.z);
-	T const angle = Length(u);
+	const T angle = Length(u);
 	if (angle < Epsilon<T>())
 		return tQuat<T>();
 
@@ -3954,7 +3954,7 @@ TRAP::Math::tQuat<T> TRAP::Math::Exp(const tQuat<T>& q)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Log(T x)
+T TRAP::Math::Log(const T x)
 {
 	return std::log(x);
 }
@@ -3972,7 +3972,7 @@ template <typename T>
 TRAP::Math::tQuat<T> TRAP::Math::Log(const tQuat<T>& q)
 {
 	Vec<3, T> u(q.x, q.y, q.z);
-	T vec3Len = Length(u);
+	const T vec3Len = Length(u);
 
 	if(vec3Len < Epsilon<T>())
 	{
@@ -3984,15 +3984,15 @@ TRAP::Math::tQuat<T> TRAP::Math::Log(const tQuat<T>& q)
 		                      std::numeric_limits<T>::infinity(), std::numeric_limits<T>::infinity());
 	}
 
-	T t = ATan(vec3Len, T(q.w)) / vec3Len;
-	T quatLen2 = vec3Len * vec3Len + q.w * q.w;
+	const T t = ATan(vec3Len, T(q.w)) / vec3Len;
+	const T quatLen2 = vec3Len * vec3Len + q.w * q.w;
 	return tQuat<T>(static_cast<T>(0.5)* Log(quatLen2), t* q.x, t* q.y, t* q.z);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::Exp2(genType x)
+genType TRAP::Math::Exp2(const genType x)
 {
 	return std::exp2(x);
 }
@@ -4009,7 +4009,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Exp2(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::Log2(genType x)
+genType TRAP::Math::Log2(const genType x)
 {
 	return static_cast<genType>(std::log2(x));
 }
@@ -4026,7 +4026,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Log2(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Sqrt(T x)
+T TRAP::Math::Sqrt(const T x)
 {
 	return std::sqrt(x);
 }
@@ -4051,7 +4051,7 @@ TRAP::Math::tQuat<T> TRAP::Math::Sqrt(const tQuat<T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::InverseSqrt(genType x)
+genType TRAP::Math::InverseSqrt(const genType x)
 {
 	return static_cast<genType>(1) / Sqrt(x);
 }
@@ -4072,7 +4072,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::InverseSqrt(const Vec<L, T>& x)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::Length(genType x)
+genType TRAP::Math::Length(const genType x)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559, "'Length' accepts only floating-point inputs");
 
@@ -4112,7 +4112,7 @@ T TRAP::Math::Distance(const Vec<L, T>& p0, const Vec<L, T>& p1)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-constexpr T TRAP::Math::Dot(T x, T y)
+constexpr T TRAP::Math::Dot(const T x, const T y)
 {
 	static_assert(std::numeric_limits<T>::is_iec559, "'Dot' accepts only floating-point inputs");
 
@@ -4125,7 +4125,7 @@ constexpr T TRAP::Math::Dot(const Vec<L, T>& x, const Vec<L, T>& y)
 	static_assert(std::numeric_limits<T>::is_iec559, "'Dot' accepts only floating-point inputs");
 
 	T result = 0;
-	Vec<L, T> tmp(x * y);
+	const Vec<L, T> tmp(x * y);
 	for (uint32_t i = 0; i < L; i++)
 		result += tmp[i];
 	return result;
@@ -4136,7 +4136,7 @@ constexpr T TRAP::Math::Dot(const tQuat<T>& x, const tQuat<T>& y)
 {
 	static_assert(std::numeric_limits<T>::is_iec559, "'Dot' accepts only floating-point inputs");
 
-	Vec<4, T> tmp(x.w * y.w, x.x * y.x, x.y * y.y, x.z * y.z);
+	const Vec<4, T> tmp(x.w * y.w, x.x * y.x, x.y * y.y, x.z * y.z);
 
 	return (tmp.x + tmp.y) + (tmp.z + tmp.w);
 }
@@ -4183,11 +4183,11 @@ TRAP::Math::Vec<L, T> TRAP::Math::Normalize(const Vec<L, T>& x)
 template <typename T>
 TRAP::Math::tQuat<T> TRAP::Math::Normalize(const tQuat<T>& q)
 {
-	T len = Length(q);
+	const T len = Length(q);
 	if (len <= static_cast<T>(0)) //Problem
 		return tQuat<T>(static_cast<T>(1), static_cast<T>(0), static_cast<T>(0), static_cast<T>(0));
 
-	T oneOverLen = static_cast<T>(1) / len;
+	const T oneOverLen = static_cast<T>(1) / len;
 	return tQuat<T>(q.w * oneOverLen, q.x * oneOverLen, q.y * oneOverLen, q.z * oneOverLen);
 }
 
@@ -4241,8 +4241,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Refract(const Vec<L, T>& I, const Vec<L, T>& N
 
 	const T dotValue(Dot(N, I));
 	const T k(static_cast<T>(1) - eta * eta * (static_cast<T>(1) - dotValue * dotValue));
-	const Vec<L, T> result = (k >= static_cast<T>(0)) ? (eta * I - (eta * dotValue + std::sqrt(k)) * N) :
-		Vec<L, T>(0);
+	const Vec<L, T> result = (k >= static_cast<T>(0)) ? (eta * I - (eta * dotValue + std::sqrt(k)) * N) : Vec<L, T>(0);
 
 	return result;
 }
@@ -4398,17 +4397,17 @@ T TRAP::Math::Determinant(const Mat<4, 4, T>& m)
 {
 	static_assert(std::numeric_limits<T>::is_iec559, "'Determinant' only accepts floating-point inputs");
 
-	T subFactor00 = m[2][2] * m[3][3] - m[3][2] * m[2][3];
-	T subFactor01 = m[2][1] * m[3][3] - m[3][1] * m[2][3];
-	T subFactor02 = m[2][1] * m[3][2] - m[3][1] * m[2][2];
-	T subFactor03 = m[2][0] * m[3][3] - m[3][0] * m[2][3];
-	T subFactor04 = m[2][0] * m[3][2] - m[3][0] * m[2][2];
-	T subFactor05 = m[2][0] * m[3][1] - m[3][0] * m[2][1];
+	const T subFactor00 = m[2][2] * m[3][3] - m[3][2] * m[2][3];
+	const T subFactor01 = m[2][1] * m[3][3] - m[3][1] * m[2][3];
+	const T subFactor02 = m[2][1] * m[3][2] - m[3][1] * m[2][2];
+	const T subFactor03 = m[2][0] * m[3][3] - m[3][0] * m[2][3];
+	const T subFactor04 = m[2][0] * m[3][2] - m[3][0] * m[2][2];
+	const T subFactor05 = m[2][0] * m[3][1] - m[3][0] * m[2][1];
 
-	Vec<4, T> detCof(+(m[1][1] * subFactor00 - m[1][2] * subFactor01 + m[1][3] * subFactor02),
-		             -(m[1][0] * subFactor00 - m[1][2] * subFactor03 + m[1][3] * subFactor04),
-		             +(m[1][0] * subFactor01 - m[1][1] * subFactor03 + m[1][3] * subFactor05),
-		             -(m[1][0] * subFactor02 - m[1][1] * subFactor04 + m[1][2] * subFactor05));
+	const Vec<4, T> detCof(+(m[1][1] * subFactor00 - m[1][2] * subFactor01 + m[1][3] * subFactor02),
+		                   -(m[1][0] * subFactor00 - m[1][2] * subFactor03 + m[1][3] * subFactor04),
+		                   +(m[1][0] * subFactor01 - m[1][1] * subFactor03 + m[1][3] * subFactor05),
+		                   -(m[1][0] * subFactor02 - m[1][1] * subFactor04 + m[1][2] * subFactor05));
 
 	return m[0][0] * detCof[0] + m[0][1] * detCof[1] +
 		   m[0][2] * detCof[2] + m[0][3] * detCof[3];
@@ -4421,9 +4420,9 @@ TRAP::Math::Mat<3, 3, T> TRAP::Math::Inverse(const Mat<3, 3, T>& m)
 {
 	static_assert(std::numeric_limits<T>::is_iec559, "'Inverse' only accepts floating-points inputs");
 
-	T oneOverDeterminant = static_cast<T>(1) / (+m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2])
-		- m[1][0] * (m[0][1] * m[2][2] - m[2][1] * m[0][2])
-		+ m[2][0] * (m[0][1] * m[1][2] - m[1][1] * m[0][2]));
+	const T oneOverDeterminant = static_cast<T>(1) / (+m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2])
+		                                              - m[1][0] * (m[0][1] * m[2][2] - m[2][1] * m[0][2])
+		                                              + m[2][0] * (m[0][1] * m[1][2] - m[1][1] * m[0][2]));
 
 	Mat<3, 3, T> inverse;
 	inverse[0][0] = +(m[1][1] * m[2][2] - m[2][1] * m[1][2]) * oneOverDeterminant;
@@ -4443,57 +4442,57 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::Inverse(const Mat<4, 4, T>& m)
 {
 	static_assert(std::numeric_limits<T>::is_iec559, "'Inverse' only accepts floating-points inputs");
 
-	T coef00 = m[2][2] * m[3][3] - m[3][2] * m[2][3];
-	T coef02 = m[1][2] * m[3][3] - m[3][2] * m[1][3];
-	T coef03 = m[1][2] * m[2][3] - m[2][2] * m[1][3];
+	const T coef00 = m[2][2] * m[3][3] - m[3][2] * m[2][3];
+	const T coef02 = m[1][2] * m[3][3] - m[3][2] * m[1][3];
+	const T coef03 = m[1][2] * m[2][3] - m[2][2] * m[1][3];
 
-	T coef04 = m[2][1] * m[3][3] - m[3][1] * m[2][3];
-	T coef06 = m[1][1] * m[3][3] - m[3][1] * m[1][3];
-	T coef07 = m[1][1] * m[2][3] - m[2][1] * m[1][3];
+	const T coef04 = m[2][1] * m[3][3] - m[3][1] * m[2][3];
+	const T coef06 = m[1][1] * m[3][3] - m[3][1] * m[1][3];
+	const T coef07 = m[1][1] * m[2][3] - m[2][1] * m[1][3];
 
-	T coef08 = m[2][1] * m[3][2] - m[3][1] * m[2][2];
-	T coef10 = m[1][1] * m[3][2] - m[3][1] * m[1][2];
-	T coef11 = m[1][1] * m[2][2] - m[2][1] * m[1][2];
+	const T coef08 = m[2][1] * m[3][2] - m[3][1] * m[2][2];
+	const T coef10 = m[1][1] * m[3][2] - m[3][1] * m[1][2];
+	const T coef11 = m[1][1] * m[2][2] - m[2][1] * m[1][2];
 
-	T coef12 = m[2][0] * m[3][3] - m[3][0] * m[2][3];
-	T coef14 = m[1][0] * m[3][3] - m[3][0] * m[1][3];
-	T coef15 = m[1][0] * m[2][3] - m[2][0] * m[1][3];
+	const T coef12 = m[2][0] * m[3][3] - m[3][0] * m[2][3];
+	const T coef14 = m[1][0] * m[3][3] - m[3][0] * m[1][3];
+	const T coef15 = m[1][0] * m[2][3] - m[2][0] * m[1][3];
 
-	T coef16 = m[2][0] * m[3][2] - m[3][0] * m[2][2];
-	T coef18 = m[1][0] * m[3][2] - m[3][0] * m[1][2];
-	T coef19 = m[1][0] * m[2][2] - m[2][0] * m[1][2];
+	const T coef16 = m[2][0] * m[3][2] - m[3][0] * m[2][2];
+	const T coef18 = m[1][0] * m[3][2] - m[3][0] * m[1][2];
+	const T coef19 = m[1][0] * m[2][2] - m[2][0] * m[1][2];
 
-	T coef20 = m[2][0] * m[3][1] - m[3][0] * m[2][1];
-	T coef22 = m[1][0] * m[3][1] - m[3][0] * m[1][1];
-	T coef23 = m[1][0] * m[2][1] - m[2][0] * m[1][1];
+	const T coef20 = m[2][0] * m[3][1] - m[3][0] * m[2][1];
+	const T coef22 = m[1][0] * m[3][1] - m[3][0] * m[1][1];
+	const T coef23 = m[1][0] * m[2][1] - m[2][0] * m[1][1];
 
-	Vec<4, T> fac0(coef00, coef00, coef02, coef03);
-	Vec<4, T> fac1(coef04, coef04, coef06, coef07);
-	Vec<4, T> fac2(coef08, coef08, coef10, coef11);
-	Vec<4, T> fac3(coef12, coef12, coef14, coef15);
-	Vec<4, T> fac4(coef16, coef16, coef18, coef19);
-	Vec<4, T> fac5(coef20, coef20, coef22, coef23);
+	const Vec<4, T> fac0(coef00, coef00, coef02, coef03);
+	const Vec<4, T> fac1(coef04, coef04, coef06, coef07);
+	const Vec<4, T> fac2(coef08, coef08, coef10, coef11);
+	const Vec<4, T> fac3(coef12, coef12, coef14, coef15);
+	const Vec<4, T> fac4(coef16, coef16, coef18, coef19);
+	const Vec<4, T> fac5(coef20, coef20, coef22, coef23);
 
-	Vec<4, T> vec0(m[1][0], m[0][0], m[0][0], m[0][0]);
-	Vec<4, T> vec1(m[1][1], m[0][1], m[0][1], m[0][1]);
-	Vec<4, T> vec2(m[1][2], m[0][2], m[0][2], m[0][2]);
-	Vec<4, T> vec3(m[1][3], m[0][3], m[0][3], m[0][3]);
+	const Vec<4, T> vec0(m[1][0], m[0][0], m[0][0], m[0][0]);
+	const Vec<4, T> vec1(m[1][1], m[0][1], m[0][1], m[0][1]);
+	const Vec<4, T> vec2(m[1][2], m[0][2], m[0][2], m[0][2]);
+	const Vec<4, T> vec3(m[1][3], m[0][3], m[0][3], m[0][3]);
 
-	Vec<4, T> inv0(vec1 * fac0 - vec2 * fac1 + vec3 * fac2);
-	Vec<4, T> inv1(vec0 * fac0 - vec2 * fac3 + vec3 * fac4);
-	Vec<4, T> inv2(vec0 * fac1 - vec1 * fac3 + vec3 * fac5);
-	Vec<4, T> inv3(vec0 * fac2 - vec1 * fac4 + vec2 * fac5);
+	const Vec<4, T> inv0(vec1 * fac0 - vec2 * fac1 + vec3 * fac2);
+	const Vec<4, T> inv1(vec0 * fac0 - vec2 * fac3 + vec3 * fac4);
+	const Vec<4, T> inv2(vec0 * fac1 - vec1 * fac3 + vec3 * fac5);
+	const Vec<4, T> inv3(vec0 * fac2 - vec1 * fac4 + vec2 * fac5);
 
-	Vec<4, T> signA(+1, -1, +1, -1);
-	Vec<4, T> signB(-1, +1, -1, +1);
-	Mat<4, 4, T> inverse(inv0 * signA, inv1 * signB, inv2 * signA, inv3 * signB);
+	const Vec<4, T> signA(+1, -1, +1, -1);
+	const Vec<4, T> signB(-1, +1, -1, +1);
+	const Mat<4, 4, T> inverse(inv0 * signA, inv1 * signB, inv2 * signA, inv3 * signB);
 
-	Vec<4, T> row0(inverse[0][0], inverse[1][0], inverse[2][0], inverse[3][0]);
+	const Vec<4, T> row0(inverse[0][0], inverse[1][0], inverse[2][0], inverse[3][0]);
 
-	Vec<4, T> dot0(m[0] * row0);
-	T dot1 = (dot0.x + dot0.y) + (dot0.z + dot0.w);
+	const Vec<4, T> dot0(m[0] * row0);
+	const T dot1 = (dot0.x + dot0.y) + (dot0.z + dot0.w);
 
-	T oneOverDeterminant = static_cast<T>(1) / dot1;
+	const T oneOverDeterminant = static_cast<T>(1) / dot1;
 
 	return inverse * oneOverDeterminant;
 }
@@ -4501,7 +4500,7 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::Inverse(const Mat<4, 4, T>& m)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-TRAP::Math::Mat<4, 4, T> TRAP::Math::Orthographic(T left, T right, T bottom, T top)
+TRAP::Math::Mat<4, 4, T> TRAP::Math::Orthographic(const T left, const T right, const T bottom, const T top)
 {
 	Mat<4, 4, T> result(static_cast<T>(1));
 
@@ -4515,7 +4514,8 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::Orthographic(T left, T right, T bottom, T t
 }
 
 template<typename T>
-TRAP::Math::Mat<4, 4, T> TRAP::Math::Orthographic(T left, T right, T bottom, T top, T zNear, T zFar)
+TRAP::Math::Mat<4, 4, T> TRAP::Math::Orthographic(const T left, const T right, const T bottom, const T top,
+                                                  const T zNear, const T zFar)
 {
 	Mat<4, 4, T> result(static_cast<T>(1));
 
@@ -4532,7 +4532,8 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::Orthographic(T left, T right, T bottom, T t
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-TRAP::Math::Mat<4, 4, T> TRAP::Math::Frustum(T left, T right, T bottom, T top, T nearVal, T farVal)
+TRAP::Math::Mat<4, 4, T> TRAP::Math::Frustum(const T left, const T right, const T bottom, const T top,
+                                             const T nearVal, const T farVal)
 {
 	Mat<4, 4, T> result(static_cast<T>(0));
 
@@ -4550,11 +4551,11 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::Frustum(T left, T right, T bottom, T top, T
 //-------------------------------------------------------------------------------------------------------------------//
 
 template <typename T>
-TRAP::Math::Mat<4, 4, T> TRAP::Math::Perspective(T fovY, T aspect, T zNear, T zFar)
+TRAP::Math::Mat<4, 4, T> TRAP::Math::Perspective(const T fovY, const T aspect, const T zNear, const T zFar)
 {
 	TRAP_ASSERT(std::abs(aspect - std::numeric_limits<T>::epsilon()) > static_cast<T>(0));
 
-	T const tanHalfFoVY = std::tan(fovY / static_cast<T>(2));
+	const T tanHalfFoVY = std::tan(fovY / static_cast<T>(2));
 
 	Mat<4, 4, T> result(static_cast<T>(0));
 
@@ -4570,15 +4571,16 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::Perspective(T fovY, T aspect, T zNear, T zF
 //-------------------------------------------------------------------------------------------------------------------//
 
 template <typename T>
-TRAP::Math::Mat<4, 4, T> TRAP::Math::PerspectiveFoV(T fov, T width, T height, T zNear, T zFar)
+TRAP::Math::Mat<4, 4, T> TRAP::Math::PerspectiveFoV(const T fov, const T width, const T height, const T zNear,
+                                                    const T zFar)
 {
 	TRAP_ASSERT(width > static_cast<T>(0));
 	TRAP_ASSERT(height > static_cast<T>(0));
 	TRAP_ASSERT(fov > static_cast<T>(0));
 
-	T const rad = fov;
-	T const h = Cos(static_cast<T>(0.5)* rad) / Sin(static_cast<T>(0.5)* rad);
-	T const w = h * height / width;
+	const T rad = fov;
+	const T h = Cos(static_cast<T>(0.5)* rad) / Sin(static_cast<T>(0.5)* rad);
+	const T w = h * height / width;
 
 	Mat<4, 4, T> result(static_cast<T>(0));
 
@@ -4594,13 +4596,13 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::PerspectiveFoV(T fov, T width, T height, T 
 //-------------------------------------------------------------------------------------------------------------------//
 
 template <typename T>
-TRAP::Math::Mat<4, 4, T> TRAP::Math::InfinitePerspective(T fovY, T aspect, T zNear)
+TRAP::Math::Mat<4, 4, T> TRAP::Math::InfinitePerspective(const T fovY, const T aspect, const T zNear)
 {
-	T const range = std::tan(fovY / static_cast<T>(2))* zNear;
-	T const left = -range * aspect;
-	T const right = range * aspect;
-	T const bottom = -range;
-	T const top = range;
+	const T range = std::tan(fovY / static_cast<T>(2))* zNear;
+	const T left = -range * aspect;
+	const T right = range * aspect;
+	const T bottom = -range;
+	const T top = range;
 
 	Mat<4, 4, T> result(static_cast<T>(0));
 
@@ -4652,14 +4654,14 @@ constexpr TRAP::Math::Mat<4, 4, T> TRAP::Math::Translate(const Vec<3, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-TRAP::Math::Mat<4, 4, T> TRAP::Math::Rotate(const Mat<4, 4, T>& m, T angleInRadians, const Vec<3, T>& v)
+TRAP::Math::Mat<4, 4, T> TRAP::Math::Rotate(const Mat<4, 4, T>& m, const T angleInRadians, const Vec<3, T>& v)
 {
 	const T a = angleInRadians;
 	const T c = std::cos(a);
 	const T s = std::sin(a);
 
-	Vec<3, T> axis(Normalize(v));
-	Vec<3, T> temp((T(1) - c) * axis);
+	const Vec<3, T> axis(Normalize(v));
+	const Vec<3, T> temp((T(1) - c) * axis);
 
 	Mat<4, 4, T> rotate;
 
@@ -4686,14 +4688,14 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::Rotate(const Mat<4, 4, T>& m, T angleInRadi
 }
 
 template<typename T>
-TRAP::Math::Mat<4, 4, T> TRAP::Math::Rotate(T angleInRadians, const Vec<3, T>& v)
+TRAP::Math::Mat<4, 4, T> TRAP::Math::Rotate(const T angleInRadians, const Vec<3, T>& v)
 {
 	const T a = angleInRadians;
 	const T c = std::cos(a);
 	const T s = std::sin(a);
 
-	Vec<3, T> axis(Normalize(v));
-	Vec<3, T> temp((T(1) - c) * axis);
+	const Vec<3, T> axis(Normalize(v));
+	const Vec<3, T> temp((T(1) - c) * axis);
 
 	Mat<4, 4, T> rotate;
 
@@ -4709,7 +4711,7 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::Rotate(T angleInRadians, const Vec<3, T>& v
 	rotate[2][1] = temp[2] * axis[1] - s * axis[0];
 	rotate[2][2] = c + temp[2] * axis[2];
 
-	Mat<4, 4, T> identity(1.0f);
+	const Mat<4, 4, T> identity(1.0f);
 	Mat<4, 4, T> result;
 
 	result[0] = identity[0] * rotate[0][0] + identity[1] * rotate[0][1] + identity[2] * rotate[0][2];
@@ -4832,7 +4834,7 @@ typename T::colType TRAP::Math::Column(const T& m, const int32_t index)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template <typename T>
-TRAP::Math::tQuat<T> TRAP::Math::SLerp(const tQuat<T>& x, const tQuat<T>& y, T a)
+TRAP::Math::tQuat<T> TRAP::Math::SLerp(const tQuat<T>& x, const tQuat<T>& y, const T a)
 {
 	static_assert(std::numeric_limits<T>::is_iec559, "'SLerp' only accepts floating-point inputs");
 
@@ -4856,14 +4858,14 @@ TRAP::Math::tQuat<T> TRAP::Math::SLerp(const tQuat<T>& x, const tQuat<T>& y, T a
 		return tQuat<T>(Mix(x.w, z.w, a), Mix(x.x, z.x, a), Mix(x.y, z.y, a), Mix(x.z, z.z, a));
 	}
 
-	T angle = ACos(cosTheta);
+	const T angle = ACos(cosTheta);
 	return (Sin((static_cast<T>(1) - a) * angle) * x + Sin(a * angle) * z) / Sin(angle);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T, typename S>
-TRAP::Math::tQuat<T> TRAP::Math::SLerp(const tQuat<T>& x, const tQuat<T>& y, T a, S k)
+TRAP::Math::tQuat<T> TRAP::Math::SLerp(const tQuat<T>& x, const tQuat<T>& y, const T a, const S k)
 {
 	static_assert(std::numeric_limits<T>::is_iec559, "'SLerp' only accepts floating-point inputs");
 	static_assert(std::numeric_limits<S>::is_integer, "'SLerp' only accepts integers for spin count");
@@ -4890,8 +4892,8 @@ TRAP::Math::tQuat<T> TRAP::Math::SLerp(const tQuat<T>& x, const tQuat<T>& y, T a
 	else
 	{
 		//Graphics Gems III, page 96
-		T angle = ACos(cosTheta);
-		T phi = angle + k * PI<T>();
+		const T angle = ACos(cosTheta);
+		const T phi = angle + k * PI<T>();
 		return (Sin(angle - a * phi) * x + Sin(a * phi) * z) / Sin(angle);
 	}
 }
@@ -4962,15 +4964,15 @@ template <typename T>
 TRAP::Math::Mat<3, 3, T> TRAP::Math::Mat3Cast(const tQuat<T>& q)
 {
 	Mat<3, 3, T> result(T(1));
-	T qxx(q.x * q.x);
-	T qyy(q.y * q.y);
-	T qzz(q.z * q.z);
-	T qxz(q.x * q.z);
-	T qxy(q.x * q.y);
-	T qyz(q.y * q.z);
-	T qwx(q.w * q.x);
-	T qwy(q.w * q.y);
-	T qwz(q.w * q.z);
+	const T qxx(q.x * q.x);
+	const T qyy(q.y * q.y);
+	const T qzz(q.z * q.z);
+	const T qxz(q.x * q.z);
+	const T qxy(q.x * q.y);
+	const T qyz(q.y * q.z);
+	const T qwx(q.w * q.x);
+	const T qwy(q.w * q.y);
+	const T qwz(q.w * q.z);
 
 	result[0][0] = T(1) - T(2) * (qyy + qzz);
 	result[0][1] = T(2) * (qxy + qwz);
@@ -4996,10 +4998,10 @@ TRAP::Math::Mat<4, 4, T> TRAP::Math::Mat4Cast(const tQuat<T>& q)
 template <typename T>
 TRAP::Math::tQuat<T> TRAP::Math::QuaternionCast(const Mat<3, 3, T>& m)
 {
-	T fourXSquaredMinus1 = m[0][0] - m[1][1] - m[2][2];
-	T fourYSquaredMinus1 = m[1][1] - m[0][0] - m[2][2];
-	T fourZSquaredMinus1 = m[2][2] - m[0][0] - m[1][1];
-	T fourWSquaredMinus1 = m[0][0] + m[1][1] + m[2][2];
+	const T fourXSquaredMinus1 = m[0][0] - m[1][1] - m[2][2];
+	const T fourYSquaredMinus1 = m[1][1] - m[0][0] - m[2][2];
+	const T fourZSquaredMinus1 = m[2][2] - m[0][0] - m[1][1];
+	const T fourWSquaredMinus1 = m[0][0] + m[1][1] + m[2][2];
 
 	int32_t biggestIndex = 0;
 	T fourBiggestSquaredMinus1 = fourWSquaredMinus1;
@@ -5019,8 +5021,8 @@ TRAP::Math::tQuat<T> TRAP::Math::QuaternionCast(const Mat<3, 3, T>& m)
 		biggestIndex = 3;
 	}
 
-	T biggestVal = Sqrt(fourBiggestSquaredMinus1 + static_cast<T>(1))* static_cast<T>(0.5);
-	T mult = static_cast<T>(0.25) / biggestVal;
+	const T biggestVal = Sqrt(fourBiggestSquaredMinus1 + static_cast<T>(1))* static_cast<T>(0.5);
+	const T mult = static_cast<T>(0.25) / biggestVal;
 
 	switch (biggestIndex)
 	{
@@ -5128,7 +5130,7 @@ TRAP::Math::Vec<4, bool> TRAP::Math::Equal(const tQuat<T>& x, const tQuat<T>& y)
 }
 
 template <typename T>
-TRAP::Math::Vec<4, bool> TRAP::Math::Equal(const tQuat<T>& x, const tQuat<T>& y, T epsilon)
+TRAP::Math::Vec<4, bool> TRAP::Math::Equal(const tQuat<T>& x, const tQuat<T>& y, const T epsilon)
 {
 	Vec<4, T> v(x.x - y.x, x.y - y.y, x.z - y.z, x.w - y.w);
 	return LessThan(Abs(v), Vec<4, T>(epsilon));
@@ -5147,9 +5149,9 @@ TRAP::Math::Vec<4, bool> TRAP::Math::NotEqual(const tQuat<T>& x, const tQuat<T>&
 }
 
 template <typename T>
-TRAP::Math::Vec<4, bool> TRAP::Math::NotEqual(const tQuat<T>& x, const tQuat<T>& y, T epsilon)
+TRAP::Math::Vec<4, bool> TRAP::Math::NotEqual(const tQuat<T>& x, const tQuat<T>& y, const T epsilon)
 {
-	Vec<4, T> v(x.x - y.x, x.y - y.y, x.z - y.z, x.w - y.w);
+	const Vec<4, T> v(x.x - y.x, x.y - y.y, x.z - y.z, x.w - y.w);
 	return GreaterThanEqual(Abs(v), Vec<4, T>(epsilon));
 }
 
@@ -5197,10 +5199,10 @@ TRAP::Math::tQuat<T> TRAP::Math::Rotate(const tQuat<T>& q, const T& angle, const
 	Vec<3, T> tmp = v;
 
 	//Axis of rotation must be normalized
-	T len = Length(tmp);
+	const T len = Length(tmp);
 	if(Abs(len - static_cast<T>(1)) > static_cast<T>(0.001))
 	{
-		T oneOverLen = static_cast<T>(1) / len;
+		const T oneOverLen = static_cast<T>(1) / len;
 		tmp.x *= oneOverLen;
 		tmp.y *= oneOverLen;
 		tmp.z *= oneOverLen;
@@ -5292,7 +5294,7 @@ constexpr TRAP::Math::Vec<L, bool> TRAP::Math::Equal(const Vec<L, T>& x, const V
 //-------------------------------------------------------------------------------------------------------------------//
 
 template <uint32_t L, typename T>
-constexpr TRAP::Math::Vec<L, bool> TRAP::Math::Equal(const Vec<L, T>& x, const Vec<L, T>& y, T epsilon)
+constexpr TRAP::Math::Vec<L, bool> TRAP::Math::Equal(const Vec<L, T>& x, const Vec<L, T>& y, const T epsilon)
 {
 	return Equal(x, y, Vec<L, T>(epsilon));
 }
@@ -5320,7 +5322,7 @@ constexpr TRAP::Math::Vec<L, bool> TRAP::Math::NotEqual(const Vec<L, T>& x, cons
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<uint32_t L, typename T>
-constexpr TRAP::Math::Vec<L, bool> TRAP::Math::NotEqual(const Vec<L, T>& x, const Vec<L, T>& y, T epsilon)
+constexpr TRAP::Math::Vec<L, bool> TRAP::Math::NotEqual(const Vec<L, T>& x, const Vec<L, T>& y, const T epsilon)
 {
 	return NotEqual(x, y, Vec<L, T>(epsilon));
 }
@@ -5372,7 +5374,7 @@ constexpr TRAP::Math::Vec<L, bool> TRAP::Math::Not(const Vec<L, bool>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-constexpr genType TRAP::Math::Radians(genType degrees)
+constexpr genType TRAP::Math::Radians(const genType degrees)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559, "'Radians' only accepts floating-point inputs");
 
@@ -5391,7 +5393,7 @@ constexpr TRAP::Math::Vec<L, T> TRAP::Math::Radians(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-constexpr genType TRAP::Math::Degrees(genType radians)
+constexpr genType TRAP::Math::Degrees(const genType radians)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559, "'Degrees' only accepts floating-point inputs");
 
@@ -5410,7 +5412,7 @@ constexpr TRAP::Math::Vec<L, T> TRAP::Math::Degrees(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Sin(T x)
+T TRAP::Math::Sin(const T x)
 {
 	return std::sin(x);
 }
@@ -5427,7 +5429,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Sin(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Cos(T x)
+T TRAP::Math::Cos(const T x)
 {
 	return std::cos(x);
 }
@@ -5444,7 +5446,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Cos(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::Tan(T x)
+T TRAP::Math::Tan(const T x)
 {
 	return std::tan(x);
 }
@@ -5461,7 +5463,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::Tan(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::ASin(T x)
+T TRAP::Math::ASin(const T x)
 {
 	return std::asin(x);
 }
@@ -5478,7 +5480,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::ASin(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::ACos(T x)
+T TRAP::Math::ACos(const T x)
 {
 	return std::acos(x);
 }
@@ -5495,7 +5497,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::ACos(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename genType>
-genType TRAP::Math::ATan(genType y, genType x)
+genType TRAP::Math::ATan(const genType y, const genType x)
 {
 	static_assert(std::numeric_limits<genType>::is_iec559, "'ATan' only accepts floating-point inputs");
 
@@ -5512,7 +5514,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::ATan(const Vec<L, T>& a, const Vec<L, T>& b)
 }
 
 template<typename T>
-T TRAP::Math::ATan(T x)
+T TRAP::Math::ATan(const T x)
 {
 	return std::atan(x);
 }
@@ -5529,7 +5531,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::ATan(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::SinH(T x)
+T TRAP::Math::SinH(const T x)
 {
 	return std::sinh(x);
 }
@@ -5546,7 +5548,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::SinH(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::CosH(T x)
+T TRAP::Math::CosH(const T x)
 {
 	return std::cosh(x);
 }
@@ -5563,7 +5565,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::CosH(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::TanH(T x)
+T TRAP::Math::TanH(const T x)
 {
 	return std::tanh(x);
 }
@@ -5580,7 +5582,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::TanH(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::ASinH(T x)
+T TRAP::Math::ASinH(const T x)
 {
 	return std::asinh(x);
 }
@@ -5597,7 +5599,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::ASinH(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::ACosH(T x)
+T TRAP::Math::ACosH(const T x)
 {
 	return std::acosh(x);
 }
@@ -5614,7 +5616,7 @@ TRAP::Math::Vec<L, T> TRAP::Math::ACosH(const Vec<L, T>& v)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-T TRAP::Math::ATanH(T x)
+T TRAP::Math::ATanH(const T x)
 {
 	return std::atanh(x);
 }
@@ -5635,19 +5637,19 @@ TRAP::Math::Vec<L, T> TRAP::Math::ATanH(const Vec<L, T>& v)
 template<typename T>
 constexpr TRAP::Math::Vec<3, T> TRAP::Math::RGBColor(const Vec<3, T>& hsvColor)
 {
-	Vec<3, T> hsv = hsvColor;
+	const Vec<3, T> hsv = hsvColor;
 	Vec<3, T> rgbColor;
 
 	if(hsv.y == static_cast<T>(0))
 		rgbColor = Vec<3, T>(hsv.z); //Achromatic (grey)
 	else
 	{
-		T sector = Floor(hsv.x * (T(1) / T(60)));
-		T frac = (hsv.x * (T(1) / T(60))) - sector;
+		const T sector = Floor(hsv.x * (T(1) / T(60)));
+		const T frac = (hsv.x * (T(1) / T(60))) - sector;
 		//Fractional part of h
-		T o = hsv.z * (T(1) - hsv.y);
-		T p = hsv.z * (T(1) - hsv.y * frac);
-		T q = hsv.z * (T(1) - hsv.y * (T(1) - frac));
+		const T o = hsv.z * (T(1) - hsv.y);
+		const T p = hsv.z * (T(1) - hsv.y * frac);
+		const T q = hsv.z * (T(1) - hsv.y * (T(1) - frac));
 
 		switch(int32_t(sector))
 		{
@@ -5694,9 +5696,9 @@ template<typename T>
 constexpr TRAP::Math::Vec<3, T> TRAP::Math::HSVColor(const Vec<3, T>& rgbColor)
 {
 	Vec<3, T> hsv = rgbColor;
-	T min = Min(Min(rgbColor.r, rgbColor.g), rgbColor.b);
-	T max = Max(Max(rgbColor.r, rgbColor.g), rgbColor.b);
-	T delta = max - min;
+	const T min = Min(Min(rgbColor.r, rgbColor.g), rgbColor.b);
+	const T max = Max(Max(rgbColor.r, rgbColor.g), rgbColor.b);
+	const T delta = max - min;
 
 	hsv.z = max;
 
@@ -5732,7 +5734,7 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::HSVColor(const Vec<3, T>& rgbColor)
 template<typename T>
 constexpr TRAP::Math::Mat<4, 4, T> TRAP::Math::Saturation(const T s)
 {
-	Vec<3, T> rgbw = Vec<3, T>(T(0.2126), T(0.7152), T(0.0722));
+	const Vec<3, T> rgbw = Vec<3, T>(T(0.2126), T(0.7152), T(0.0722));
 
 	const Vec<3, T> col((T(1) - s) * rgbw);
 

--- a/TRAP/src/Maths/Quaternion.h
+++ b/TRAP/src/Maths/Quaternion.h
@@ -87,7 +87,7 @@ namespace TRAP::Math
 		//Conversion constructors
 
 		template<typename U>
-		constexpr explicit tQuat(const tQuat<T>& q);
+		explicit constexpr tQuat(const tQuat<T>& q);
 
 		//Explicit conversion operators
 		//explicit operator Mat<3, 3, T>() const;
@@ -102,7 +102,7 @@ namespace TRAP::Math
 		/// Build a quaternion from euler angles (pitch, yaw, roll).
 		/// </summary>
 		/// <param name="eulerAnglesInRadians">Euler angles (pitch, yaw, roll).</param>
-		constexpr explicit tQuat(const Vec<3, T>& eulerAnglesInRadians);
+		explicit constexpr tQuat(const Vec<3, T>& eulerAnglesInRadians);
 		explicit tQuat(const Mat<3, 3, T>& m);
 		explicit tQuat(const Mat<4, 4, T>& m);
 

--- a/TRAP/src/Maths/Quaternion.h
+++ b/TRAP/src/Maths/Quaternion.h
@@ -209,13 +209,13 @@ namespace std
 //-------------------------------------------------------------------------------------------------------------------//
 //Explicit basic constructors
 template <typename T>
-constexpr TRAP::Math::tQuat<T>::tQuat(T s, const Vec<3, T>& v)
+constexpr TRAP::Math::tQuat<T>::tQuat(const T s, const Vec<3, T>& v)
 	: x(v.x), y(v.y), z(v.z), w(s)
 {
 }
 
 template <typename T>
-constexpr TRAP::Math::tQuat<T>::tQuat(T w, T x, T y, T z)
+constexpr TRAP::Math::tQuat<T>::tQuat(const T w, const T x, const T y, const T z)
 	: x(x), y(y), z(z), w(w)
 {
 }
@@ -251,7 +251,7 @@ template <typename T>
 TRAP::Math::tQuat<T>::tQuat(const Vec<3, T>& u, const Vec<3, T>& v)
 {
 	//TODO Can't use TRAP::Math::Sqrt here
-	T normUNormV = std::sqrt(Dot(u, u) * Dot(v, v));
+	const T normUNormV = std::sqrt(Dot(u, u) * Dot(v, v));
 	T realPart = normUNormV + Dot(u, v);
 	Vec<3, T> t;
 
@@ -278,8 +278,8 @@ TRAP::Math::tQuat<T>::tQuat(const Vec<3, T>& u, const Vec<3, T>& v)
 template <typename T>
 constexpr TRAP::Math::tQuat<T>::tQuat(const Vec<3, T>& eulerAnglesInRadians)
 {
-	Vec<3, T> c = Cos(eulerAnglesInRadians * T(0.5));
-	Vec<3, T> s = Sin(eulerAnglesInRadians * T(0.5));
+	const Vec<3, T> c = Cos(eulerAnglesInRadians * T(0.5));
+	const Vec<3, T> s = Sin(eulerAnglesInRadians * T(0.5));
 
 	this->w = c.x * c.y * c.z + s.x * s.y * s.z;
 	this->x = s.x * c.y * c.z - c.x * s.y * s.z;
@@ -349,14 +349,14 @@ constexpr TRAP::Math::tQuat<T>& TRAP::Math::tQuat<T>::operator*=(const tQuat<U>&
 
 template <typename T>
 template <typename U>
-constexpr TRAP::Math::tQuat<T>& TRAP::Math::tQuat<T>::operator*=(U s)
+constexpr TRAP::Math::tQuat<T>& TRAP::Math::tQuat<T>::operator*=(const U s)
 {
 	return (*this = tQuat<T>(this->w * s, this->x * s, this->y * s, this->z * s));
 }
 
 template <typename T>
 template <typename U>
-constexpr TRAP::Math::tQuat<T>& TRAP::Math::tQuat<T>::operator/=(U s)
+constexpr TRAP::Math::tQuat<T>& TRAP::Math::tQuat<T>::operator/=(const U s)
 {
 	return (*this = tQuat<T>(this->w / s, this->x / s, this->y / s, this->z / s));
 }
@@ -373,7 +373,7 @@ constexpr int TRAP::Math::tQuat<T>::Length()
 //Component Access
 
 template <typename T>
-constexpr T& TRAP::Math::tQuat<T>::operator[](int i)
+constexpr T& TRAP::Math::tQuat<T>::operator[](const int i)
 {
 	TRAP_ASSERT(i >= 0 && i < this->Length());
 
@@ -383,7 +383,7 @@ constexpr T& TRAP::Math::tQuat<T>::operator[](int i)
 //-------------------------------------------------------------------------------------------------------------------//
 
 template <typename T>
-constexpr const T& TRAP::Math::tQuat<T>::operator[](int i) const
+constexpr const T& TRAP::Math::tQuat<T>::operator[](const int i) const
 {
 	TRAP_ASSERT(i >= 0 && i < this->Length());
 

--- a/TRAP/src/Maths/Vec2.h
+++ b/TRAP/src/Maths/Vec2.h
@@ -294,12 +294,12 @@ namespace std
 //Explicit basic constructors
 //
 template<typename T>
-constexpr TRAP::Math::Vec<2, T>::Vec(T scalar)
+constexpr TRAP::Math::Vec<2, T>::Vec(const T scalar)
 	: x(scalar), y(scalar)
 {}
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T>::Vec(T x, T y)
+constexpr TRAP::Math::Vec<2, T>::Vec(const T x, const T y)
 	: x(x), y(y)
 {}
 
@@ -308,7 +308,7 @@ constexpr TRAP::Math::Vec<2, T>::Vec(T x, T y)
 
 template<typename T>
 template<typename A, typename B>
-constexpr TRAP::Math::Vec<2, T>::Vec(A x, B y)
+constexpr TRAP::Math::Vec<2, T>::Vec(const A x, const B y)
 	: x(static_cast<T>(x)), y(static_cast<T>(y))
 {}
 
@@ -345,7 +345,7 @@ constexpr int TRAP::Math::Vec<2, T>::Length()
 //Component accesses
 
 template<typename T>
-constexpr T& TRAP::Math::Vec<2, T>::operator[](int i)
+constexpr T& TRAP::Math::Vec<2, T>::operator[](const int i)
 {
 	TRAP_ASSERT(i >= 0 && i < this->Length());
 
@@ -353,7 +353,7 @@ constexpr T& TRAP::Math::Vec<2, T>::operator[](int i)
 }
 
 template<typename T>
-constexpr const T& TRAP::Math::Vec<2, T>::operator[](int i) const
+constexpr const T& TRAP::Math::Vec<2, T>::operator[](const int i) const
 {
 	TRAP_ASSERT(i >= 0 && i < this->Length());
 
@@ -375,7 +375,7 @@ constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator=(const Vec<2, U
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator+=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator+=(const U scalar)
 {
 	this->x += static_cast<T>(scalar);
 	this->y += static_cast<T>(scalar);
@@ -395,7 +395,7 @@ constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator+=(const Vec<2, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator-=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator-=(const U scalar)
 {
 	this->x -= static_cast<T>(scalar);
 	this->y -= static_cast<T>(scalar);
@@ -415,7 +415,7 @@ constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator-=(const Vec<2, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator*=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator*=(const U scalar)
 {
 	this->x *= static_cast<T>(scalar);
 	this->y *= static_cast<T>(scalar);
@@ -435,7 +435,7 @@ constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator*=(const Vec<2, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator/=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator/=(const U scalar)
 {
 	this->x /= static_cast<T>(scalar);
 	this->y /= static_cast<T>(scalar);
@@ -497,7 +497,7 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::Vec<2, T>::operator--(int)
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator%=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator%=(const U scalar)
 {
 	this->x %= static_cast<T>(scalar);
 	this->y %= static_cast<T>(scalar);
@@ -517,7 +517,7 @@ constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator%=(const Vec<2, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator&=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator&=(const U scalar)
 {
 	this->x &= static_cast<T>(scalar);
 	this->y &= static_cast<T>(scalar);
@@ -537,7 +537,7 @@ constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator&=(const Vec<2, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator|=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator|=(const U scalar)
 {
 	this->x |= static_cast<T>(scalar);
 	this->y |= static_cast<T>(scalar);
@@ -557,7 +557,7 @@ constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator|=(const Vec<2, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator^=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator^=(const U scalar)
 {
 	this->x ^= static_cast<T>(scalar);
 	this->y ^= static_cast<T>(scalar);
@@ -577,7 +577,7 @@ constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator^=(const Vec<2, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator<<=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator<<=(const U scalar)
 {
 	this->x <<= static_cast<T>(scalar);
 	this->y <<= static_cast<T>(scalar);
@@ -597,7 +597,7 @@ constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator<<=(const Vec<2,
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator>>=(U scalar)
+constexpr TRAP::Math::Vec<2, T>& TRAP::Math::Vec<2, T>::operator>>=(const U scalar)
 {
 	this->x >>= static_cast<T>(scalar);
 	this->y >>= static_cast<T>(scalar);
@@ -665,13 +665,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator-(const Vec<2, T>& v)
 //Binary arithmetic operators
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator+(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator+(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x + scalar, v.y + scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator+(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator+(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar + v.x, scalar + v.y);
 }
@@ -683,13 +683,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator+(const Vec<2, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator-(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator-(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x - scalar, v.y - scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator-(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator-(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar - v.x, scalar - v.y);
 }
@@ -701,13 +701,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator-(const Vec<2, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator*(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator*(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x * scalar, v.y * scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator*(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator*(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar * v.x, scalar * v.y);
 }
@@ -719,13 +719,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator*(const Vec<2, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator/(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator/(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x / scalar, v.y / scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator/(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator/(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar / v.x, scalar / v.y);
 }
@@ -740,13 +740,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator/(const Vec<2, T>& v1, const
 //Binary bit operators
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator%(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator%(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x % scalar, v.y % scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator%(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator%(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar % v.x, scalar % v.y);
 }
@@ -758,13 +758,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator%(const Vec<2, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator&(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator&(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x & scalar, v.y & scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator&(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator&(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar & v.x, scalar & v.y);
 }
@@ -776,13 +776,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator&(const Vec<2, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator|(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator|(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x | scalar, v.y | scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator|(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator|(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar | v.x, scalar | v.y);
 }
@@ -794,13 +794,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator|(const Vec<2, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator^(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator^(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x ^ scalar, v.y ^ scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator^(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator^(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar ^ v.x, scalar ^ v.y);
 }
@@ -812,13 +812,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator^(const Vec<2, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator<<(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator<<(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x << scalar, v.y << scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator<<(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator<<(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar << v.x, scalar << v.y);
 }
@@ -830,13 +830,13 @@ constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator<<(const Vec<2, T>& v1, cons
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator>>(const Vec<2, T>& v, T scalar)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator>>(const Vec<2, T>& v, const T scalar)
 {
 	return Vec<2, T>(v.x >> scalar, v.y >> scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator>>(T scalar, const Vec<2, T>& v)
+constexpr TRAP::Math::Vec<2, T> TRAP::Math::operator>>(const T scalar, const Vec<2, T>& v)
 {
 	return Vec<2, T>(scalar >> v.x, scalar >> v.y);
 }

--- a/TRAP/src/Maths/Vec2.h
+++ b/TRAP/src/Maths/Vec2.h
@@ -58,7 +58,7 @@ namespace TRAP::Math
 		constexpr Vec(const Vec & v) = default;
 
 		//Explicit basic constructors
-		constexpr explicit Vec(T scalar);
+		explicit constexpr Vec(T scalar);
 		constexpr Vec(T x, T y);
 
 		//Explicit conversions
@@ -69,14 +69,14 @@ namespace TRAP::Math
 
 		//Explicit conversions
 		template<typename U>
-		constexpr explicit Vec(const Vec<3, U> & v);
+		explicit constexpr Vec(const Vec<3, U> & v);
 		//Explicit conversions
 		template<typename U>
-		constexpr explicit Vec(const Vec<4, U> & v);
+		explicit constexpr Vec(const Vec<4, U> & v);
 
 		//Explicit conversions
 		template<typename U>
-		constexpr explicit Vec(const Vec<2, U> & v);
+		explicit constexpr Vec(const Vec<2, U> & v);
 
 		constexpr Vec(Vec&&) = default;
 		~Vec() = default;

--- a/TRAP/src/Maths/Vec3.h
+++ b/TRAP/src/Maths/Vec3.h
@@ -290,7 +290,7 @@ namespace std
 
 //Explicit basic constructors
 template<typename T>
-constexpr TRAP::Math::Vec<3, T>::Vec(T scalar)
+constexpr TRAP::Math::Vec<3, T>::Vec(const T scalar)
 	: x(scalar), y(scalar), z(scalar)
 {}
 
@@ -304,7 +304,7 @@ constexpr TRAP::Math::Vec<3, T>::Vec(T x, T y, T z)
 
 template<typename T>
 template<typename X, typename Y, typename Z>
-constexpr TRAP::Math::Vec<3, T>::Vec(X x, Y y, Z z)
+constexpr TRAP::Math::Vec<3, T>::Vec(const X x, const Y y, const Z z)
 	: x(static_cast<T>(x)),
 	  y(static_cast<T>(y)),
 	  z(static_cast<T>(z))
@@ -315,7 +315,7 @@ constexpr TRAP::Math::Vec<3, T>::Vec(X x, Y y, Z z)
 
 template<typename T>
 template<typename A, typename B>
-constexpr TRAP::Math::Vec<3, T>::Vec(const Vec<2, A>& xy, B z)
+constexpr TRAP::Math::Vec<3, T>::Vec(const Vec<2, A>& xy, const B z)
 	: x(static_cast<T>(xy.x)),
 	  y(static_cast<T>(xy.y)),
 	  z(static_cast<T>(z))
@@ -323,7 +323,7 @@ constexpr TRAP::Math::Vec<3, T>::Vec(const Vec<2, A>& xy, B z)
 
 template<typename T>
 template<typename A, typename B>
-constexpr TRAP::Math::Vec<3, T>::Vec(A x, const Vec<2, B>& yz)
+constexpr TRAP::Math::Vec<3, T>::Vec(const A x, const Vec<2, B>& yz)
 	: x(static_cast<T>(x)),
 	  y(static_cast<T>(yz.x)),
 	  z(static_cast<T>(yz.y))
@@ -357,7 +357,7 @@ constexpr int TRAP::Math::Vec<3, T>::Length()
 //Component accesses
 
 template<typename T>
-constexpr T& TRAP::Math::Vec<3, T>::operator[](int i)
+constexpr T& TRAP::Math::Vec<3, T>::operator[](const int i)
 {
 	TRAP_ASSERT(i >= 0 && i < this->Length());
 
@@ -376,7 +376,7 @@ constexpr T& TRAP::Math::Vec<3, T>::operator[](int i)
 }
 
 template<typename T>
-constexpr const T& TRAP::Math::Vec<3, T>::operator[](int i) const
+constexpr const T& TRAP::Math::Vec<3, T>::operator[](const int i) const
 {
 	TRAP_ASSERT(i >= 0 && i < this->Length());
 
@@ -410,7 +410,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator=(const Vec<3, U
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator+=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator+=(const U scalar)
 {
 	this->x += static_cast<T>(scalar);
 	this->y += static_cast<T>(scalar);
@@ -432,7 +432,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator+=(const Vec<3, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator-=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator-=(const U scalar)
 {
 	this->x -= static_cast<T>(scalar);
 	this->y -= static_cast<T>(scalar);
@@ -454,7 +454,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator-=(const Vec<3, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator*=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator*=(const U scalar)
 {
 	this->x *= static_cast<T>(scalar);
 	this->y *= static_cast<T>(scalar);
@@ -476,7 +476,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator*=(const Vec<3, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator/=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator/=(const U scalar)
 {
 	this->x /= static_cast<T>(scalar);
 	this->y /= static_cast<T>(scalar);
@@ -520,7 +520,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator--()
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::Vec<3, T>::operator++(int)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::Vec<3, T>::operator++(const int)
 {
 	Vec<3, T> result(*this);
 	++*this;
@@ -529,7 +529,7 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::Vec<3, T>::operator++(int)
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::Vec<3, T>::operator--(int)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::Vec<3, T>::operator--(const int)
 {
 	Vec<3, T> result(*this);
 	--*this;
@@ -542,7 +542,7 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::Vec<3, T>::operator--(int)
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator%=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator%=(const U scalar)
 {
 	this->x %= static_cast<T>(scalar);
 	this->y %= static_cast<T>(scalar);
@@ -564,7 +564,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator%=(const Vec<3, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator&=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator&=(const U scalar)
 {
 	this->x &= static_cast<T>(scalar);
 	this->y &= static_cast<T>(scalar);
@@ -586,7 +586,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator&=(const Vec<3, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator|=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator|=(const U scalar)
 {
 	this->x |= static_cast<T>(scalar);
 	this->y |= static_cast<T>(scalar);
@@ -608,7 +608,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator|=(const Vec<3, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator^=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator^=(const U scalar)
 {
 	this->x ^= static_cast<T>(scalar);
 	this->y ^= static_cast<T>(scalar);
@@ -630,7 +630,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator^=(const Vec<3, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator<<=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator<<=(const U scalar)
 {
 	this->x <<= static_cast<T>(scalar);
 	this->y <<= static_cast<T>(scalar);
@@ -652,7 +652,7 @@ constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator<<=(const Vec<3,
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator>>=(U scalar)
+constexpr TRAP::Math::Vec<3, T>& TRAP::Math::Vec<3, T>::operator>>=(const U scalar)
 {
 	this->x >>= static_cast<T>(scalar);
 	this->y >>= static_cast<T>(scalar);
@@ -722,13 +722,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator-(const Vec<3, T>& v)
 //Binary arithmetic operators
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator+(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator+(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x + scalar, v.y + scalar, v.z + scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator+(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator+(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar + v.x, scalar + v.y, scalar + v.z);
 }
@@ -740,13 +740,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator+(const Vec<3, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator-(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator-(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x - scalar, v.y - scalar, v.z - scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator-(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator-(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar - v.x, scalar - v.y, scalar - v.z);
 }
@@ -758,13 +758,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator-(const Vec<3, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator*(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator*(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x * scalar, v.y * scalar, v.z * scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator*(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator*(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar * v.x, scalar * v.y, scalar * v.z);
 }
@@ -776,13 +776,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator*(const Vec<3, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator/(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator/(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x / scalar, v.y / scalar, v.z / scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator/(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator/(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar / v.x, scalar / v.y, scalar / v.z);
 }
@@ -797,13 +797,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator/(const Vec<3, T>& v1, const
 //Binary bit operators
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator%(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator%(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x % scalar, v.y % scalar, v.z % scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator%(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator%(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar % v.x, scalar % v.y, scalar % v.z);
 }
@@ -815,13 +815,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator%(const Vec<3, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator&(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator&(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x & scalar, v.y & scalar, v.z & scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator&(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator&(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar & v.x, scalar & v.y, scalar & v.z);
 }
@@ -833,13 +833,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator&(const Vec<3, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator|(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator|(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x | scalar, v.y | scalar, v.z | scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator|(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator|(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar | v.x, scalar | v.y, scalar | v.z);
 }
@@ -851,13 +851,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator|(const Vec<3, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator^(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator^(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x ^ scalar, v.y ^ scalar, v.z ^ scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator^(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator^(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar ^ v.x, scalar ^ v.y, scalar ^ v.z);
 }
@@ -869,13 +869,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator^(const Vec<3, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator<<(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator<<(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x << scalar, v.y << scalar, v.z << scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator<<(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator<<(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar << v.x, scalar << v.y, scalar << v.z);
 }
@@ -887,13 +887,13 @@ constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator<<(const Vec<3, T>& v1, cons
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator>>(const Vec<3, T>& v, T scalar)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator>>(const Vec<3, T>& v, const T scalar)
 {
 	return Vec<3, T>(v.x >> scalar, v.y >> scalar, v.z >> scalar);
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator>>(T scalar, const Vec<3, T>& v)
+constexpr TRAP::Math::Vec<3, T> TRAP::Math::operator>>(const T scalar, const Vec<3, T>& v)
 {
 	return Vec<3, T>(scalar >> v.x, scalar >> v.y, scalar >> v.z);
 }

--- a/TRAP/src/Maths/Vec3.h
+++ b/TRAP/src/Maths/Vec3.h
@@ -58,7 +58,7 @@ namespace TRAP::Math
 		constexpr Vec(const Vec & v) = default;
 
 		//Explicit basic constructors
-		constexpr explicit Vec(T scalar);
+		explicit constexpr Vec(T scalar);
 		constexpr Vec(T x, T y, T z);
 
 		//Explicit conversions
@@ -75,11 +75,11 @@ namespace TRAP::Math
 		constexpr Vec(A x, const Vec<2, B> & yz);
 		//Explicit conversions
 		template<typename U>
-		constexpr explicit Vec(const Vec<4, U> & v);
+		explicit constexpr Vec(const Vec<4, U> & v);
 
 		//Explicit conversions
 		template<typename U>
-		constexpr explicit Vec(const Vec<3, U> & v);
+		explicit constexpr Vec(const Vec<3, U> & v);
 
 		constexpr Vec(Vec&&) = default;
 		~Vec() = default;

--- a/TRAP/src/Maths/Vec4.h
+++ b/TRAP/src/Maths/Vec4.h
@@ -58,7 +58,7 @@ namespace TRAP::Math
 		constexpr Vec(const Vec<4, T> & v) = default;
 
 		//Explicit basic constructors
-		constexpr explicit Vec(T scalar);
+		explicit constexpr Vec(T scalar);
 		constexpr Vec(T x, T y, T z, T w);
 
 		//Explicit conversions
@@ -72,7 +72,7 @@ namespace TRAP::Math
 		constexpr Vec(const Vec<2, A> & xy, B z, C w);
 		//Explicit conversions
 		template<typename A, typename B, typename C>
-		constexpr explicit Vec(A x, const Vec<2, B> & yz, C w);
+		explicit constexpr Vec(A x, const Vec<2, B> & yz, C w);
 		//Explicit conversions
 		template<typename A, typename B, typename C>
 		constexpr Vec(A x, B y, const Vec<2, C> & zw);
@@ -88,7 +88,7 @@ namespace TRAP::Math
 
 		//Explicit conversions
 		template<typename U>
-		constexpr explicit Vec(const Vec<4, U> & v);
+		explicit constexpr Vec(const Vec<4, U> & v);
 
 		constexpr Vec(Vec&&) = default;
 		~Vec() = default;

--- a/TRAP/src/Maths/Vec4.h
+++ b/TRAP/src/Maths/Vec4.h
@@ -299,7 +299,7 @@ namespace std
 
 //Explicit basic constructors
 template<typename T>
-constexpr TRAP::Math::Vec<4, T>::Vec(T scalar)
+constexpr TRAP::Math::Vec<4, T>::Vec(const T scalar)
 	: x(scalar), y(scalar), z(scalar), w(scalar)
 {}
 
@@ -313,7 +313,7 @@ constexpr TRAP::Math::Vec<4, T>::Vec(T x, T y, T z, T w)
 
 template<typename T>
 template<typename X, typename Y, typename Z, typename W>
-constexpr TRAP::Math::Vec<4, T>::Vec(X x, Y y, Z z, W w)
+constexpr TRAP::Math::Vec<4, T>::Vec(const X x, const Y y, const Z z, const W w)
 	: x(static_cast<T>(x)),
 	  y(static_cast<T>(y)),
 	  z(static_cast<T>(z)),
@@ -325,7 +325,7 @@ constexpr TRAP::Math::Vec<4, T>::Vec(X x, Y y, Z z, W w)
 
 template<typename T>
 template<typename A, typename B, typename C>
-constexpr TRAP::Math::Vec<4, T>::Vec(const Vec<2, A>& xy, B z, C w)
+constexpr TRAP::Math::Vec<4, T>::Vec(const Vec<2, A>& xy, const B z, const C w)
 	: x(static_cast<T>(xy.x)),
 	  y(static_cast<T>(xy.y)),
 	  z(static_cast<T>(z)),
@@ -334,7 +334,7 @@ constexpr TRAP::Math::Vec<4, T>::Vec(const Vec<2, A>& xy, B z, C w)
 
 template<typename T>
 template<typename A, typename B, typename C>
-constexpr TRAP::Math::Vec<4, T>::Vec(A x, const Vec<2, B>& yz, C w)
+constexpr TRAP::Math::Vec<4, T>::Vec(const A x, const Vec<2, B>& yz, const C w)
 	: x(static_cast<T>(x)),
 	  y(static_cast<T>(yz.x)),
 	  z(static_cast<T>(yz.y)),
@@ -343,7 +343,7 @@ constexpr TRAP::Math::Vec<4, T>::Vec(A x, const Vec<2, B>& yz, C w)
 
 template<typename T>
 template<typename A, typename B, typename C>
-constexpr TRAP::Math::Vec<4, T>::Vec(A x, B y, const Vec<2, C>& zw)
+constexpr TRAP::Math::Vec<4, T>::Vec(const A x, const B y, const Vec<2, C>& zw)
 	: x(static_cast<T>(x)),
 	  y(static_cast<T>(y)),
 	  z(static_cast<T>(zw.x)),
@@ -352,7 +352,7 @@ constexpr TRAP::Math::Vec<4, T>::Vec(A x, B y, const Vec<2, C>& zw)
 
 template<typename T>
 template<typename A, typename B>
-constexpr TRAP::Math::Vec<4, T>::Vec(const Vec<3, A>& xyz, B w)
+constexpr TRAP::Math::Vec<4, T>::Vec(const Vec<3, A>& xyz, const B w)
 	: x(static_cast<T>(xyz.x)),
 	  y(static_cast<T>(xyz.y)),
 	  z(static_cast<T>(xyz.z)),
@@ -361,7 +361,7 @@ constexpr TRAP::Math::Vec<4, T>::Vec(const Vec<3, A>& xyz, B w)
 
 template<typename T>
 template<typename A, typename B>
-constexpr TRAP::Math::Vec<4, T>::Vec(A x, const Vec<3, B>& yzw)
+constexpr TRAP::Math::Vec<4, T>::Vec(const A x, const Vec<3, B>& yzw)
 	: x(static_cast<T>(x)),
 	  y(static_cast<T>(yzw.x)),
 	  z(static_cast<T>(yzw.y)),
@@ -397,7 +397,7 @@ constexpr int TRAP::Math::Vec<4, T>::Length()
 //-------------------------------------------------------------------------------------------------------------------//
 //Component accesses
 template<typename T>
-constexpr T& TRAP::Math::Vec<4, T>::operator[](int i)
+constexpr T& TRAP::Math::Vec<4, T>::operator[](const int i)
 {
 	TRAP_ASSERT(i >= 0 && i < this->Length());
 
@@ -419,7 +419,7 @@ constexpr T& TRAP::Math::Vec<4, T>::operator[](int i)
 }
 
 template<typename T>
-constexpr const T& TRAP::Math::Vec<4, T>::operator[](int i) const
+constexpr const T& TRAP::Math::Vec<4, T>::operator[](const int i) const
 {
 	TRAP_ASSERT(i >= 0 && i < this->Length());
 
@@ -457,7 +457,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator=(const Vec<4, U
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator+=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator+=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x + scalar, this->y + scalar, this->z + scalar, this->w + scalar));
 }
@@ -471,7 +471,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator+=(const Vec<4, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator-=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator-=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x - scalar, this->y - scalar, this->z - scalar, this->w - scalar));
 }
@@ -485,7 +485,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator-=(const Vec<4, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator*=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator*=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x * scalar, this->y * scalar, this->z * scalar, this->w * scalar));
 }
@@ -499,7 +499,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator*=(const Vec<4, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator/=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator/=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x / scalar, this->y / scalar, this->z / scalar, this->w / scalar));
 }
@@ -537,7 +537,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator--()
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::Vec<4, T>::operator++(int)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::Vec<4, T>::operator++(const int)
 {
 	Vec<4, T> Result(*this);
 	++*this;
@@ -546,7 +546,7 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::Vec<4, T>::operator++(int)
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::Vec<4, T>::operator--(int)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::Vec<4, T>::operator--(const int)
 {
 	Vec<4, T> Result(*this);
 	--*this;
@@ -559,7 +559,7 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::Vec<4, T>::operator--(int)
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator%=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator%=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x % scalar, this->y % scalar, this->z % scalar, this->w % scalar));
 }
@@ -573,7 +573,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator%=(const Vec<4, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator&=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator&=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x & scalar, this->y & scalar, this->z & scalar, this->w & scalar));
 }
@@ -587,7 +587,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator&=(const Vec<4, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator|=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator|=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x | scalar, this->y | scalar, this->z | scalar, this->w | scalar));
 }
@@ -601,7 +601,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator|=(const Vec<4, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator^=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator^=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x ^ scalar, this->y ^ scalar, this->z ^ scalar, this->w ^ scalar));
 }
@@ -615,7 +615,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator^=(const Vec<4, 
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator<<=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator<<=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x << scalar, this->y << scalar, this->z << scalar, this->w << scalar));
 }
@@ -629,7 +629,7 @@ constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator<<=(const Vec<4,
 
 template<typename T>
 template<typename U>
-constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator>>=(U scalar)
+constexpr TRAP::Math::Vec<4, T>& TRAP::Math::Vec<4, T>::operator>>=(const U scalar)
 {
 	return (*this = Vec<4, T>(this->x >> scalar, this->y >> scalar, this->z >> scalar, this->w >> scalar));
 }
@@ -707,7 +707,7 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator+(const Vec<4, T>& v, const 
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator+(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator+(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(v) += scalar;
 }
@@ -725,7 +725,7 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator-(const Vec<4, T>& v, const 
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator-(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator-(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(scalar) -= v;
 }
@@ -743,7 +743,7 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator*(const Vec<4, T>& v, const 
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator*(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator*(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(v) *= scalar;
 }
@@ -761,7 +761,7 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator/(const Vec<4, T>& v, const 
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator/(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator/(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(scalar) /= v;
 }
@@ -777,13 +777,13 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator/(const Vec<4, T>& v1, const
 //Binary bit operators
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator%(const Vec<4, T>& v, T scalar)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator%(const Vec<4, T>& v, const T scalar)
 {
 	return Vec<4, T>(v) %= scalar;
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator%(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator%(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(scalar) %= v;
 }
@@ -795,13 +795,13 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator%(const Vec<4, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator&(const Vec<4, T>& v, T scalar)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator&(const Vec<4, T>& v, const T scalar)
 {
 	return Vec<4, T>(v) &= scalar;
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator&(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator&(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(scalar) &= v;
 }
@@ -813,13 +813,13 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator&(const Vec<4, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator|(const Vec<4, T>& v, T scalar)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator|(const Vec<4, T>& v, const T scalar)
 {
 	return Vec<4, T>(v) |= scalar;
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator|(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator|(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(scalar) |= v;
 }
@@ -831,13 +831,13 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator|(const Vec<4, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator^(const Vec<4, T>& v, T scalar)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator^(const Vec<4, T>& v, const T scalar)
 {
 	return Vec<4, T>(v) ^= scalar;
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator^(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator^(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(scalar) ^= v;
 }
@@ -849,13 +849,13 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator^(const Vec<4, T>& v1, const
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator<<(const Vec<4, T>& v, T scalar)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator<<(const Vec<4, T>& v, const T scalar)
 {
 	return Vec<4, T>(v) <<= scalar;
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator<<(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator<<(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(scalar) <<= v;
 }
@@ -867,13 +867,13 @@ constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator<<(const Vec<4, T>& v1, cons
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator>>(const Vec<4, T>& v, T scalar)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator>>(const Vec<4, T>& v, const T scalar)
 {
 	return Vec<4, T>(v) >>= scalar;
 }
 
 template<typename T>
-constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator>>(T scalar, const Vec<4, T>& v)
+constexpr TRAP::Math::Vec<4, T> TRAP::Math::operator>>(const T scalar, const Vec<4, T>& v)
 {
 	return Vec<4, T>(scalar) >>= v;
 }

--- a/TRAP/src/Network/FTP/FTP.cpp
+++ b/TRAP/src/Network/FTP/FTP.cpp
@@ -41,7 +41,7 @@ namespace TRAP::Network
 		DataChannel(const DataChannel&) = delete;
 		DataChannel& operator=(const DataChannel&) = delete;
 		DataChannel(DataChannel&&) = default;
-		DataChannel& operator=(DataChannel&&) = default;
+		DataChannel& operator=(DataChannel&&) = delete;
 		~DataChannel() = default;
 
 		explicit DataChannel(FTP& owner);
@@ -135,7 +135,7 @@ const std::vector<std::filesystem::path>& TRAP::Network::FTP::ListingResponse::G
 
 TRAP::Network::FTP::~FTP()
 {
-	auto response = Disconnect();
+	const auto response = Disconnect();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -174,7 +174,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Login(const std::string& name, 
 TRAP::Network::FTP::Response TRAP::Network::FTP::Disconnect()
 {
 	//Send the exit command
-	Response response = SendCommand("QUIT");
+	const Response response = SendCommand("QUIT");
 	if (response.IsOK())
 		m_commandSocket.Disconnect();
 
@@ -295,7 +295,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Download(const std::filesystem:
 				return Response(Response::Status::InvalidFile);
 
 			//Create the file and truncate it if necessary
-			std::filesystem::path filePath = path / *filename;
+			const std::filesystem::path filePath = path / *filename;
 			std::ofstream file(filePath, std::ios::binary | std::ios::trunc);
 			if (!file.is_open() || !file.good())
 			{
@@ -325,7 +325,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Download(const std::filesystem:
 
 TRAP::Network::FTP::Response TRAP::Network::FTP::Upload(const std::filesystem::path& localFile,
                                                         const std::filesystem::path& remotePath,
-														TransferMode mode, bool append)
+														const TransferMode mode, const bool append)
 {
 	if(!FileSystem::FileOrFolderExists(localFile))
 		return Response(Response::Status::InvalidFile);

--- a/TRAP/src/Network/FTP/FTP.cpp
+++ b/TRAP/src/Network/FTP/FTP.cpp
@@ -31,7 +31,7 @@ Modified by: Jan "GamesTrap" Schuerkamp
 
 #include "Network/IP/IPv4Address.h"
 #include "Utils/Time/TimeStep.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 namespace TRAP::Network
 {
@@ -283,7 +283,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Download(const std::filesystem:
 		if(response.IsOK())
 		{
 			//Extract the filename from the file path
-			const auto filename = TRAP::FS::GetFileNameWithEnding(remoteFile);
+			const auto filename = TRAP::FileSystem::GetFileNameWithEnding(remoteFile);
 			if(!filename)
 			{
 				TP_ERROR(Log::NetworkFTPPrefix, "Couldn't get file name from file path: ", remoteFile.generic_u8string(), "!");
@@ -291,7 +291,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Download(const std::filesystem:
 			}
 
 			//Create missing directories if any
-			if(!TRAP::FS::FileOrFolderExists(path) && !TRAP::FS::CreateFolder(path))
+			if(!TRAP::FileSystem::FileOrFolderExists(path) && !TRAP::FileSystem::CreateFolder(path))
 				return Response(Response::Status::InvalidFile);
 
 			//Create the file and truncate it if necessary
@@ -327,7 +327,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Upload(const std::filesystem::p
                                                         const std::filesystem::path& remotePath,
 														TransferMode mode, bool append)
 {
-	if(!FS::FileOrFolderExists(localFile))
+	if(!FileSystem::FileOrFolderExists(localFile))
 		return Response(Response::Status::InvalidFile);
 
 	//Get the contents of the file to send
@@ -339,7 +339,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Upload(const std::filesystem::p
 	}
 
 	//Extract the filename from the file path
-	const auto filename = TRAP::FS::GetFileNameWithEnding(localFile);
+	const auto filename = TRAP::FileSystem::GetFileNameWithEnding(localFile);
 	if(!filename)
 	{
 		TP_ERROR(Log::NetworkFTPPrefix, "Couldn't get file name from file path: ", localFile.generic_u8string(), "!");

--- a/TRAP/src/Network/FTP/FTP.cpp
+++ b/TRAP/src/Network/FTP/FTP.cpp
@@ -206,7 +206,7 @@ TRAP::Network::FTP::ListingResponse TRAP::Network::FTP::GetDirectoryListing(cons
 	if(response.IsOK())
 	{
 		//Tell the server to send us the listing
-		response = SendCommand("NLST", directory.generic_u8string());
+		response = SendCommand("NLST", directory.u8string());
 		if(response.IsOK())
 		{
 			//Receive the listing
@@ -224,7 +224,7 @@ TRAP::Network::FTP::ListingResponse TRAP::Network::FTP::GetDirectoryListing(cons
 
 TRAP::Network::FTP::Response TRAP::Network::FTP::ChangeDirectory(const std::filesystem::path& directory)
 {
-	return SendCommand("CWD", directory.generic_u8string());
+	return SendCommand("CWD", directory.u8string());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -238,14 +238,14 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::ParentDirectory()
 
 TRAP::Network::FTP::Response TRAP::Network::FTP::CreateDirectory(const std::filesystem::path& name)
 {
-	return SendCommand("MKD", name.generic_u8string());
+	return SendCommand("MKD", name.u8string());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 TRAP::Network::FTP::Response TRAP::Network::FTP::DeleteDirectory(const std::filesystem::path& name)
 {
-	return SendCommand("RMD", name.generic_u8string());
+	return SendCommand("RMD", name.u8string());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -253,9 +253,9 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::DeleteDirectory(const std::file
 TRAP::Network::FTP::Response TRAP::Network::FTP::RenameFile(const std::filesystem::path& file,
    															const std::filesystem::path& newName)
 {
-	Response response = SendCommand("RNFR", file.generic_u8string());
+	Response response = SendCommand("RNFR", file.u8string());
 	if (response.IsOK())
-		response = SendCommand("RNTO", newName.generic_u8string());
+		response = SendCommand("RNTO", newName.u8string());
 
 	return response;
 }
@@ -264,7 +264,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::RenameFile(const std::filesyste
 
 TRAP::Network::FTP::Response TRAP::Network::FTP::DeleteFile(const std::filesystem::path& name)
 {
-	return SendCommand("DELE", name.generic_u8string());
+	return SendCommand("DELE", name.u8string());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -279,14 +279,14 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Download(const std::filesystem:
 	if(response.IsOK())
 	{
 		//Tell the server to start the transfer
-		response = SendCommand("RETR", remoteFile.generic_u8string());
+		response = SendCommand("RETR", remoteFile.u8string());
 		if(response.IsOK())
 		{
 			//Extract the filename from the file path
 			const auto filename = TRAP::FileSystem::GetFileNameWithEnding(remoteFile);
 			if(!filename)
 			{
-				TP_ERROR(Log::NetworkFTPPrefix, "Couldn't get file name from file path: ", remoteFile.generic_u8string(), "!");
+				TP_ERROR(Log::NetworkFTPPrefix, "Couldn't get file name from file path: ", remoteFile.u8string(), "!");
 				return Response(Response::Status::InvalidFile);
 			}
 
@@ -299,7 +299,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Download(const std::filesystem:
 			std::ofstream file(filePath, std::ios::binary | std::ios::trunc);
 			if (!file.is_open() || !file.good())
 			{
-				TP_ERROR(Log::NetworkFTPPrefix, "Couldn't open file path: ", filePath.generic_u8string(), "!");
+				TP_ERROR(Log::NetworkFTPPrefix, "Couldn't open file path: ", filePath.u8string(), "!");
 				return Response(Response::Status::InvalidFile);
 			}
 
@@ -334,7 +334,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Upload(const std::filesystem::p
 	std::ifstream file(localFile, std::ios::binary);
 	if (!file.is_open() || !file.good())
 	{
-		TP_ERROR(Log::NetworkFTPPrefix, "Couldn't open file path: ", localFile.generic_u8string(), "!");
+		TP_ERROR(Log::NetworkFTPPrefix, "Couldn't open file path: ", localFile.u8string(), "!");
 		return Response(Response::Status::InvalidFile);
 	}
 
@@ -342,7 +342,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Upload(const std::filesystem::p
 	const auto filename = TRAP::FileSystem::GetFileNameWithEnding(localFile);
 	if(!filename)
 	{
-		TP_ERROR(Log::NetworkFTPPrefix, "Couldn't get file name from file path: ", localFile.generic_u8string(), "!");
+		TP_ERROR(Log::NetworkFTPPrefix, "Couldn't get file name from file path: ", localFile.u8string(), "!");
 		return Response(Response::Status::InvalidFile);
 	}
 
@@ -352,7 +352,7 @@ TRAP::Network::FTP::Response TRAP::Network::FTP::Upload(const std::filesystem::p
 	if (response.IsOK())
 	{
 		//Tell the server to start the transfer
-		response = SendCommand(append ? "APPE" : "STOR", (remotePath / *filename).generic_u8string());
+		response = SendCommand(append ? "APPE" : "STOR", (remotePath / *filename).u8string());
 		if (response.IsOK())
 		{
 			//Send the file data

--- a/TRAP/src/Network/FTP/FTP.cpp
+++ b/TRAP/src/Network/FTP/FTP.cpp
@@ -81,7 +81,7 @@ TRAP::Network::FTP::Response::Status TRAP::Network::FTP::Response::GetStatus() c
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Network::FTP::Response::GetMessage() const
+std::string TRAP::Network::FTP::Response::GetMessage() const
 {
 	return m_message;
 }

--- a/TRAP/src/Network/FTP/FTP.h
+++ b/TRAP/src/Network/FTP/FTP.h
@@ -150,7 +150,7 @@ namespace TRAP::Network
 			/// Get the full message contained in the response.
 			/// </summary>
 			/// <returns>The response message.</returns>
-			const std::string& GetMessage() const;
+			std::string GetMessage() const;
 
 		private:
 			Status m_status; //Status code returned from the server

--- a/TRAP/src/Network/HTTP/HTTP.cpp
+++ b/TRAP/src/Network/HTTP/HTTP.cpp
@@ -31,10 +31,10 @@ Modified by: Jan "GamesTrap" Schuerkamp
 
 #include "Utils/String/String.h"
 
-TRAP::Network::HTTP::Request::Request(const std::string& uri, const Method method, std::string body)
+TRAP::Network::HTTP::Request::Request(const std::string uri, const Method method, std::string body)
 	: m_method(method), m_majorVersion(1), m_minorVersion(0), m_body(std::move(body))
 {
-	SetURI(uri);
+	SetURI(std::move(uri));
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -147,14 +147,13 @@ TRAP::Network::HTTP::Response::Response()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Network::HTTP::Response::GetField(const std::string& field) const
+std::string TRAP::Network::HTTP::Response::GetField(const std::string& field) const
 {
 	const FieldTable::const_iterator it = m_fields.find(Utils::String::ToLower(field));
 	if (it != m_fields.end())
 		return it->second;
 
-	static const std::string empty;
-	return empty;
+	return "";
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -180,7 +179,7 @@ uint32_t TRAP::Network::HTTP::Response::GetMinorHTTPVersion() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Network::HTTP::Response::GetBody() const
+std::string TRAP::Network::HTTP::Response::GetBody() const
 {
 	return m_body;
 }
@@ -294,10 +293,10 @@ TRAP::Network::HTTP::HTTP()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Network::HTTP::HTTP(const std::string& host, const uint16_t port)
+TRAP::Network::HTTP::HTTP(const std::string host, const uint16_t port)
 	: m_port(0)
 {
-	SetHost(host, port);
+	SetHost(std::move(host), port);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Network/HTTP/HTTP.cpp
+++ b/TRAP/src/Network/HTTP/HTTP.cpp
@@ -247,7 +247,7 @@ void TRAP::Network::HTTP::Response::Parse(const std::string& data)
 
 			//Copy the actual content data
 			std::istreambuf_iterator<char> it(in);
-			std::istreambuf_iterator<char> itEnd;
+			const std::istreambuf_iterator<char> itEnd;
 			for (std::size_t i = 0; ((i < length) && (it != itEnd)); i++)
 				m_body.push_back(*it++);
 		}
@@ -364,7 +364,7 @@ TRAP::Network::HTTP::Response TRAP::Network::HTTP::SendRequest(const Request& re
 	if(m_connectionIPv6.Connect(m_hostIPv6, m_port, timeout) == Socket::Status::Done)
 	{
 		//Convert the request to string and send it through the connected socket
-		std::string requestStr = toSend.Prepare();
+		const std::string requestStr = toSend.Prepare();
 
 		if (!requestStr.empty())
 		{
@@ -389,7 +389,7 @@ TRAP::Network::HTTP::Response TRAP::Network::HTTP::SendRequest(const Request& re
 	else if(m_connection.Connect(m_host, m_port, timeout) == Socket::Status::Done)
 	{
 		//Convert the request to string and send it through the connected socket
-		std::string requestStr = toSend.Prepare();
+		const std::string requestStr = toSend.Prepare();
 
 		if(!requestStr.empty())
 		{

--- a/TRAP/src/Network/HTTP/HTTP.h
+++ b/TRAP/src/Network/HTTP/HTTP.h
@@ -72,7 +72,7 @@ namespace TRAP::Network
 			/// <param name="uri">Target URI.</param>
 			/// <param name="method">Method to use for the request.</param>
 			/// <param name="body">Content of the request's body.</param>
-			explicit Request(const std::string& uri = "/", Method method = Method::GET, std::string body = "");
+			explicit Request(std::string uri = "/", Method method = Method::GET, std::string body = "");
 
 			/// <summary>
 			/// Set the value of a field.
@@ -217,7 +217,7 @@ namespace TRAP::Network
 			/// </summary>
 			/// <param name="field">Name of the field to get.</param>
 			/// <returns>Value of the field, or empty string if not found.</returns>
-			const std::string& GetField(const std::string& field) const;
+			std::string GetField(const std::string& field) const;
 
 			/// <summary>
 			/// Get the response status code.
@@ -252,7 +252,7 @@ namespace TRAP::Network
 			/// - an error message (in case of an error)
 			/// </summary>
 			/// <returns>The response body.</returns>
-			const std::string& GetBody() const;
+			std::string GetBody() const;
 
 		private:
 			friend class HTTP;
@@ -301,7 +301,7 @@ namespace TRAP::Network
 		/// </summary>
 		/// <param name="host">Web server to connect to.</param>
 		/// <param name="port">Port to use for connection.</param>
-		explicit HTTP(const std::string& host, uint16_t port = 0);
+		explicit HTTP(std::string host, uint16_t port = 0);
 
 		/// <summary>
 		/// Move constructor.

--- a/TRAP/src/Network/IP/IPv4Address.cpp
+++ b/TRAP/src/Network/IP/IPv4Address.cpp
@@ -49,14 +49,6 @@ TRAP::Network::IPv4Address::IPv4Address(const std::string_view address)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Network::IPv4Address::IPv4Address(const char* address)
-	: m_address(0), m_valid(false)
-{
-	Resolve(address);
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Network::IPv4Address::IPv4Address(const uint8_t byte0, const uint8_t byte1, const uint8_t byte2,
                                         const uint8_t byte3)
 	: m_address(static_cast<uint32_t>((byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3)), m_valid(true)

--- a/TRAP/src/Network/IP/IPv4Address.cpp
+++ b/TRAP/src/Network/IP/IPv4Address.cpp
@@ -198,7 +198,6 @@ void TRAP::Network::IPv4Address::Resolve(const std::string_view address)
 		{
 			//Not a valid address, try to convert it as a host name
 			addrinfo hints{};
-			memset(&hints, 0, sizeof(hints));
 			hints.ai_family = AF_INET;
 			addrinfo* result = nullptr;
 			if(getaddrinfo(address.data(), nullptr, &hints, &result) == 0)

--- a/TRAP/src/Network/IP/IPv4Address.cpp
+++ b/TRAP/src/Network/IP/IPv4Address.cpp
@@ -109,7 +109,7 @@ TRAP::Network::IPv4Address TRAP::Network::IPv4Address::GetLocalAddress()
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 		TRAP::Utils::Memory::SwapBytes(loopback);
 
-	sockaddr_in address = INTERNAL::Network::SocketImpl::CreateAddress(loopback, 9);
+	const sockaddr_in address = INTERNAL::Network::SocketImpl::CreateAddress(loopback, 9);
 	sockaddr convertedAddress = Utils::BitCast<sockaddr_in, sockaddr>(address);
 	if (connect(sock, &convertedAddress, sizeof(address)) == -1)
 	{

--- a/TRAP/src/Network/IP/IPv4Address.cpp
+++ b/TRAP/src/Network/IP/IPv4Address.cpp
@@ -137,8 +137,7 @@ TRAP::Network::IPv4Address TRAP::Network::IPv4Address::GetLocalAddress()
 	INTERNAL::Network::SocketImpl::Close(sock);
 
 	//Finally build the IP address
-	address = Utils::BitCast<sockaddr, sockaddr_in>(convertedAddress);
-	uint32_t addr = address.sin_addr.s_addr;
+	uint32_t addr = Utils::BitCast<sockaddr, sockaddr_in>(convertedAddress).sin_addr.s_addr;
 
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 		TRAP::Utils::Memory::SwapBytes(addr);

--- a/TRAP/src/Network/IP/IPv4Address.cpp
+++ b/TRAP/src/Network/IP/IPv4Address.cpp
@@ -198,7 +198,7 @@ void TRAP::Network::IPv4Address::Resolve(const std::string_view address)
 		{
 			//Not a valid address, try to convert it as a host name
 			addrinfo hints{};
-			std::memset(&hints, 0, sizeof(hints));
+			memset(&hints, 0, sizeof(hints));
 			hints.ai_family = AF_INET;
 			addrinfo* result = nullptr;
 			if(getaddrinfo(address.data(), nullptr, &hints, &result) == 0)

--- a/TRAP/src/Network/IP/IPv4Address.h
+++ b/TRAP/src/Network/IP/IPv4Address.h
@@ -58,18 +58,6 @@ namespace TRAP::Network
 		explicit IPv4Address(std::string_view address);
 
 		/// <summary>
-		/// Construct the address from a string.
-		///
-		/// Here address can either be a decimal address (ex: "192.168.1.180") or a
-		/// network name (ex: "localhost").
-		/// This is equivalent to the constructor taking a std::string_view
-		/// parameter, it is defined for convenience so that the
-		/// implicit conversion from literal strings to IPv4Address work.
-		/// </summary>
-		/// <param name="address">IPv4 address or network name.</param>
-		explicit IPv4Address(const char* address);
-
-		/// <summary>
 		/// Construct the address from 4 bytes.
 		///
 		/// Calling IPv4Address(a, b, c, d) is equivalent to calling

--- a/TRAP/src/Network/IP/IPv6Address.cpp
+++ b/TRAP/src/Network/IP/IPv6Address.cpp
@@ -21,10 +21,10 @@ const TRAP::Network::IPv6Address TRAP::Network::IPv6Address::LocalHost(std::arra
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Network::IPv6Address::IPv6Address(const std::string& address)
+TRAP::Network::IPv6Address::IPv6Address(const std::string address)
 	: m_address(), m_valid(false)
 {
-	Resolve(address);
+	Resolve(std::move(address));
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Network/IP/IPv6Address.cpp
+++ b/TRAP/src/Network/IP/IPv6Address.cpp
@@ -48,9 +48,9 @@ std::string TRAP::Network::IPv6Address::ToString() const
 {
 	in6_addr address{};
 #ifdef TRAP_PLATFORM_WINDOWS
-	memcpy(address.u.Byte, m_address.data(), m_address.size());
+	std::copy(m_address.begin(), m_address.end(), address.u.Byte);
 #else
-	memcpy(address.s6_addr, m_address.data(), m_address.size());
+	std::copy(m_address.begin(), m_address.end(), address.s6_addr);
 #endif
 
 	//8 * 4 = 8 Blocks 4 Values each | 7 = 7 times ':'
@@ -82,9 +82,9 @@ TRAP::Network::IPv6Address TRAP::Network::IPv6Address::GetLocalAddress()
 	//Connect the socket to localhost on any port
 	std::array<uint8_t, 16> loopback{};
 #ifdef TRAP_PLATFORM_WINDOWS
-	memcpy(loopback.data(), in6addr_loopback.u.Byte, loopback.size());
+	std::copy_n(in6addr_loopback.u.Byte, loopback.size(), loopback.data());
 #else
-	memcpy(loopback.data(), in6addr_loopback.s6_addr, loopback.size());
+	std::copy_n(in6addr_loopback.s6_addr, loopback.size(), loopback.data());
 #endif
 	sockaddr_in6 address = INTERNAL::Network::SocketImpl::CreateAddress(loopback, 9);
 	if(connect(sock, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
@@ -107,9 +107,9 @@ TRAP::Network::IPv6Address TRAP::Network::IPv6Address::GetLocalAddress()
 	//Finally build the IP address
 	std::array<uint8_t, 16> addr{};
 #ifdef TRAP_PLATFORM_WINDOWS
-	memcpy(addr.data(), address.sin6_addr.u.Byte, addr.size());
+	std::copy_n(address.sin6_addr.u.Byte, addr.size(), addr.data());
 #else
-	memcpy(addr.data(), address.sin6_addr.s6_addr, addr.size());
+	std::copy_n(address.sin6_addr.s6_addr, addr.size(), addr.data());
 #endif
 	return IPv6Address(addr);
 }
@@ -145,9 +145,9 @@ void TRAP::Network::IPv6Address::Resolve(const std::string& address)
 		address == "0000:0000:0000:0000:0000:0000:0000:0000")
 	{
 #ifdef TRAP_PLATFORM_WINDOWS
-		memcpy(m_address.data(), in6addr_any.u.Byte, m_address.size());
+		std::copy_n(in6addr_any.u.Byte, m_address.size(), m_address.data());
 #else
-		memcpy(m_address.data(), in6addr_any.s6_addr, m_address.size());
+		std::copy_n(in6addr_any.s6_addr, m_address.size(), m_address.data());
 #endif
 		m_valid = true;
 	}
@@ -171,7 +171,7 @@ void TRAP::Network::IPv6Address::Resolve(const std::string& address)
 			{
 				if(result)
 				{
-					memcpy(ip.data(), &reinterpret_cast<sockaddr_in6*>(result->ai_addr)->sin6_addr, ip.size());
+					std::copy_n(reinterpret_cast<sockaddr_in6*>(result->ai_addr)->sin6_addr.s6_addr, ip.size(), ip.data());
 					freeaddrinfo(result);
 					m_address = ip;
 					m_valid = true;

--- a/TRAP/src/Network/IP/IPv6Address.cpp
+++ b/TRAP/src/Network/IP/IPv6Address.cpp
@@ -164,7 +164,6 @@ void TRAP::Network::IPv6Address::Resolve(const std::string& address)
 		{
 			//Not a valid address, try to convert it as a host name
 			addrinfo hints{};
-			memset(&hints, 0, sizeof(hints));
 			hints.ai_family = AF_INET6;
 			addrinfo* result = nullptr;
 			if(getaddrinfo(lowerAddress.c_str(), nullptr, &hints, &result) == 0)

--- a/TRAP/src/Network/IP/IPv6Address.cpp
+++ b/TRAP/src/Network/IP/IPv6Address.cpp
@@ -171,7 +171,7 @@ void TRAP::Network::IPv6Address::Resolve(const std::string& address)
 			{
 				if(result)
 				{
-					std::memcpy(ip.data(), &reinterpret_cast<sockaddr_in6*>(result->ai_addr)->sin6_addr, 16);
+					memcpy(ip.data(), &reinterpret_cast<sockaddr_in6*>(result->ai_addr)->sin6_addr, ip.size());
 					freeaddrinfo(result);
 					m_address = ip;
 					m_valid = true;

--- a/TRAP/src/Network/IP/IPv6Address.cpp
+++ b/TRAP/src/Network/IP/IPv6Address.cpp
@@ -48,9 +48,9 @@ std::string TRAP::Network::IPv6Address::ToString() const
 {
 	in6_addr address{};
 #ifdef TRAP_PLATFORM_WINDOWS
-	std::memcpy(address.u.Byte, m_address.data(), m_address.size());
+	memcpy(address.u.Byte, m_address.data(), m_address.size());
 #else
-	std::memcpy(address.s6_addr, m_address.data(), m_address.size());
+	memcpy(address.s6_addr, m_address.data(), m_address.size());
 #endif
 
 	//8 * 4 = 8 Blocks 4 Values each | 7 = 7 times ':'
@@ -82,9 +82,9 @@ TRAP::Network::IPv6Address TRAP::Network::IPv6Address::GetLocalAddress()
 	//Connect the socket to localhost on any port
 	std::array<uint8_t, 16> loopback{};
 #ifdef TRAP_PLATFORM_WINDOWS
-	std::memcpy(loopback.data(), in6addr_loopback.u.Byte, loopback.size());
+	memcpy(loopback.data(), in6addr_loopback.u.Byte, loopback.size());
 #else
-	std::memcpy(loopback.data(), in6addr_loopback.s6_addr, loopback.size());
+	memcpy(loopback.data(), in6addr_loopback.s6_addr, loopback.size());
 #endif
 	sockaddr_in6 address = INTERNAL::Network::SocketImpl::CreateAddress(loopback, 9);
 	if(connect(sock, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
@@ -107,9 +107,9 @@ TRAP::Network::IPv6Address TRAP::Network::IPv6Address::GetLocalAddress()
 	//Finally build the IP address
 	std::array<uint8_t, 16> addr{};
 #ifdef TRAP_PLATFORM_WINDOWS
-	std::memcpy(addr.data(), address.sin6_addr.u.Byte, addr.size());
+	memcpy(addr.data(), address.sin6_addr.u.Byte, addr.size());
 #else
-	std::memcpy(addr.data(), address.sin6_addr.s6_addr, addr.size());
+	memcpy(addr.data(), address.sin6_addr.s6_addr, addr.size());
 #endif
 	return IPv6Address(addr);
 }
@@ -145,9 +145,9 @@ void TRAP::Network::IPv6Address::Resolve(const std::string& address)
 		address == "0000:0000:0000:0000:0000:0000:0000:0000")
 	{
 #ifdef TRAP_PLATFORM_WINDOWS
-		std::memcpy(m_address.data(), in6addr_any.u.Byte, m_address.size());
+		memcpy(m_address.data(), in6addr_any.u.Byte, m_address.size());
 #else
-		std::memcpy(m_address.data(), in6addr_any.s6_addr, m_address.size());
+		memcpy(m_address.data(), in6addr_any.s6_addr, m_address.size());
 #endif
 		m_valid = true;
 	}

--- a/TRAP/src/Network/IP/IPv6Address.cpp
+++ b/TRAP/src/Network/IP/IPv6Address.cpp
@@ -164,7 +164,7 @@ void TRAP::Network::IPv6Address::Resolve(const std::string& address)
 		{
 			//Not a valid address, try to convert it as a host name
 			addrinfo hints{};
-			std::memset(&hints, 0, sizeof(hints));
+			memset(&hints, 0, sizeof(hints));
 			hints.ai_family = AF_INET6;
 			addrinfo* result = nullptr;
 			if(getaddrinfo(lowerAddress.c_str(), nullptr, &hints, &result) == 0)

--- a/TRAP/src/Network/IP/IPv6Address.h
+++ b/TRAP/src/Network/IP/IPv6Address.h
@@ -28,7 +28,7 @@ namespace TRAP::Network
 		/// network name (ex: "localhost").
 		/// </summary>
 		/// <param name="address">IPv6 address or network name.</param>
-		explicit IPv6Address(const std::string& address);
+		explicit IPv6Address(std::string address);
 
 		/// <summary>
 		/// Construct the address from a string.

--- a/TRAP/src/Network/Packet.cpp
+++ b/TRAP/src/Network/Packet.cpp
@@ -110,7 +110,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(int8_t& data)
 {
 	if(CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<const int8_t*>(&m_data[m_readPos]);
+		data = *reinterpret_cast<int8_t*>(&m_data[m_readPos]);
 		m_readPos += sizeof(data);
 	}
 
@@ -123,7 +123,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(uint8_t& data)
 {
 	if(CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<const uint8_t*>(&m_data[m_readPos]);
+		data = *reinterpret_cast<uint8_t*>(&m_data[m_readPos]);
 		m_readPos += sizeof(data);
 	}
 

--- a/TRAP/src/Network/Packet.cpp
+++ b/TRAP/src/Network/Packet.cpp
@@ -46,7 +46,7 @@ void TRAP::Network::Packet::Append(const void* data, const std::size_t sizeInByt
 
 	const std::size_t start = m_data.size();
 	m_data.resize(start + sizeInBytes);
-	memcpy(&m_data[start], data, sizeInBytes);
+	std::copy_n(static_cast<const uint8_t*>(data), sizeInBytes, &m_data[start]);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -270,7 +270,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(char* data)
 	if((length > 0) && CheckSize(length))
 	{
 		//Then extract characters
-		memcpy(data, &m_data[m_readPos], length);
+		std::copy_n(&m_data[m_readPos], length, data);
 		data[length] = '\0';
 
 		//Update reading position

--- a/TRAP/src/Network/Packet.cpp
+++ b/TRAP/src/Network/Packet.cpp
@@ -110,7 +110,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(int8_t& data)
 {
 	if(CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<int8_t*>(&m_data[m_readPos]);
+		data = static_cast<int8_t>(m_data[m_readPos]);
 		m_readPos += sizeof(data);
 	}
 
@@ -123,7 +123,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(uint8_t& data)
 {
 	if(CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<uint8_t*>(&m_data[m_readPos]);
+		data = static_cast<uint8_t>(m_data[m_readPos]);
 		m_readPos += sizeof(data);
 	}
 
@@ -136,7 +136,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(int16_t& data)
 {
 	if(CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<int16_t*>(&m_data[m_readPos]);
+		std::copy_n(&m_data[m_readPos], sizeof(data), &data);
 
 		if(TRAP::Utils::GetEndian() == TRAP::Utils::Endian::Little) //Need to convert to little endian
 			TRAP::Utils::Memory::SwapBytes(data);
@@ -153,7 +153,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(uint16_t& data)
 {
 	if (CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<uint16_t*>(&m_data[m_readPos]);
+		std::copy_n(&m_data[m_readPos], sizeof(data), &data);
 
 		if(TRAP::Utils::GetEndian() == TRAP::Utils::Endian::Little) //Need to convert to little endian
 			TRAP::Utils::Memory::SwapBytes(data);
@@ -170,7 +170,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(int32_t& data)
 {
 	if (CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<int32_t*>(&m_data[m_readPos]);
+		std::copy_n(&m_data[m_readPos], sizeof(data), &data);
 
 		if(TRAP::Utils::GetEndian() == TRAP::Utils::Endian::Little) //Need to convert to little endian
 			TRAP::Utils::Memory::SwapBytes(data);
@@ -187,7 +187,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(uint32_t& data)
 {
 	if (CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<uint32_t*>(&m_data[m_readPos]);
+		std::copy_n(&m_data[m_readPos], sizeof(data), &data);
 
 		if(TRAP::Utils::GetEndian() == TRAP::Utils::Endian::Little) //Need to convert to little endian
 			TRAP::Utils::Memory::SwapBytes(data);
@@ -204,7 +204,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(int64_t& data)
 {
 	if(CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<int64_t*>(&m_data[m_readPos]);
+		std::copy_n(&m_data[m_readPos], sizeof(data), &data);
 
 		if(TRAP::Utils::GetEndian() == TRAP::Utils::Endian::Little) //Need to convert to little endian
 			TRAP::Utils::Memory::SwapBytes(data);
@@ -221,7 +221,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(uint64_t& data)
 {
 	if (CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<uint64_t*>(&m_data[m_readPos]);
+		std::copy_n(&m_data[m_readPos], sizeof(data), &data);
 
 		if(TRAP::Utils::GetEndian() == TRAP::Utils::Endian::Little) //Need to convert to little endian
 			TRAP::Utils::Memory::SwapBytes(data);
@@ -238,7 +238,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(float& data)
 {
 	if(CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<float*>(&m_data[m_readPos]);
+		std::copy_n(&m_data[m_readPos], sizeof(data), &data);
 		m_readPos += sizeof(data);
 	}
 
@@ -251,7 +251,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(double& data)
 {
 	if (CheckSize(sizeof(data)))
 	{
-		data = *reinterpret_cast<double*>(&m_data[m_readPos]);
+		std::copy_n(&m_data[m_readPos], sizeof(data), &data);
 		m_readPos += sizeof(data);
 	}
 

--- a/TRAP/src/Network/Packet.cpp
+++ b/TRAP/src/Network/Packet.cpp
@@ -46,7 +46,7 @@ void TRAP::Network::Packet::Append(const void* data, const std::size_t sizeInByt
 
 	const std::size_t start = m_data.size();
 	m_data.resize(start + sizeInBytes);
-	std::memcpy(&m_data[start], data, sizeInBytes);
+	memcpy(&m_data[start], data, sizeInBytes);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -270,7 +270,7 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator>>(char* data)
 	if((length > 0) && CheckSize(length))
 	{
 		//Then extract characters
-		std::memcpy(data, &m_data[m_readPos], length);
+		memcpy(data, &m_data[m_readPos], length);
 		data[length] = '\0';
 
 		//Update reading position

--- a/TRAP/src/Network/Packet.cpp
+++ b/TRAP/src/Network/Packet.cpp
@@ -467,20 +467,6 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator<<(double data)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Network::Packet& TRAP::Network::Packet::operator<<(const char* data)
-{
-	//First insert string length
-	const uint32_t length = static_cast<uint32_t>(std::strlen(data));
-	*this << length;
-
-	//Then insert characters
-	Append(data, length * sizeof(char));
-
-	return *this;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Network::Packet& TRAP::Network::Packet::operator<<(const std::string_view data)
 {
 	//First insert string length
@@ -496,33 +482,15 @@ TRAP::Network::Packet& TRAP::Network::Packet::operator<<(const std::string_view 
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Network::Packet& TRAP::Network::Packet::operator<<(const wchar_t* data)
-{
-	//First insert string length
-	const uint32_t length = static_cast<uint32_t>(std::wcslen(data));
-	*this << length;
-
-	//Then insert characters
-	for (const wchar_t* c = data; *c != L'\0'; ++c)
-		*this << static_cast<uint32_t>(*c);
-
-	return *this;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Network::Packet& TRAP::Network::Packet::operator<<(const std::wstring& data)
+TRAP::Network::Packet& TRAP::Network::Packet::operator<<(const std::wstring_view data)
 {
 	//First insert string length
 	const uint32_t length = static_cast<uint32_t>(data.size());
 	*this << length;
 
 	//Then insert characters
-	if(length > 0)
-	{
-		for(const auto& c : data)
-			*this << static_cast<uint32_t>(c);
-	}
+	if (length > 0)
+		Append(data.data(), length * sizeof(std::wstring::value_type));
 
 	return *this;
 }

--- a/TRAP/src/Network/Packet.h
+++ b/TRAP/src/Network/Packet.h
@@ -177,10 +177,8 @@ namespace TRAP::Network
 		Packet& operator<<(uint64_t data);
 		Packet& operator<<(float data);
 		Packet& operator<<(double data);
-		Packet& operator<<(const char* data);
 		Packet& operator<<(const std::string_view data);
-		Packet& operator<<(const wchar_t* data);
-		Packet& operator<<(const std::wstring& data);
+		Packet& operator<<(const std::wstring_view data);
 
 	protected:
 		friend class TCPSocket;

--- a/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
+++ b/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
@@ -41,7 +41,6 @@ Modified by: Jan "GamesTrap" Schuerkamp
 sockaddr_in TRAP::INTERNAL::Network::SocketImpl::CreateAddress(uint32_t address, uint16_t port)
 {
 	sockaddr_in addr{};
-	memset(&addr, 0, sizeof(addr));
 
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 	{
@@ -62,7 +61,6 @@ sockaddr_in6 TRAP::INTERNAL::Network::SocketImpl::CreateAddress(const std::array
                                                                 uint16_t port)
 {
 	sockaddr_in6 addr{};
-	memset(&addr, 0, sizeof(addr));
 	std::copy(address.begin(), address.end(), addr.sin6_addr.s6_addr);
 	addr.sin6_family = AF_INET6;
 

--- a/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
+++ b/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
@@ -41,7 +41,7 @@ Modified by: Jan "GamesTrap" Schuerkamp
 sockaddr_in TRAP::INTERNAL::Network::SocketImpl::CreateAddress(uint32_t address, uint16_t port)
 {
 	sockaddr_in addr{};
-	std::memset(&addr, 0, sizeof(addr));
+	memset(&addr, 0, sizeof(addr));
 
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 	{
@@ -62,7 +62,7 @@ sockaddr_in6 TRAP::INTERNAL::Network::SocketImpl::CreateAddress(const std::array
                                                                 uint16_t port)
 {
 	sockaddr_in6 addr{};
-	std::memset(&addr, 0, sizeof(addr));
+	memset(&addr, 0, sizeof(addr));
 	std::copy(address.begin(), address.end(), addr.sin6_addr.s6_addr);
 	addr.sin6_family = AF_INET6;
 

--- a/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
+++ b/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
@@ -63,7 +63,7 @@ sockaddr_in6 TRAP::INTERNAL::Network::SocketImpl::CreateAddress(const std::array
 {
 	sockaddr_in6 addr{};
 	std::memset(&addr, 0, sizeof(addr));
-	std::memcpy(addr.sin6_addr.s6_addr, address.data(), address.size());
+	memcpy(addr.sin6_addr.s6_addr, address.data(), address.size());
 	addr.sin6_family = AF_INET6;
 
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)

--- a/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
+++ b/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
@@ -63,7 +63,7 @@ sockaddr_in6 TRAP::INTERNAL::Network::SocketImpl::CreateAddress(const std::array
 {
 	sockaddr_in6 addr{};
 	std::memset(&addr, 0, sizeof(addr));
-	memcpy(addr.sin6_addr.s6_addr, address.data(), address.size());
+	std::copy(address.begin(), address.end(), addr.sin6_addr.s6_addr);
 	addr.sin6_family = AF_INET6;
 
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)

--- a/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
+++ b/TRAP/src/Network/Sockets/Platform/SocketImplLinux.cpp
@@ -88,9 +88,9 @@ void TRAP::INTERNAL::Network::SocketImpl::Close(TRAP::Network::SocketHandle sock
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::Network::SocketImpl::SetBlocking(TRAP::Network::SocketHandle sock, bool block)
+void TRAP::INTERNAL::Network::SocketImpl::SetBlocking(const TRAP::Network::SocketHandle sock, const bool block)
 {
-	int32_t status = fcntl(sock, F_GETFL);
+	const int32_t status = fcntl(sock, F_GETFL);
 	if (block)
 	{
 		if (fcntl(sock, F_SETFL, status & ~O_NONBLOCK) == -1)

--- a/TRAP/src/Network/Sockets/Platform/SocketImplWinAPI.cpp
+++ b/TRAP/src/Network/Sockets/Platform/SocketImplWinAPI.cpp
@@ -39,7 +39,7 @@ Modified by: Jan "GamesTrap" Schuerkamp
 sockaddr_in TRAP::INTERNAL::Network::SocketImpl::CreateAddress(uint32_t address, uint16_t port)
 {
 	sockaddr_in addr{};
-	std::memset(&addr, 0, sizeof(addr));
+	memset(&addr, 0, sizeof(addr));
 
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 	{
@@ -60,7 +60,7 @@ sockaddr_in6 TRAP::INTERNAL::Network::SocketImpl::CreateAddress(const std::array
                                                                 uint16_t port)
 {
 	sockaddr_in6 addr{};
-	std::memset(&addr, 0, sizeof(addr));
+	memset(&addr, 0, sizeof(addr));
 	std::copy(address.begin(), address.end(), addr.sin6_addr.u.Byte);
 	addr.sin6_family = AF_INET6;
 

--- a/TRAP/src/Network/Sockets/Platform/SocketImplWinAPI.cpp
+++ b/TRAP/src/Network/Sockets/Platform/SocketImplWinAPI.cpp
@@ -61,7 +61,7 @@ sockaddr_in6 TRAP::INTERNAL::Network::SocketImpl::CreateAddress(const std::array
 {
 	sockaddr_in6 addr{};
 	std::memset(&addr, 0, sizeof(addr));
-	memcpy(addr.sin6_addr.u.Byte, address.data(), address.size());
+	std::copy(address.begin(), address.end(), addr.sin6_addr.u.Byte);
 	addr.sin6_family = AF_INET6;
 
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)

--- a/TRAP/src/Network/Sockets/Platform/SocketImplWinAPI.cpp
+++ b/TRAP/src/Network/Sockets/Platform/SocketImplWinAPI.cpp
@@ -39,7 +39,6 @@ Modified by: Jan "GamesTrap" Schuerkamp
 sockaddr_in TRAP::INTERNAL::Network::SocketImpl::CreateAddress(uint32_t address, uint16_t port)
 {
 	sockaddr_in addr{};
-	memset(&addr, 0, sizeof(addr));
 
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 	{
@@ -60,7 +59,6 @@ sockaddr_in6 TRAP::INTERNAL::Network::SocketImpl::CreateAddress(const std::array
                                                                 uint16_t port)
 {
 	sockaddr_in6 addr{};
-	memset(&addr, 0, sizeof(addr));
 	std::copy(address.begin(), address.end(), addr.sin6_addr.u.Byte);
 	addr.sin6_family = AF_INET6;
 

--- a/TRAP/src/Network/Sockets/Platform/SocketImplWinAPI.cpp
+++ b/TRAP/src/Network/Sockets/Platform/SocketImplWinAPI.cpp
@@ -61,7 +61,7 @@ sockaddr_in6 TRAP::INTERNAL::Network::SocketImpl::CreateAddress(const std::array
 {
 	sockaddr_in6 addr{};
 	std::memset(&addr, 0, sizeof(addr));
-	std::memcpy(addr.sin6_addr.u.Byte, address.data(), address.size());
+	memcpy(addr.sin6_addr.u.Byte, address.data(), address.size());
 	addr.sin6_family = AF_INET6;
 
 	if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)

--- a/TRAP/src/Network/Sockets/Socket.cpp
+++ b/TRAP/src/Network/Sockets/Socket.cpp
@@ -125,7 +125,7 @@ void TRAP::Network::Socket::Create(const SocketHandle handle)
 	{
 		//Disable the Nagle algorithm (i.e. removes buffering of TCP packets)
 		int32_t yes = 1;
-		if (setsockopt(m_socket, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char*>(&yes), sizeof(yes)) == -1)
+		if (setsockopt(m_socket, IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(yes)) == -1)
 		{
 			TP_ERROR(Log::NetworkSocketPrefix,
 						"Failed to set socket option \"TCP_NODELAY\"; all your TCP packets will be buffered");
@@ -135,7 +135,7 @@ void TRAP::Network::Socket::Create(const SocketHandle handle)
 	{
 		//Enable broadcast by default for UDP sockets
 		int32_t yes = 1;
-		if (setsockopt(m_socket, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<char*>(&yes), sizeof(yes)) == -1)
+		if (setsockopt(m_socket, SOL_SOCKET, SO_BROADCAST, &yes, sizeof(yes)) == -1)
 		{
 			TP_ERROR(Log::NetworkSocketPrefix, "Failed to enable broadcast on UDP socket");
 		}

--- a/TRAP/src/Network/Sockets/Socket.cpp
+++ b/TRAP/src/Network/Sockets/Socket.cpp
@@ -125,7 +125,7 @@ void TRAP::Network::Socket::Create(const SocketHandle handle)
 	{
 		//Disable the Nagle algorithm (i.e. removes buffering of TCP packets)
 		int32_t yes = 1;
-		if (setsockopt(m_socket, IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(yes)) == -1)
+		if (setsockopt(m_socket, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char*>(&yes), sizeof(yes)) == -1)
 		{
 			TP_ERROR(Log::NetworkSocketPrefix,
 						"Failed to set socket option \"TCP_NODELAY\"; all your TCP packets will be buffered");
@@ -135,7 +135,7 @@ void TRAP::Network::Socket::Create(const SocketHandle handle)
 	{
 		//Enable broadcast by default for UDP sockets
 		int32_t yes = 1;
-		if (setsockopt(m_socket, SOL_SOCKET, SO_BROADCAST, &yes, sizeof(yes)) == -1)
+		if (setsockopt(m_socket, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<const char*>(&yes), sizeof(yes)) == -1)
 		{
 			TP_ERROR(Log::NetworkSocketPrefix, "Failed to enable broadcast on UDP socket");
 		}

--- a/TRAP/src/Network/Sockets/TCPSocket.cpp
+++ b/TRAP/src/Network/Sockets/TCPSocket.cpp
@@ -69,8 +69,7 @@ uint16_t TRAP::Network::TCPSocket::GetLocalPort() const
 	INTERNAL::Network::SocketImpl::AddressLength size = sizeof(sockaddr_in);
 	if (getsockname(GetHandle(), &address, &size) != -1)
 	{
-		const sockaddr_in addrIn = Utils::BitCast<sockaddr, sockaddr_in>(address);
-		uint16_t port = addrIn.sin_port;
+		uint16_t port = Utils::BitCast<sockaddr, sockaddr_in>(address).sin_port;
 
 		if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 			TRAP::Utils::Memory::SwapBytes(port);
@@ -94,8 +93,7 @@ TRAP::Network::IPv4Address TRAP::Network::TCPSocket::GetRemoteAddress() const
 	INTERNAL::Network::SocketImpl::AddressLength size = sizeof(sockaddr_in);
 	if (getpeername(GetHandle(), &address, &size) != -1)
 	{
-		const sockaddr_in addrIn = Utils::BitCast<sockaddr, sockaddr_in>(address);
-		uint32_t addr = addrIn.sin_addr.s_addr;
+		uint32_t addr = Utils::BitCast<sockaddr, sockaddr_in>(address).sin_addr.s_addr;
 
 		if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 			TRAP::Utils::Memory::SwapBytes(addr);
@@ -118,8 +116,7 @@ uint16_t TRAP::Network::TCPSocket::GetRemotePort() const
 	INTERNAL::Network::SocketImpl::AddressLength size = sizeof(sockaddr_in);
 	if (getpeername(GetHandle(), &address, &size) != -1)
 	{
-		const sockaddr_in addrIn = Utils::BitCast<sockaddr, sockaddr_in>(address);
-		uint16_t port = addrIn.sin_port;
+		uint16_t port = Utils::BitCast<sockaddr, sockaddr_in>(address).sin_port;
 
 		if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 			TRAP::Utils::Memory::SwapBytes(port);

--- a/TRAP/src/Network/Sockets/TCPSocket.cpp
+++ b/TRAP/src/Network/Sockets/TCPSocket.cpp
@@ -329,9 +329,9 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocket::Send(Packet& packet) con
 	std::vector<char> blockToSend(sizeof(packetSize) + size);
 
 	//Copy the packet size and data into the block to send
-	std::memcpy(&blockToSend[0], &packetSize, sizeof(packetSize));
+	memcpy(&blockToSend[0], &packetSize, sizeof(packetSize));
 	if (size > 0)
-		std::memcpy(&blockToSend[0] + sizeof(packetSize), data, size);
+		memcpy(&blockToSend[0] + sizeof(packetSize), data, size);
 
 	//Send the data block
 	std::size_t sent = 0;
@@ -400,7 +400,7 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocket::Receive(Packet& packet)
 		{
 			m_pendingPacket.Data.resize(m_pendingPacket.Data.size() + received);
 			char* begin = &m_pendingPacket.Data[0] + m_pendingPacket.Data.size() - received;
-			std::memcpy(begin, buffer.data(), received);
+			memcpy(begin, buffer.data(), received);
 		}
 	}
 

--- a/TRAP/src/Network/Sockets/TCPSocket.cpp
+++ b/TRAP/src/Network/Sockets/TCPSocket.cpp
@@ -329,9 +329,9 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocket::Send(Packet& packet) con
 	std::vector<char> blockToSend(sizeof(packetSize) + size);
 
 	//Copy the packet size and data into the block to send
-	memcpy(&blockToSend[0], &packetSize, sizeof(packetSize));
+	std::copy_n(reinterpret_cast<const uint8_t*>(&packetSize), sizeof(packetSize), blockToSend.data());
 	if (size > 0)
-		memcpy(&blockToSend[0] + sizeof(packetSize), data, size);
+		std::copy_n(static_cast<const uint8_t*>(data), size, blockToSend.data() + sizeof(packetSize));
 
 	//Send the data block
 	std::size_t sent = 0;
@@ -400,7 +400,7 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocket::Receive(Packet& packet)
 		{
 			m_pendingPacket.Data.resize(m_pendingPacket.Data.size() + received);
 			char* begin = &m_pendingPacket.Data[0] + m_pendingPacket.Data.size() - received;
-			memcpy(begin, buffer.data(), received);
+			std::copy_n(buffer.data(), received, begin);
 		}
 	}
 

--- a/TRAP/src/Network/Sockets/TCPSocketIPv6.cpp
+++ b/TRAP/src/Network/Sockets/TCPSocketIPv6.cpp
@@ -66,9 +66,9 @@ TRAP::Network::IPv6Address TRAP::Network::TCPSocketIPv6::GetRemoteAddress() cons
 	{
 		std::array<uint8_t, 16> addr{};
 #ifdef TRAP_PLATFORM_WINDOWS
-		std::memcpy(addr.data(), address.sin6_addr.u.Byte, addr.size());
+		memcpy(addr.data(), address.sin6_addr.u.Byte, addr.size());
 #else
-		std::memcpy(addr.data(), address.sin6_addr.s6_addr, addr.size());
+		memcpy(addr.data(), address.sin6_addr.s6_addr, addr.size());
 #endif
 		return IPv6Address(addr);
 	}
@@ -298,9 +298,9 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocketIPv6::Send(Packet& packet)
 	std::vector<char> blockToSend(sizeof(packetSize) + size);
 
 	//Copy the packet size and data into the block to send
-	std::memcpy(&blockToSend[0], &packetSize, sizeof(packetSize));
+	memcpy(&blockToSend[0], &packetSize, sizeof(packetSize));
 	if (size > 0)
-		std::memcpy(&blockToSend[0] + sizeof(packetSize), data, size);
+		memcpy(&blockToSend[0] + sizeof(packetSize), data, size);
 
 	//Send the data block
 	std::size_t sent = 0;
@@ -369,7 +369,7 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocketIPv6::Receive(Packet& pack
 		{
 			m_pendingPacket.Data.resize(m_pendingPacket.Data.size() + received);
 			char* begin = &m_pendingPacket.Data[0] + m_pendingPacket.Data.size() - received;
-			std::memcpy(begin, buffer.data(), received);
+			memcpy(begin, buffer.data(), received);
 		}
 	}
 

--- a/TRAP/src/Network/Sockets/TCPSocketIPv6.cpp
+++ b/TRAP/src/Network/Sockets/TCPSocketIPv6.cpp
@@ -66,9 +66,9 @@ TRAP::Network::IPv6Address TRAP::Network::TCPSocketIPv6::GetRemoteAddress() cons
 	{
 		std::array<uint8_t, 16> addr{};
 #ifdef TRAP_PLATFORM_WINDOWS
-		memcpy(addr.data(), address.sin6_addr.u.Byte, addr.size());
+		std::copy_n(address.sin6_addr.u.Byte, addr.size(), addr.data());
 #else
-		memcpy(addr.data(), address.sin6_addr.s6_addr, addr.size());
+		std::copy_n(address.sin6_addr.s6_addr, addr.size(), addr.data());
 #endif
 		return IPv6Address(addr);
 	}
@@ -298,9 +298,9 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocketIPv6::Send(Packet& packet)
 	std::vector<char> blockToSend(sizeof(packetSize) + size);
 
 	//Copy the packet size and data into the block to send
-	memcpy(&blockToSend[0], &packetSize, sizeof(packetSize));
+	std::copy_n(reinterpret_cast<const uint8_t*>(&packetSize), sizeof(packetSize), blockToSend.data());
 	if (size > 0)
-		memcpy(&blockToSend[0] + sizeof(packetSize), data, size);
+		std::copy_n(static_cast<const uint8_t*>(data), size, blockToSend.data() + sizeof(packetSize));
 
 	//Send the data block
 	std::size_t sent = 0;
@@ -369,7 +369,7 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocketIPv6::Receive(Packet& pack
 		{
 			m_pendingPacket.Data.resize(m_pendingPacket.Data.size() + received);
 			char* begin = &m_pendingPacket.Data[0] + m_pendingPacket.Data.size() - received;
-			memcpy(begin, buffer.data(), received);
+			std::copy_n(buffer.data(), received, begin);
 		}
 	}
 

--- a/TRAP/src/Network/Sockets/TCPSocketIPv6.cpp
+++ b/TRAP/src/Network/Sockets/TCPSocketIPv6.cpp
@@ -112,14 +112,14 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocketIPv6::Connect(const IPv6Ad
 	CreateIPv6();
 
 	//Create the remote address
-	sockaddr_in6 address = INTERNAL::Network::SocketImpl::CreateAddress(remoteAddress.ToArray(), remotePort);
+	const sockaddr_in6 address = INTERNAL::Network::SocketImpl::CreateAddress(remoteAddress.ToArray(), remotePort);
 
 	if(timeout <= Utils::TimeStep(0.0f))
 	{
 		//We're not using a timeout: just try to connect
 
 		//Connect the socket
-		if (::connect(GetHandle(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
+		if (::connect(GetHandle(), reinterpret_cast<const sockaddr*>(&address), sizeof(address)) == -1)
 			return INTERNAL::Network::SocketImpl::GetErrorStatus();
 
 		//Connection succeeded
@@ -136,7 +136,7 @@ TRAP::Network::Socket::Status TRAP::Network::TCPSocketIPv6::Connect(const IPv6Ad
 		SetBlocking(false);
 
 	//Try to connect to the remote address
-	if(::connect(GetHandle(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) >= 0)
+	if(::connect(GetHandle(), reinterpret_cast<const sockaddr*>(&address), sizeof(address)) >= 0)
 	{
 		//We got instantly connected! (it may no happen a lot...)
 		SetBlocking(blocking);

--- a/TRAP/src/Network/Sockets/UDPSocket.cpp
+++ b/TRAP/src/Network/Sockets/UDPSocket.cpp
@@ -51,8 +51,7 @@ uint16_t TRAP::Network::UDPSocket::GetLocalPort() const
 	INTERNAL::Network::SocketImpl::AddressLength size = sizeof(sockaddr_in);
 	if (getsockname(GetHandle(), &address, &size) != -1)
 	{
-		const sockaddr_in convertedAddress = Utils::BitCast<sockaddr, sockaddr_in>(address);
-		uint16_t port = convertedAddress.sin_port;
+		uint16_t port = Utils::BitCast<sockaddr, sockaddr_in>(address).sin_port;
 
 		if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 			TRAP::Utils::Memory::SwapBytes(port);

--- a/TRAP/src/Network/Sockets/UDPSocket.cpp
+++ b/TRAP/src/Network/Sockets/UDPSocket.cpp
@@ -47,11 +47,12 @@ uint16_t TRAP::Network::UDPSocket::GetLocalPort() const
 		return 0; //We failed to retrieve the port
 
 	//Retrieve information about the local end of the socket
-	sockaddr_in address{};
-	INTERNAL::Network::SocketImpl::AddressLength size = sizeof(address);
-	if (getsockname(GetHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
+	sockaddr address{};
+	INTERNAL::Network::SocketImpl::AddressLength size = sizeof(sockaddr_in);
+	if (getsockname(GetHandle(), &address, &size) != -1)
 	{
-		uint16_t port = address.sin_port;
+		const sockaddr_in convertedAddress = Utils::BitCast<sockaddr, sockaddr_in>(address);
+		uint16_t port = convertedAddress.sin_port;
 
 		if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 			TRAP::Utils::Memory::SwapBytes(port);
@@ -78,7 +79,8 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocket::Bind(const uint16_t port
 
 	//Bind the socket
 	sockaddr_in addr = INTERNAL::Network::SocketImpl::CreateAddress(address.ToInteger(), port);
-	if(::bind(GetHandle(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == -1)
+	sockaddr finalAddr = Utils::BitCast<sockaddr_in, sockaddr>(addr);
+	if(::bind(GetHandle(), &finalAddr, sizeof(addr)) == -1)
 	{
 		TP_ERROR(Log::NetworkUDPSocketPrefix, "Failed to bind socket to port");
 		return Status::Error;
@@ -114,10 +116,11 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocket::Send(const void* data, c
 
 	//Build the target address
 	sockaddr_in address = INTERNAL::Network::SocketImpl::CreateAddress(remoteAddress.ToInteger(), remotePort);
+	const sockaddr finalAddress = Utils::BitCast<sockaddr_in, sockaddr>(address);
 
 	//Send the data (unlike TCP, all the data is always sent in one call)
 	const int64_t sent = sendto(GetHandle(), static_cast<const char*>(data), static_cast<int32_t>(size), 0,
-	                            reinterpret_cast<sockaddr*>(&address), sizeof(address));
+	                            &finalAddress, sizeof(sockaddr_in));
 
 	//Check for errors
 	if (sent < 0)
@@ -147,11 +150,12 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocket::Receive(void* data, cons
 
 	//Data that will be filled with the other computer's address
 	sockaddr_in address = INTERNAL::Network::SocketImpl::CreateAddress(INADDR_ANY, 0);
+	sockaddr convertedAddress = Utils::BitCast<sockaddr_in, sockaddr>(address);
 
 	//Receive a chunk of bytes
-	INTERNAL::Network::SocketImpl::AddressLength addressSize = sizeof(address);
+	INTERNAL::Network::SocketImpl::AddressLength addressSize = sizeof(sockaddr_in);
 	const int64_t sizeReceived = recvfrom(GetHandle(), static_cast<char*>(data), static_cast<int32_t>(size), 0,
-	                                      reinterpret_cast<sockaddr*>(&address), &addressSize);
+	                                      &convertedAddress, &addressSize);
 
 	//Check for errors
 	if (sizeReceived < 0)
@@ -160,6 +164,7 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocket::Receive(void* data, cons
 	//Fill the sender information
 	received = static_cast<std::size_t>(sizeReceived);
 
+	address = Utils::BitCast<sockaddr, sockaddr_in>(convertedAddress);
 	uint32_t addr = address.sin_addr.s_addr;
 	uint16_t port = address.sin_port;
 

--- a/TRAP/src/Network/Sockets/UDPSocket.cpp
+++ b/TRAP/src/Network/Sockets/UDPSocket.cpp
@@ -77,8 +77,8 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocket::Bind(const uint16_t port
 		return Status::Error;
 
 	//Bind the socket
-	sockaddr_in addr = INTERNAL::Network::SocketImpl::CreateAddress(address.ToInteger(), port);
-	sockaddr finalAddr = Utils::BitCast<sockaddr_in, sockaddr>(addr);
+	const sockaddr_in addr = INTERNAL::Network::SocketImpl::CreateAddress(address.ToInteger(), port);
+	const sockaddr finalAddr = Utils::BitCast<sockaddr_in, sockaddr>(addr);
 	if(::bind(GetHandle(), &finalAddr, sizeof(addr)) == -1)
 	{
 		TP_ERROR(Log::NetworkUDPSocketPrefix, "Failed to bind socket to port");
@@ -114,7 +114,7 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocket::Send(const void* data, c
 	}
 
 	//Build the target address
-	sockaddr_in address = INTERNAL::Network::SocketImpl::CreateAddress(remoteAddress.ToInteger(), remotePort);
+	const sockaddr_in address = INTERNAL::Network::SocketImpl::CreateAddress(remoteAddress.ToInteger(), remotePort);
 	const sockaddr finalAddress = Utils::BitCast<sockaddr_in, sockaddr>(address);
 
 	//Send the data (unlike TCP, all the data is always sent in one call)

--- a/TRAP/src/Network/Sockets/UDPSocketIPv6.cpp
+++ b/TRAP/src/Network/Sockets/UDPSocketIPv6.cpp
@@ -50,8 +50,8 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocketIPv6::Bind(const uint16_t 
 		return Status::Error;
 
 	//Bind the socket
-	sockaddr_in6 addr = INTERNAL::Network::SocketImpl::CreateAddress(address.ToArray(), port);
-	if(::bind(GetHandle(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == -1)
+	const sockaddr_in6 addr = INTERNAL::Network::SocketImpl::CreateAddress(address.ToArray(), port);
+	if(::bind(GetHandle(), reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) == -1)
 	{
 		TP_ERROR(Log::NetworkUDPSocketPrefix, "Failed to bind socket to port");
 		return Status::Error;
@@ -72,7 +72,7 @@ void TRAP::Network::UDPSocketIPv6::Unbind()
 
 TRAP::Network::Socket::Status TRAP::Network::UDPSocketIPv6::Send(const void* data, const std::size_t size,
                                                                  const IPv6Address& remoteAddress,
-																 uint16_t remotePort)
+																 const uint16_t remotePort)
 {
 	//Create the internal socket if it doesn't exist
 	CreateIPv6();
@@ -86,11 +86,11 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocketIPv6::Send(const void* dat
 	}
 
 	//Build the target address
-	sockaddr_in6 address = INTERNAL::Network::SocketImpl::CreateAddress(remoteAddress.ToArray(), remotePort);
+	const sockaddr_in6 address = INTERNAL::Network::SocketImpl::CreateAddress(remoteAddress.ToArray(), remotePort);
 
 	//Send the data (unlike TCP, all the data is always sent in one call)
 	const int64_t sent = sendto(GetHandle(), static_cast<const char*>(data), static_cast<int32_t>(size), 0,
-	                            reinterpret_cast<sockaddr*>(&address), sizeof(address));
+	                            reinterpret_cast<const sockaddr*>(&address), sizeof(address));
 
 	//Check for errors
 	if (sent < 0)

--- a/TRAP/src/Network/Sockets/UDPSocketIPv6.cpp
+++ b/TRAP/src/Network/Sockets/UDPSocketIPv6.cpp
@@ -122,9 +122,9 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocketIPv6::Receive(void* data, 
 	//Data that will be filled with the other computer's address
 	std::array<uint8_t, 16> addr{};
 #ifdef TRAP_PLATFORM_WINDOWS
-	std::memcpy(addr.data(), in6addr_any.u.Byte, addr.size());
+	memcpy(addr.data(), in6addr_any.u.Byte, addr.size());
 #else
-	std::memcpy(addr.data(), in6addr_any.s6_addr, addr.size());
+	memcpy(addr.data(), in6addr_any.s6_addr, addr.size());
 #endif
 	sockaddr_in6 address = INTERNAL::Network::SocketImpl::CreateAddress(addr, 0);
 
@@ -141,9 +141,9 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocketIPv6::Receive(void* data, 
 	received = static_cast<std::size_t>(sizeReceived);
 	addr = {};
 #ifdef TRAP_PLATFORM_WINDOWS
-	std::memcpy(addr.data(), address.sin6_addr.u.Byte, addr.size());
+	memcpy(addr.data(), address.sin6_addr.u.Byte, addr.size());
 #else
-	std::memcpy(addr.data(), address.sin6_addr.s6_addr, addr.size());
+	memcpy(addr.data(), address.sin6_addr.s6_addr, addr.size());
 #endif
 	remoteAddress = IPv6Address(addr);
 

--- a/TRAP/src/Network/Sockets/UDPSocketIPv6.cpp
+++ b/TRAP/src/Network/Sockets/UDPSocketIPv6.cpp
@@ -122,9 +122,9 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocketIPv6::Receive(void* data, 
 	//Data that will be filled with the other computer's address
 	std::array<uint8_t, 16> addr{};
 #ifdef TRAP_PLATFORM_WINDOWS
-	memcpy(addr.data(), in6addr_any.u.Byte, addr.size());
+	std::copy_n(in6addr_any.u.Byte, addr.size(), addr.data());
 #else
-	memcpy(addr.data(), in6addr_any.s6_addr, addr.size());
+	std::copy_n(in6addr_any.s6_addr, addr.size(), addr.data());
 #endif
 	sockaddr_in6 address = INTERNAL::Network::SocketImpl::CreateAddress(addr, 0);
 
@@ -141,9 +141,9 @@ TRAP::Network::Socket::Status TRAP::Network::UDPSocketIPv6::Receive(void* data, 
 	received = static_cast<std::size_t>(sizeReceived);
 	addr = {};
 #ifdef TRAP_PLATFORM_WINDOWS
-	memcpy(addr.data(), address.sin6_addr.u.Byte, addr.size());
+	std::copy_n(address.sin6_addr.u.Byte, addr.size(), addr.data());
 #else
-	memcpy(addr.data(), address.sin6_addr.s6_addr, addr.size());
+	std::copy_n(address.sin6_addr.s6_addr, addr.size(), addr.data());
 #endif
 	remoteAddress = IPv6Address(addr);
 

--- a/TRAP/src/Network/TCPListener.cpp
+++ b/TRAP/src/Network/TCPListener.cpp
@@ -53,9 +53,7 @@ uint16_t TRAP::Network::TCPListener::GetLocalPort() const
 	INTERNAL::Network::SocketImpl::AddressLength size = sizeof(sockaddr_in);
 	if (getsockname(GetHandle(), &address, &size) != -1)
 	{
-		const sockaddr_in finalAddress = Utils::BitCast<sockaddr, sockaddr_in>(address);
-
-		uint16_t res = finalAddress.sin_port;
+		uint16_t res = Utils::BitCast<sockaddr, sockaddr_in>(address).sin_port;
 
 		if(TRAP::Utils::GetEndian() != TRAP::Utils::Endian::Big)
 			TRAP::Utils::Memory::SwapBytes(res);

--- a/TRAP/src/Network/TCPListenerIPv6.cpp
+++ b/TRAP/src/Network/TCPListenerIPv6.cpp
@@ -50,7 +50,7 @@ uint16_t TRAP::Network::TCPListenerIPv6::GetLocalPort() const
 
 	//Retrieve information about the local end of the socket
 	sockaddr_in6 address{};
-	INTERNAL::Network::SocketImpl::AddressLength size = sizeof(address);
+	INTERNAL::Network::SocketImpl::AddressLength size = sizeof(sockaddr_in6);
 	if (getsockname(GetHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
 	{
 		uint16_t res = address.sin6_port;
@@ -79,8 +79,8 @@ TRAP::Network::Socket::Status TRAP::Network::TCPListenerIPv6::Listen(const uint1
 		return Status::Error;
 
 	//Bind the socket to the specified port
-	sockaddr_in6 addr = INTERNAL::Network::SocketImpl::CreateAddress(address.ToArray(), port);
-	if(bind(GetHandle(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == -1)
+	const sockaddr_in6 addr = INTERNAL::Network::SocketImpl::CreateAddress(address.ToArray(), port);
+	if(bind(GetHandle(), reinterpret_cast<const sockaddr*>(&addr), sizeof(sockaddr_in6)) == -1)
 	{
 		//Not likely to happen, but...
 		TP_ERROR(Log::NetworkTCPListenerPrefix, "Failed to bind listener socket to port", port);
@@ -119,7 +119,7 @@ TRAP::Network::Socket::Status TRAP::Network::TCPListenerIPv6::Accept(TCPSocketIP
 
 	//Accept a new connection
 	sockaddr_in6 address{};
-	INTERNAL::Network::SocketImpl::AddressLength length = sizeof(address);
+	INTERNAL::Network::SocketImpl::AddressLength length = sizeof(sockaddr_in6);
 	const SocketHandle remote = ::accept(GetHandle(), reinterpret_cast<sockaddr*>(&address), &length);
 
 	//Check for errors

--- a/TRAP/src/Scene/SceneSerializer.cpp
+++ b/TRAP/src/Scene/SceneSerializer.cpp
@@ -11,7 +11,7 @@
 
 #include "Components.h"
 #include "Entity.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 namespace YAML
 {
@@ -178,7 +178,7 @@ void TRAP::SceneSerializer::Serialize(const std::filesystem::path& filepath)
 	out << YAML::EndSeq;
 	out << YAML::EndMap;
 
-	if(!FS::WriteTextFile(filepath, out.c_str()))
+	if(!FileSystem::WriteTextFile(filepath, out.c_str()))
 		TP_ERROR(Log::SceneSerializerPrefix, " Saving to: \"", filepath.generic_u8string(), "\" failed!");
 }
 
@@ -193,7 +193,7 @@ void TRAP::SceneSerializer::SerializeRuntime(const std::filesystem::path&)
 
 bool TRAP::SceneSerializer::Deserialize(const std::filesystem::path& filepath)
 {
-	if (!FS::FileOrFolderExists(filepath))
+	if (!FileSystem::FileOrFolderExists(filepath))
 	{
 		TP_ERROR(Log::SceneSerializerPrefix, "File: \"", filepath.generic_u8string(), "\" doesn't exists!");
 		return false;

--- a/TRAP/src/Scene/SceneSerializer.cpp
+++ b/TRAP/src/Scene/SceneSerializer.cpp
@@ -179,7 +179,7 @@ void TRAP::SceneSerializer::Serialize(const std::filesystem::path& filepath)
 	out << YAML::EndMap;
 
 	if(!FileSystem::WriteTextFile(filepath, out.c_str()))
-		TP_ERROR(Log::SceneSerializerPrefix, " Saving to: \"", filepath.generic_u8string(), "\" failed!");
+		TP_ERROR(Log::SceneSerializerPrefix, " Saving to: \"", filepath.u8string(), "\" failed!");
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -195,18 +195,18 @@ bool TRAP::SceneSerializer::Deserialize(const std::filesystem::path& filepath)
 {
 	if (!FileSystem::FileOrFolderExists(filepath))
 	{
-		TP_ERROR(Log::SceneSerializerPrefix, "File: \"", filepath.generic_u8string(), "\" doesn't exists!");
+		TP_ERROR(Log::SceneSerializerPrefix, "File: \"", filepath.u8string(), "\" doesn't exists!");
 		return false;
 	}
 
 	YAML::Node data;
 	try
 	{
-		data = YAML::LoadFile(filepath.generic_u8string());
+		data = YAML::LoadFile(filepath.u8string());
 	}
 	catch(const YAML::ParserException& ex)
 	{
-		TP_ERROR(Log::SceneSerializerPrefix, "Failed to load scene file: \"", filepath.generic_u8string(), "\" ", ex.what());
+		TP_ERROR(Log::SceneSerializerPrefix, "Failed to load scene file: \"", filepath.u8string(), "\" ", ex.what());
 	}
 
 	if (!data["Scene"])

--- a/TRAP/src/TRAP.h
+++ b/TRAP/src/TRAP.h
@@ -37,8 +37,8 @@
 //-----------------------
 
 //----FILE-SYSTEM--------
-#include "../src/FS/FS.h"
-#include "../src/FS/FileWatcher.h"
+#include "../src/FileSystem/FileSystem.h"
+#include "../src/FileSystem/FileWatcher.h"
 //-----------------------
 
 //----UTILS--------------

--- a/TRAP/src/TRAP_Assert.h
+++ b/TRAP/src/TRAP_Assert.h
@@ -1,6 +1,8 @@
 #ifndef TRAP_TRAPASSERT_H
 #define TRAP_TRAPASSERT_H
 
+#include "Core/Base.h"
+#include "Log/Log.h"
 #include <filesystem>
 
 #if defined(TRAP_DEBUG) || defined(TRAP_RELWITHDEBINFO)
@@ -8,29 +10,29 @@
 #endif
 
 #ifdef TRAP_ENABLE_ASSERTS
-//Alternatively we could use the same "default" message for both "WITH_MSG" and "NO_MSG" and
-//provide support for custom formatting by concatenating the formatting string instead of having the format inside the default message
-#define TRAP_INTERNAL_ASSERT_IMPL(type, check, msg, ...) { if(!(check)) { TP_CRITICAL(type, msg, __VA_ARGS__);\
-                                                                          TRAP_DEBUG_BREAK(); } }
-#define TRAP_INTERNAL_ASSERT_WITH_MSG(type, check, ...) TRAP_INTERNAL_ASSERT_IMPL\
-	(\
-		type, check, "Assertion '", TRAP_STRINGIFY_MACRO(check), "' failed: ", __VA_ARGS__, " @ ",\
-		std::filesystem::path(__FILE__).filename(), ":", __LINE__\
+
+#define TRAP_INTERNAL_ASSERT_IMPL(check, msg, ...) { if(!(check)) { TP_CRITICAL(msg, __VA_ARGS__);                   \
+                                                                    TRAP_DEBUG_BREAK(); } }
+
+#define TRAP_INTERNAL_ASSERT_WITH_MSG(check, ...) TRAP_INTERNAL_ASSERT_IMPL                                          \
+	(                                                                                                                \
+		check, " Assertion '", TRAP_STRINGIFY_MACRO(check), "' failed: ", __VA_ARGS__, " @ ",                        \
+		std::filesystem::absolute(std::filesystem::path(__FILE__)).u8string(), ':', __LINE__                         \
 	)
-#define TRAP_INTERNAL_ASSERT_NO_MSG(type, check) TRAP_INTERNAL_ASSERT_IMPL\
-	(\
-		type, check, "Assertion '", TRAP_STRINGIFY_MACRO(check)"' failed @ ",\
-		std::filesystem::path(__FILE__).filename(), ":", __LINE__\
+#define TRAP_INTERNAL_ASSERT_NO_MSG(check) TRAP_INTERNAL_ASSERT_IMPL                                                 \
+	(                                                                                                                \
+		check, " Assertion '", TRAP_STRINGIFY_MACRO(check)"' failed @ ",                                             \
+		std::filesystem::absolute(std::filesystem::path(__FILE__)).u8string(), ':', __LINE__                         \
 	)
 
 #define TRAP_INTERNAL_ASSERT_GET_MACRO_NAME(arg1, arg2, macro, ...) macro
-#define TRAP_INTERNAL_ASSERT_GET_MACRO(...) TRAP_EXPAND_MACRO\
-	(\
-		TRAP_INTERNAL_ASSERT_GET_MACRO_NAME(__VA_ARGS__, TRAP_INTERNAL_ASSERT_WITH_MSG, TRAP_INTERNAL_ASSERT_NO_MSG)\
+#define TRAP_INTERNAL_ASSERT_GET_MACRO(...) TRAP_EXPAND_MACRO                                                        \
+	(                                                                                                                \
+		TRAP_INTERNAL_ASSERT_GET_MACRO_NAME(__VA_ARGS__, TRAP_INTERNAL_ASSERT_WITH_MSG, TRAP_INTERNAL_ASSERT_NO_MSG) \
 	)
 
 //Currently accepts at least the condition and one additional parameter (the message) being optional
-#define TRAP_ASSERT(...) TRAP_EXPAND_MACRO(TRAP_INTERNAL_ASSERT_GET_MACRO(__VA_ARGS__)(" ", __VA_ARGS__))
+#define TRAP_ASSERT(...) TRAP_EXPAND_MACRO(TRAP_INTERNAL_ASSERT_GET_MACRO(__VA_ARGS__)(__VA_ARGS__))
 #else
 template<typename... Args>
 constexpr void TRAP_ASSERT(const Args&...) {}

--- a/TRAP/src/ThreadPool/ThreadPool.h
+++ b/TRAP/src/ThreadPool/ThreadPool.h
@@ -108,8 +108,8 @@ auto TRAP::ThreadPool::EnqueueTask(F&& f, Args&&... args) -> std::future<std::in
 	using TaskReturnType = std::invoke_result_t<F, Args...>;
 	using TaskType = std::packaged_task<TaskReturnType()>;
 
-	auto task = std::make_shared<TaskType>(std::bind(std::forward<F>(f), std::forward<Args>(args)...));
-	std::future<TaskReturnType> result = task->get_future();
+	const auto task = std::make_shared<TaskType>(std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+	const std::future<TaskReturnType> result = task->get_future();
 
 	auto work = [task]()
 	{

--- a/TRAP/src/Utils/ByteSwap.h
+++ b/TRAP/src/Utils/ByteSwap.h
@@ -2,6 +2,7 @@
 #define TRAP_BYTESWAP_H
 
 #include <bitset>
+#include <type_traits>
 
 #include "Core/Base.h"
 #include "TRAP_Assert.h"
@@ -15,8 +16,10 @@ namespace TRAP::Utils::Memory
 	/// <typeparam name="T">Primitive data type.</typeparam>
 	/// <param name="t">Primitive data type.</param>
 	template<typename T>
-	inline static void SwapBytes(T& /*t*/)
+	inline static constexpr void SwapBytes(T& /*t*/)
 	{
+		static_assert(std::is_reference_v<T>, "T must be a reference type");
+		static_assert(!std::is_const_v<std::remove_reference_t<T>>, "T must not be a const reference");
 		TRAP_ASSERT(false, "Invalid template type used for byte swapping!");
 	}
 }

--- a/TRAP/src/Utils/Config/Config.cpp
+++ b/TRAP/src/Utils/Config/Config.cpp
@@ -26,14 +26,14 @@ bool TRAP::Utils::Config::LoadFromFile(const std::filesystem::path& file)
 		return false;
 
 	TP_INFO(TRAP::Log::ConfigPrefix, "Loading file: \"", file.u8string(), "\"");
-	std::vector<std::string_view> lines = String::SplitStringView(*input, '\n');
+	const std::vector<std::string_view> lines = String::SplitStringView(*input, '\n');
 
 	for (const auto& line : lines)
 	{
 		if (!line.empty())
 		{
 			//Parse line
-			auto [key, value] = ParseLine(line);
+			const auto [key, value] = ParseLine(line);
 
 			if (!key.empty())
 			{

--- a/TRAP/src/Utils/Config/Config.cpp
+++ b/TRAP/src/Utils/Config/Config.cpp
@@ -25,7 +25,7 @@ bool TRAP::Utils::Config::LoadFromFile(const std::filesystem::path& file)
 	if (!input)
 		return false;
 
-	TP_INFO(TRAP::Log::ConfigPrefix, "Loading file: \"", file.generic_u8string(), "\"");
+	TP_INFO(TRAP::Log::ConfigPrefix, "Loading file: \"", file.u8string(), "\"");
 	std::vector<std::string_view> lines = String::SplitStringView(*input, '\n');
 
 	for (const auto& line : lines)
@@ -61,7 +61,7 @@ bool TRAP::Utils::Config::SaveToFile(const std::filesystem::path& file)
 	//Write
 	std::vector<std::pair<std::string, std::string>> fileContents;
 
-	TP_INFO(TRAP::Log::ConfigPrefix, "Saving file: \"", file.generic_u8string(), "\"");
+	TP_INFO(TRAP::Log::ConfigPrefix, "Saving file: \"", file.u8string(), "\"");
 
 	//Read the file into a vector and replace the values of the keys that match with our map
 	const auto input = FileSystem::ReadTextFile(file);

--- a/TRAP/src/Utils/Config/Config.cpp
+++ b/TRAP/src/Utils/Config/Config.cpp
@@ -21,12 +21,12 @@ bool TRAP::Utils::Config::LoadFromFile(const std::filesystem::path& file)
 	m_data.clear();
 
 	//Load
-	const std::string input = FS::ReadTextFile(file);
-	if (input.empty())
+	const auto input = FS::ReadTextFile(file);
+	if (!input)
 		return false;
 
 	TP_INFO(TRAP::Log::ConfigPrefix, "Loading file: \"", file.generic_u8string(), "\"");
-	std::vector<std::string_view> lines = String::SplitStringView(input, '\n');
+	std::vector<std::string_view> lines = String::SplitStringView(*input, '\n');
 
 	for (const auto& line : lines)
 	{
@@ -64,10 +64,10 @@ bool TRAP::Utils::Config::SaveToFile(const std::filesystem::path& file)
 	TP_INFO(TRAP::Log::ConfigPrefix, "Saving file: \"", file.generic_u8string(), "\"");
 
 	//Read the file into a vector and replace the values of the keys that match with our map
-	const std::string input = FS::ReadTextFile(file);
-	if (!input.empty())
+	const auto input = FS::ReadTextFile(file);
+	if (input)
 	{
-		const std::vector<std::string> lines = String::SplitString(input, '\n');
+		const std::vector<std::string> lines = String::SplitString(*input, '\n');
 
 		for (const auto& line : lines)
 		{

--- a/TRAP/src/Utils/Config/Config.cpp
+++ b/TRAP/src/Utils/Config/Config.cpp
@@ -2,7 +2,7 @@
 #include "Config.h"
 
 #include "Utils/String/String.h"
-#include "FS/FS.h"
+#include "FileSystem/FileSystem.h"
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -21,7 +21,7 @@ bool TRAP::Utils::Config::LoadFromFile(const std::filesystem::path& file)
 	m_data.clear();
 
 	//Load
-	const auto input = FS::ReadTextFile(file);
+	const auto input = FileSystem::ReadTextFile(file);
 	if (!input)
 		return false;
 
@@ -64,7 +64,7 @@ bool TRAP::Utils::Config::SaveToFile(const std::filesystem::path& file)
 	TP_INFO(TRAP::Log::ConfigPrefix, "Saving file: \"", file.generic_u8string(), "\"");
 
 	//Read the file into a vector and replace the values of the keys that match with our map
-	const auto input = FS::ReadTextFile(file);
+	const auto input = FileSystem::ReadTextFile(file);
 	if (input)
 	{
 		const std::vector<std::string> lines = String::SplitString(*input, '\n');
@@ -133,7 +133,7 @@ bool TRAP::Utils::Config::SaveToFile(const std::filesystem::path& file)
 		ss << '\n';
 	}
 
-	return FS::WriteTextFile(file, ss.str());
+	return FileSystem::WriteTextFile(file, ss.str());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Utils/Decompress/Inflate.cpp
+++ b/TRAP/src/Utils/Decompress/Inflate.cpp
@@ -683,7 +683,7 @@ bool TRAP::Utils::Decompress::INTERNAL::InflateNoCompression(std::vector<uint8_t
 	if (bytePos + LEN > size)
 		return false; //Error: Reading outside of in buffer
 
-	std::memcpy(out.data() + pos, reader.Data + bytePos, LEN);
+	memcpy(out.data() + pos, reader.Data + bytePos, LEN);
 	pos += LEN;
 	bytePos += LEN;
 
@@ -784,14 +784,14 @@ bool TRAP::Utils::Decompress::INTERNAL::InflateHuffmanBlock(std::vector<uint8_t>
 			out.resize(pos + length);
 			if(distance < length)
 			{
-				std::memcpy(out.data() + pos, out.data() + backward, distance);
+				memcpy(out.data() + pos, out.data() + backward, distance);
 				pos += distance;
 				for (std::size_t forward = distance; forward < length; ++forward)
 					out[pos++] = out[backward++];
 			}
 			else
 			{
-				std::memcpy(out.data() + pos, out.data() + backward, length);
+				memcpy(out.data() + pos, out.data() + backward, length);
 				pos += length;
 			}
 		}
@@ -852,7 +852,7 @@ bool TRAP::Utils::Decompress::Inflate(const uint8_t* source, const std::size_t s
 		}
 	}
 
-	std::memcpy(destination, result.data(), result.size());
+	memcpy(destination, result.data(), result.size());
 
 	return true;
 }

--- a/TRAP/src/Utils/Decompress/Inflate.cpp
+++ b/TRAP/src/Utils/Decompress/Inflate.cpp
@@ -683,7 +683,7 @@ bool TRAP::Utils::Decompress::INTERNAL::InflateNoCompression(std::vector<uint8_t
 	if (bytePos + LEN > size)
 		return false; //Error: Reading outside of in buffer
 
-	memcpy(out.data() + pos, reader.Data + bytePos, LEN);
+	std::copy_n(reader.Data + bytePos, LEN, out.data() + pos);
 	pos += LEN;
 	bytePos += LEN;
 
@@ -784,14 +784,14 @@ bool TRAP::Utils::Decompress::INTERNAL::InflateHuffmanBlock(std::vector<uint8_t>
 			out.resize(pos + length);
 			if(distance < length)
 			{
-				memcpy(out.data() + pos, out.data() + backward, distance);
+				std::copy_n(out.data() + backward, distance, out.data() + pos);
 				pos += distance;
 				for (std::size_t forward = distance; forward < length; ++forward)
 					out[pos++] = out[backward++];
 			}
 			else
 			{
-				memcpy(out.data() + pos, out.data() + backward, length);
+				std::copy_n(out.data() + backward, length, out.data() + pos);
 				pos += length;
 			}
 		}
@@ -852,7 +852,7 @@ bool TRAP::Utils::Decompress::Inflate(const uint8_t* source, const std::size_t s
 		}
 	}
 
-	memcpy(destination, result.data(), result.size());
+	std::copy(result.begin(), result.end(), destination);
 
 	return true;
 }

--- a/TRAP/src/Utils/Decompress/Inflate.cpp
+++ b/TRAP/src/Utils/Decompress/Inflate.cpp
@@ -404,7 +404,7 @@ bool TRAP::Utils::Decompress::INTERNAL::HuffmanTree::GetTreeInflateDynamic(Huffm
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Returns the code. The bit reader must already have been ensured at least 15bits
-uint32_t TRAP::Utils::Decompress::INTERNAL::HuffmanTree::DecodeSymbol(BitReader& reader)
+uint32_t TRAP::Utils::Decompress::INTERNAL::HuffmanTree::DecodeSymbol(BitReader& reader) const
 {
 	const uint16_t code = static_cast<uint16_t>(reader.PeekBits(FirstBits));
 	const uint16_t l = TableLength[code];
@@ -522,7 +522,7 @@ bool TRAP::Utils::Decompress::INTERNAL::HuffmanTree::MakeTable()
 	for(i = 0; i < NumCodes; i++)
 	{
 		const uint32_t symbol = Codes[i];
-		uint32_t l = Lengths[i];
+		const uint32_t l = Lengths[i];
 		if (l <= FirstBits)
 			continue; //Symbols that fit in first table dont increase secondary table size
 		//Get the FIRSTBITS(9u) MSBs, the MSBs of the symbol are encoded first.

--- a/TRAP/src/Utils/Decompress/Inflate.h
+++ b/TRAP/src/Utils/Decompress/Inflate.h
@@ -155,7 +155,7 @@ namespace TRAP::Utils::Decompress
 			/// </summary>
 			/// <param name="reader">BitReader to decode symbol from.</param>
 			/// <returns>Code.</returns>
-			uint32_t DecodeSymbol(BitReader& reader);
+			uint32_t DecodeSymbol(BitReader& reader) const;
 
 			//The base lengths represented by codes 257-285
 			static constexpr std::array<uint32_t, 29> LengthBase

--- a/TRAP/src/Utils/Discord/DiscordGameSDK.cpp
+++ b/TRAP/src/Utils/Discord/DiscordGameSDK.cpp
@@ -99,7 +99,6 @@ bool TRAP::Utils::Discord::RunCallbacks()
     }
 
     TRAP::Utils::Discord::SetActivity(CurrentActivity);
-
 #endif
 
     return true;
@@ -130,7 +129,6 @@ bool TRAP::Utils::Discord::SetActivity([[maybe_unused]] const Activity& activity
 
         return lastRes == discord::Result::Ok;
     }
-
 #endif
 
     return false;

--- a/TRAP/src/Utils/Discord/DiscordGameSDK.cpp
+++ b/TRAP/src/Utils/Discord/DiscordGameSDK.cpp
@@ -21,7 +21,7 @@ int64_t CurrentAppID = 639903785971613728;
 TRAP::Utils::Discord::Activity CurrentActivity{};
 
 //Forward declares
-void DiscordLogger(discord::LogLevel logLevel, const char* msg);
+void DiscordLogger(discord::LogLevel logLevel, std::string_view msg);
 void DiscordLogResult(discord::Result res);
 #endif
 
@@ -148,7 +148,7 @@ discord::Core* TRAP::Utils::Discord::GetDiscordCore()
 //-------------------------------------------------------------------------------------------------------------------//
 
 #ifdef USE_DISCORD_GAME_SDK
-void DiscordLogger(const discord::LogLevel logLevel, const char* msg)
+void DiscordLogger(const discord::LogLevel logLevel, const std::string_view msg)
 {
     switch (logLevel)
     {

--- a/TRAP/src/Utils/DynamicLoading/DynamicLoading.cpp
+++ b/TRAP/src/Utils/DynamicLoading/DynamicLoading.cpp
@@ -1,12 +1,12 @@
 #include "TRAPPCH.h"
 #include "DynamicLoading.h"
 
-void* TRAP::Utils::DynamicLoading::LoadLibrary(const std::string& path)
+void* TRAP::Utils::DynamicLoading::LoadLibrary(const std::string_view path)
 {
 #ifdef TRAP_PLATFORM_WINDOWS
-    return LoadLibraryA(path.c_str());
+    return LoadLibraryA(path.data());
 #elif defined(TRAP_PLATFORM_LINUX)
-	return dlopen(path.c_str(), RTLD_LAZY | RTLD_LOCAL);
+	return dlopen(path.data(), RTLD_LAZY | RTLD_LOCAL);
 #else
     return nullptr;
 #endif

--- a/TRAP/src/Utils/DynamicLoading/DynamicLoading.h
+++ b/TRAP/src/Utils/DynamicLoading/DynamicLoading.h
@@ -10,7 +10,7 @@ namespace TRAP::Utils::DynamicLoading
     /// </summary>
     /// <param name="path">Path to the library.</param>
     /// <returns>Pointer to the loaded library.</returns>
-    void* LoadLibrary(const std::string& path);
+    void* LoadLibrary(std::string_view path);
     /// <summary>
     /// Unloads a dynamic library from memory.
     /// </summary>
@@ -23,18 +23,18 @@ namespace TRAP::Utils::DynamicLoading
     /// <param name="name">Name of the function.</param>
     /// <returns>Pointer to the function.</returns>
     template<typename T>
-    T GetLibrarySymbol(void* module, const std::string& name);
+    T GetLibrarySymbol(void* module, const std::string_view name);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 template<typename T>
-inline T TRAP::Utils::DynamicLoading::GetLibrarySymbol(void* module, const std::string& name)
+inline T TRAP::Utils::DynamicLoading::GetLibrarySymbol(void* module, const std::string_view name)
 {
 #ifdef TRAP_PLATFORM_WINDOWS
-    return reinterpret_cast<T>(::GetProcAddress(static_cast<HMODULE>(module), name.c_str()));
+    return reinterpret_cast<T>(::GetProcAddress(static_cast<HMODULE>(module), name.data()));
 #elif defined(TRAP_PLATFORM_LINUX)
-    return reinterpret_cast<T>(dlsym(module, name.c_str()));
+    return reinterpret_cast<T>(dlsym(module, name.data()));
 #else
     return T();
 #endif

--- a/TRAP/src/Utils/Hash/Adler32.cpp
+++ b/TRAP/src/Utils/Hash/Adler32.cpp
@@ -30,7 +30,7 @@ std::array<uint8_t, 4> TRAP::Utils::Hash::Adler32(const void* data, uint64_t len
 	Memory::SwapBytes(adler32);
 
 	std::array<uint8_t, 4> result{};
-	memcpy(result.data(), &adler32, result.size());
+	std::copy_n(reinterpret_cast<const uint8_t*>(&adler32), result.size(), result.data());
 
 	return result;
 }

--- a/TRAP/src/Utils/Hash/CRC32.cpp
+++ b/TRAP/src/Utils/Hash/CRC32.cpp
@@ -632,7 +632,7 @@ std::array<uint8_t, 4> TRAP::Utils::Hash::CRC32(const void* data, uint64_t lengt
 	Memory::SwapBytes(crc);
 
 	std::array<uint8_t, 4> result{};
-	memcpy(result.data(), &crc, result.size());
+	std::copy_n(reinterpret_cast<const uint8_t*>(&crc), result.size(), result.data());
 
 	return result;
 }

--- a/TRAP/src/Utils/Hash/SHA-2.cpp
+++ b/TRAP/src/Utils/Hash/SHA-2.cpp
@@ -291,7 +291,7 @@ std::array<uint8_t, 32> TRAP::Utils::Hash::SHA2_256(const void* data, uint64_t l
 		total += bytes * 8;
 		dataPtr += bytes;
 	}
-	memcpy(&m[0] + pos, dataPtr, length);
+	std::copy_n(dataPtr, length, &m[0] + pos);
 	pos += length;
 	total += length * 8;
 
@@ -305,13 +305,13 @@ std::array<uint8_t, 32> TRAP::Utils::Hash::SHA2_256(const void* data, uint64_t l
 	memset(&m[0] + pos, 0, 56 - pos);
 	uint64_t mLength = total;
 	TRAP::Utils::Memory::SwapBytes<uint64_t>(mLength);
-	memcpy(&m[0] + (64 - 8), &mLength, 64 / 8);
+	std::copy_n(reinterpret_cast<uint8_t*>(&mLength), 64 / 8, &m[0] + (64 - 8));
 	Transform(&m[0], 1, hash);
 	for(uint32_t i = 0; i < 8; i++)
 		TRAP::Utils::Memory::SwapBytes<uint32_t>(hash[i]);
 
 	std::array<uint8_t, 32> result{};
-	memcpy(result.data(), hash.data(), result.size());
+	std::copy_n(reinterpret_cast<const uint8_t*>(hash.data()), result.size(), result.data());
 
 	return result;
 }
@@ -354,7 +354,7 @@ std::array<uint8_t, 64> TRAP::Utils::Hash::SHA2_512(const void* data, uint64_t l
 		total += bytes * 8;
 		dataPtr += bytes;
 	}
-	memcpy(&m[0] + pos, dataPtr, length);
+	std::copy_n(dataPtr, length, &m[0] + pos);
 	pos += length;
 	total += length * 8;
 
@@ -368,13 +368,13 @@ std::array<uint8_t, 64> TRAP::Utils::Hash::SHA2_512(const void* data, uint64_t l
 	memset(&m[0] + pos, 0, 128 - pos);
 	uint64_t mLength = total;
 	TRAP::Utils::Memory::SwapBytes<uint64_t>(mLength);
-	memcpy(&m[0] + (128 - 8), &mLength, 64 / 8);
+	std::copy_n(reinterpret_cast<const uint8_t*>(&mLength), 64 / 8, &m[0] + (128 - 8));
 	Transform(&m[0], 1, hash);
 	for (uint32_t i = 0; i < 8; i++)
 		TRAP::Utils::Memory::SwapBytes<uint64_t>(hash[i]);
 
 	std::array<uint8_t, 64> result{};
-	memcpy(result.data(), hash.data(), result.size());
+	std::copy_n(reinterpret_cast<const uint8_t*>(hash.data()), result.size(), result.data());
 
 	return result;
 }

--- a/TRAP/src/Utils/Hash/SHA-2.cpp
+++ b/TRAP/src/Utils/Hash/SHA-2.cpp
@@ -298,11 +298,11 @@ std::array<uint8_t, 32> TRAP::Utils::Hash::SHA2_256(const void* data, uint64_t l
 	m[pos++] = 0x80;
 	if(pos > 56)
 	{
-		memset(&m[0] + pos, 0, 64 - pos);
+		std::fill_n(m.data() + pos, 64 - pos, 0u);
 		Transform(&m[0], 1, hash);
 		pos = 0;
 	}
-	memset(&m[0] + pos, 0, 56 - pos);
+	std::fill_n(m.data() + pos, 56 - pos, 0u);
 	uint64_t mLength = total;
 	TRAP::Utils::Memory::SwapBytes<uint64_t>(mLength);
 	std::copy_n(reinterpret_cast<uint8_t*>(&mLength), 64 / 8, &m[0] + (64 - 8));
@@ -361,11 +361,11 @@ std::array<uint8_t, 64> TRAP::Utils::Hash::SHA2_512(const void* data, uint64_t l
 	m[pos++] = 0x80;
 	if(pos > 112)
 	{
-		memset(&m[0] + pos, 0, 128 - pos);
+		std::fill_n(m.data() + pos, 128 - pos, 0u);
 		Transform(&m[0], 1, hash);
 		pos = 0;
 	}
-	memset(&m[0] + pos, 0, 128 - pos);
+	std::fill_n(m.data() + pos, 128 - pos, 0u);
 	uint64_t mLength = total;
 	TRAP::Utils::Memory::SwapBytes<uint64_t>(mLength);
 	std::copy_n(reinterpret_cast<const uint8_t*>(&mLength), 64 / 8, &m[0] + (128 - 8));

--- a/TRAP/src/Utils/Hash/SHA-2.cpp
+++ b/TRAP/src/Utils/Hash/SHA-2.cpp
@@ -298,11 +298,11 @@ std::array<uint8_t, 32> TRAP::Utils::Hash::SHA2_256(const void* data, uint64_t l
 	m[pos++] = 0x80;
 	if(pos > 56)
 	{
-		std::fill_n(m.data() + pos, 64 - pos, 0u);
+		std::fill_n(m.data() + pos, 64 - pos, static_cast<uint8_t>(0u));
 		Transform(&m[0], 1, hash);
 		pos = 0;
 	}
-	std::fill_n(m.data() + pos, 56 - pos, 0u);
+	std::fill_n(m.data() + pos, 56 - pos, static_cast<uint8_t>(0u));
 	uint64_t mLength = total;
 	TRAP::Utils::Memory::SwapBytes<uint64_t>(mLength);
 	std::copy_n(reinterpret_cast<uint8_t*>(&mLength), 64 / 8, &m[0] + (64 - 8));
@@ -361,11 +361,11 @@ std::array<uint8_t, 64> TRAP::Utils::Hash::SHA2_512(const void* data, uint64_t l
 	m[pos++] = 0x80;
 	if(pos > 112)
 	{
-		std::fill_n(m.data() + pos, 128 - pos, 0u);
+		std::fill_n(m.data() + pos, 128 - pos, static_cast<uint8_t>(0u));
 		Transform(&m[0], 1, hash);
 		pos = 0;
 	}
-	std::fill_n(m.data() + pos, 128 - pos, 0u);
+	std::fill_n(m.data() + pos, 128 - pos, static_cast<uint8_t>(0u));
 	uint64_t mLength = total;
 	TRAP::Utils::Memory::SwapBytes<uint64_t>(mLength);
 	std::copy_n(reinterpret_cast<const uint8_t*>(&mLength), 64 / 8, &m[0] + (128 - 8));

--- a/TRAP/src/Utils/Hash/SHA-3.cpp
+++ b/TRAP/src/Utils/Hash/SHA-3.cpp
@@ -146,7 +146,7 @@ std::array<uint8_t, 32> TRAP::Utils::Hash::SHA3_256(const void* data, uint64_t l
 	pos += length;
 
 	m[pos++] = 0x06;
-	std::fill_n(m.data() + pos, r - pos, 0u);
+	std::fill_n(m.data() + pos, r - pos, static_cast<uint8_t>(0u));
 	m[r - 1] |= 0x80;
 	Transform(m.data(), 1, A, rate);
 
@@ -187,7 +187,7 @@ std::array<uint8_t, 64> TRAP::Utils::Hash::SHA3_512(const void* data, uint64_t l
 	pos += length;
 
 	m[pos++] = 0x06;
-	std::fill_n(m.data() + pos, r - pos, 0u);
+	std::fill_n(m.data() + pos, r - pos, static_cast<uint8_t>(0u));
 	m[r - 1] |= 0x80;
 	Transform(m.data(), 1, A, rate);
 

--- a/TRAP/src/Utils/Hash/SHA-3.cpp
+++ b/TRAP/src/Utils/Hash/SHA-3.cpp
@@ -146,7 +146,7 @@ std::array<uint8_t, 32> TRAP::Utils::Hash::SHA3_256(const void* data, uint64_t l
 	pos += length;
 
 	m[pos++] = 0x06;
-	memset(m.data() + pos, 0, r - pos);
+	std::fill_n(m.data() + pos, r - pos, 0u);
 	m[r - 1] |= 0x80;
 	Transform(m.data(), 1, A, rate);
 
@@ -187,7 +187,7 @@ std::array<uint8_t, 64> TRAP::Utils::Hash::SHA3_512(const void* data, uint64_t l
 	pos += length;
 
 	m[pos++] = 0x06;
-	memset(m.data() + pos, 0, r - pos);
+	std::fill_n(m.data() + pos, r - pos, 0u);
 	m[r - 1] |= 0x80;
 	Transform(m.data(), 1, A, rate);
 

--- a/TRAP/src/Utils/Hash/SHA-3.cpp
+++ b/TRAP/src/Utils/Hash/SHA-3.cpp
@@ -14,7 +14,7 @@ constexpr std::array<uint64_t, 24> RC =
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-template<class T> T Rotatel64(T x, int64_t y)
+template<class T> T Rotatel64(const T x, const int64_t y)
 {
 	static const uint32_t thisSize = sizeof(T) * 8;
 	static const uint32_t mask = thisSize - 1;

--- a/TRAP/src/Utils/Hash/SHA-3.cpp
+++ b/TRAP/src/Utils/Hash/SHA-3.cpp
@@ -131,7 +131,6 @@ std::array<uint8_t, 32> TRAP::Utils::Hash::SHA3_256(const void* data, uint64_t l
 	std::array<uint8_t, rate / 8> m{};
 	std::size_t pos = 0;
 	std::array<uint64_t, 25> A{};
-	memset(A.data(), 0, A.size());
 
 	const uint8_t* dataPtr = static_cast<const uint8_t*>(data);
 	constexpr std::size_t r = rate / 8;
@@ -173,7 +172,6 @@ std::array<uint8_t, 64> TRAP::Utils::Hash::SHA3_512(const void* data, uint64_t l
 	std::array<uint8_t, rate / 8> m{};
 	std::size_t pos = 0;
 	std::array<uint64_t, 25> A{};
-	memset(A.data(), 0, A.size());
 
 	const uint8_t* dataPtr = static_cast<const uint8_t*>(data);
 	constexpr std::size_t r = rate / 8;

--- a/TRAP/src/Utils/Hash/SHA-3.cpp
+++ b/TRAP/src/Utils/Hash/SHA-3.cpp
@@ -143,7 +143,7 @@ std::array<uint8_t, 32> TRAP::Utils::Hash::SHA3_256(const void* data, uint64_t l
 		length -= bytes;
 		dataPtr += bytes;
 	}
-	memcpy(m.data() + pos, dataPtr, length);
+	std::copy_n(dataPtr, length, m.data() + pos);
 	pos += length;
 
 	m[pos++] = 0x06;
@@ -152,7 +152,7 @@ std::array<uint8_t, 32> TRAP::Utils::Hash::SHA3_256(const void* data, uint64_t l
 	Transform(m.data(), 1, A, rate);
 
 	std::array<uint8_t, hs / 8> result{};
-	memcpy(result.data(), A.data(), result.size());
+	std::copy_n(reinterpret_cast<const uint8_t*>(A.data()), result.size(), result.data());
 
 	return result;
 }
@@ -185,7 +185,7 @@ std::array<uint8_t, 64> TRAP::Utils::Hash::SHA3_512(const void* data, uint64_t l
 		length -= bytes;
 		dataPtr += bytes;
 	}
-	memcpy(m.data() + pos, dataPtr, length);
+	std::copy_n(dataPtr, length, m.data() + pos);
 	pos += length;
 
 	m[pos++] = 0x06;
@@ -194,7 +194,7 @@ std::array<uint8_t, 64> TRAP::Utils::Hash::SHA3_512(const void* data, uint64_t l
 	Transform(m.data(), 1, A, rate);
 
 	std::array<uint8_t, hs / 8> result{};
-	memcpy(result.data(), A.data(), result.size());
+	std::copy_n(reinterpret_cast<const uint8_t*>(A.data()), result.size(), result.data());
 
 	return result;
 }

--- a/TRAP/src/Utils/Profiler/Instrumentor.cpp
+++ b/TRAP/src/Utils/Profiler/Instrumentor.cpp
@@ -113,8 +113,8 @@ void TRAP::Utils::Debug::Instrumentor::InternalEndSession()
 //-------------------------------------------------------------------------------------------------------------------//
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Utils::Debug::InstrumentationTimer::InstrumentationTimer(const char* name)
-	: m_name(name), m_stopped(false)
+TRAP::Utils::Debug::InstrumentationTimer::InstrumentationTimer(const std::string name)
+	: m_name(std::move(name)), m_stopped(false)
 {
 	m_startTimePoint = std::chrono::steady_clock::now();
 }

--- a/TRAP/src/Utils/Profiler/Instrumentor.h
+++ b/TRAP/src/Utils/Profiler/Instrumentor.h
@@ -78,7 +78,7 @@ namespace TRAP::Utils::Debug
 		/// Begin a new profiling session.
 		/// </summary>
 		/// <param name="name">Name for the new session.</param>
-		/// <param name="filePath">Non-VFS file path for the new session.</param>
+		/// <param name="filePath">File path for the new session.</param>
 		void BeginSession(const std::string& name, const std::string& filePath = "results.json");
 		/// <summary>
 		/// End current profiling session.

--- a/TRAP/src/Utils/Profiler/Instrumentor.h
+++ b/TRAP/src/Utils/Profiler/Instrumentor.h
@@ -120,7 +120,7 @@ namespace TRAP::Utils::Debug
 		/// Constructor.
 		/// </summary>
 		/// <param name="name">Name of the function to profile.</param>
-		explicit InstrumentationTimer(const char* name);
+		explicit InstrumentationTimer(const std::string name);
 
 		/// <summary>
 		/// Destructor.
@@ -150,7 +150,7 @@ namespace TRAP::Utils::Debug
 		void Stop();
 
 	private:
-		const char* m_name = nullptr;
+		std::string m_name = nullptr;
 		std::chrono::time_point<std::chrono::steady_clock> m_startTimePoint;
 		bool m_stopped;
 	};

--- a/TRAP/src/Utils/Random/Random.h
+++ b/TRAP/src/Utils/Random/Random.h
@@ -138,7 +138,7 @@ namespace TRAP::Utils
         /// </summary>
         static void Reseed()
     	{
-            Seeder seeder;
+            const Seeder seeder;
             Seed(seeder());
         }
 
@@ -551,7 +551,7 @@ namespace TRAP::Utils
         /// </summary>
         static void Reseed()
         {
-            Seeder seeder;
+            const Seeder seeder;
             Seed(seeder());
         }
 
@@ -933,7 +933,7 @@ namespace TRAP::Utils
         /// </summary>
         void Reseed()
     	{
-            Seeder seeder;
+            const Seeder seeder;
             Seed(seeder());
         }
 

--- a/TRAP/src/Utils/String/String.cpp
+++ b/TRAP/src/Utils/String/String.cpp
@@ -90,9 +90,9 @@ std::vector<std::string> TRAP::Utils::String::GetLines(const std::string& str)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Utils::String::FindToken(const char* str, const std::string_view token)
+const char* TRAP::Utils::String::FindToken(const std::string_view str, const std::string_view token)
 {
-	const char* t = strstr(str, token.data());
+	const char* t = strstr(str.data(), token.data());
 	while (t)
 	{
 		const bool left = str == t || isspace(t[-1]);
@@ -104,13 +104,6 @@ const char* TRAP::Utils::String::FindToken(const char* str, const std::string_vi
 		t = strstr(t, token.data());
 	}
 	return nullptr;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-const char* TRAP::Utils::String::FindToken(const std::string_view str, const std::string_view token)
-{
-	return FindToken(str.data(), token);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Utils/String/String.cpp
+++ b/TRAP/src/Utils/String/String.cpp
@@ -199,7 +199,7 @@ std::string TRAP::Utils::String::GetTimeStamp(const std::chrono::time_point<std:
 #endif
 
 	char buffer[9];
-	std::memset(buffer, 0, sizeof(buffer));
+	memset(buffer, 0, sizeof(buffer));
 	std::strftime(buffer, sizeof(buffer), "%T", &tm);
 
 	return buffer;
@@ -219,7 +219,7 @@ std::string TRAP::Utils::String::GetDateTimeStamp(const std::chrono::time_point<
 #endif
 
 	char buffer[20];
-	std::memset(buffer, 0, sizeof(buffer));
+	memset(buffer, 0, sizeof(buffer));
 	std::strftime(buffer, sizeof(buffer), "%F %T", &tm);
 
 	return buffer;

--- a/TRAP/src/Utils/String/String.cpp
+++ b/TRAP/src/Utils/String/String.cpp
@@ -52,7 +52,7 @@ std::vector<std::string> TRAP::Utils::String::SplitString(const std::string& str
 
 	while (end <= std::string::npos)
 	{
-		std::string token = str.substr(start, end - start);
+		const std::string token = str.substr(start, end - start);
 
 		if (!token.empty())
 			result.push_back(token);
@@ -164,7 +164,7 @@ bool TRAP::Utils::String::CompareAnyCase(const std::string_view left, const std:
 
 std::string TRAP::Utils::String::GetTimeStamp(const std::chrono::time_point<std::chrono::system_clock>& timePoint)
 {
-	std::time_t time = std::chrono::system_clock::to_time_t(timePoint);
+	const std::time_t time = std::chrono::system_clock::to_time_t(timePoint);
 
 	std::tm tm{};
 #ifdef TRAP_PLATFORM_WINDOWS
@@ -183,7 +183,7 @@ std::string TRAP::Utils::String::GetTimeStamp(const std::chrono::time_point<std:
 
 std::string TRAP::Utils::String::GetDateTimeStamp(const std::chrono::time_point<std::chrono::system_clock>& dateTimePoint)
 {
-	std::time_t time = std::chrono::system_clock::to_time_t(dateTimePoint);
+	const std::time_t time = std::chrono::system_clock::to_time_t(dateTimePoint);
 
 	std::tm tm{};
 #ifdef TRAP_PLATFORM_WINDOWS
@@ -197,3 +197,29 @@ std::string TRAP::Utils::String::GetDateTimeStamp(const std::chrono::time_point<
 
 	return std::string(buffer.begin(), buffer.end());
 }
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+#ifdef TRAP_PLATFORM_LINUX
+std::string TRAP::Utils::String::GetStrError()
+{
+    std::string error(1024, '\0');
+    #if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
+        strerror_r(errno, error.data(), error.size());
+        //Remove trailing terminating null characters
+        error.resize(error.find('\0'));
+        return error;
+    #else
+        char* errorCStr = strerror_r(errno, error.data(), error.size());
+        return std::string(errorCStr);
+    #endif
+
+    return "";
+}
+#elif defined(TRAP_PLATFORM_WINDOWS)
+std::string TRAP::Utils::String::GetStrError()
+{
+	//TODO Use GetLastError?
+	return "";
+}
+#endif

--- a/TRAP/src/Utils/String/String.cpp
+++ b/TRAP/src/Utils/String/String.cpp
@@ -90,24 +90,6 @@ std::vector<std::string> TRAP::Utils::String::GetLines(const std::string& str)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::Utils::String::FindToken(const std::string_view str, const std::string_view token)
-{
-	const char* t = strstr(str.data(), token.data());
-	while (t)
-	{
-		const bool left = str == t || isspace(t[-1]);
-		const bool right = !t[token.size()] || isspace(t[token.size()]);
-		if (left && right)
-			return t;
-
-		t += token.size();
-		t = strstr(t, token.data());
-	}
-	return nullptr;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 bool TRAP::Utils::String::StartsWith(const std::string_view str, const std::string_view start)
 {
 	return str.find(start) == 0;

--- a/TRAP/src/Utils/String/String.cpp
+++ b/TRAP/src/Utils/String/String.cpp
@@ -52,7 +52,7 @@ std::vector<std::string> TRAP::Utils::String::SplitString(const std::string& str
 
 	while (end <= std::string::npos)
 	{
-		std::string token = std::string(str.substr(start, end - start));
+		std::string token = str.substr(start, end - start);
 
 		if (!token.empty())
 			result.push_back(token);

--- a/TRAP/src/Utils/String/String.cpp
+++ b/TRAP/src/Utils/String/String.cpp
@@ -198,11 +198,10 @@ std::string TRAP::Utils::String::GetTimeStamp(const std::chrono::time_point<std:
 	localtime_r(&time, &tm);
 #endif
 
-	char buffer[9];
-	memset(buffer, 0, sizeof(buffer));
-	std::strftime(buffer, sizeof(buffer), "%T", &tm);
+	std::array<char, 9> buffer{};
+	strftime(buffer.data(), buffer.size(), "%T", &tm);
 
-	return buffer;
+	return std::string(buffer.begin(), buffer.end());
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -218,9 +217,8 @@ std::string TRAP::Utils::String::GetDateTimeStamp(const std::chrono::time_point<
 	localtime_r(&time, &tm);
 #endif
 
-	char buffer[20];
-	memset(buffer, 0, sizeof(buffer));
-	std::strftime(buffer, sizeof(buffer), "%F %T", &tm);
+	std::array<char, 20> buffer{};
+	strftime(buffer.data(), buffer.size(), "%F %T", &tm);
 
-	return buffer;
+	return std::string(buffer.begin(), buffer.end());
 }

--- a/TRAP/src/Utils/String/String.h
+++ b/TRAP/src/Utils/String/String.h
@@ -55,13 +55,6 @@ namespace TRAP::Utils::String
 	/// <summary>
 	/// Find a token in a string.
 	/// </summary>
-	/// <param name="str">String to query.</param>
-	/// <param name="token">Token to find in string.</param>
-	/// <returns>If found string starting on first occurrence of the token, nullptr otherwise.</returns>
-	const char* FindToken(const char* str, std::string_view token);
-	/// <summary>
-	/// Find a token in a string.
-	/// </summary>
 	/// <param name="string">String to query.</param>
 	/// <param name="token">Token to find in string.</param>
 	/// <returns>If found string starting on first occurrence of the token, nullptr otherwise.</returns>

--- a/TRAP/src/Utils/String/String.h
+++ b/TRAP/src/Utils/String/String.h
@@ -53,16 +53,6 @@ namespace TRAP::Utils::String
 	//-------------------------------------------------------------------------------------------------------------------//
 
 	/// <summary>
-	/// Find a token in a string.
-	/// </summary>
-	/// <param name="string">String to query.</param>
-	/// <param name="token">Token to find in string.</param>
-	/// <returns>If found string starting on first occurrence of the token, nullptr otherwise.</returns>
-	const char* FindToken(std::string_view str, std::string_view token);
-
-	//-------------------------------------------------------------------------------------------------------------------//
-
-	/// <summary>
 	/// Check if a string starts with contents another string or char.
 	/// </summary>
 	/// <param name="string">String to check.</param>

--- a/TRAP/src/Utils/String/String.h
+++ b/TRAP/src/Utils/String/String.h
@@ -146,6 +146,14 @@ namespace TRAP::Utils::String
 	/// <param name="timePoint">Timestamp to convert.</param>
 	/// <returns>Timestamp as string.</returns>
 	std::string GetDateTimeStamp(const std::chrono::time_point<std::chrono::system_clock>& timePoint);
+
+	//-------------------------------------------------------------------------------------------------------------------//
+
+	/// <summary>
+	/// Retrieve the last set OS error message.
+	/// </summary>
+	/// <returns>Last OS error message.</returns>
+	std::string GetStrError();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Utils/String/String.inl
+++ b/TRAP/src/Utils/String/String.inl
@@ -233,7 +233,7 @@ inline TRAP::Window::DisplayMode TRAP::Utils::String::ConvertToType<TRAP::Window
 {
 	if (Utils::String::CompareAnyCase("Windowed", input))
 		return Window::DisplayMode::Windowed;
-	if (Utils::String::CompareAnyCase("Borderless", input))
+	if (Utils::String::CompareAnyCase("Fullscreen (Borderless)", input))
 		return Window::DisplayMode::Borderless;
 	if (Utils::String::CompareAnyCase("Fullscreen", input))
 		return Window::DisplayMode::Fullscreen;
@@ -294,6 +294,20 @@ inline TRAP::Graphics::RendererAPI::SampleCount TRAP::Utils::String::ConvertToTy
 
 	TP_ERROR(TRAP::Log::ConfigPrefix, "Exception while converting string to TRAP::Graphics::RendererAPI::SampleCount!");
 	return Graphics::RendererAPI::SampleCount::One;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+template<>
+inline TRAP::Utils::LinuxWindowManager TRAP::Utils::String::ConvertToType<TRAP::Utils::LinuxWindowManager>(const std::string& input)
+{
+	if(Utils::String::CompareAnyCase("X11", input))
+		return Utils::LinuxWindowManager::X11;
+
+	if(Utils::String::CompareAnyCase("Wayland", input))
+		return Utils::LinuxWindowManager::Wayland;
+
+	return Utils::LinuxWindowManager::Unknown;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -422,7 +436,7 @@ inline std::string TRAP::Utils::String::ConvertToString<TRAP::Window::DisplayMod
 		return "Windowed";
 
 	case Window::DisplayMode::Borderless:
-		return "Borderless";
+		return "Fullscreen (Borderless)";
 
 	case Window::DisplayMode::Fullscreen:
 		return "Fullscreen";
@@ -492,6 +506,24 @@ inline std::string TRAP::Utils::String::ConvertToString<TRAP::Graphics::Renderer
 
 	default:
 		return "";
+	}
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+template<>
+inline std::string TRAP::Utils::String::ConvertToString<TRAP::Utils::LinuxWindowManager>(const Utils::LinuxWindowManager value)
+{
+	switch(value)
+	{
+	case LinuxWindowManager::X11:
+		return "X11";
+
+	case LinuxWindowManager::Wayland:
+		return "Wayland";
+
+	default:
+		return "Unknown";
 	}
 }
 

--- a/TRAP/src/Utils/Utils.cpp
+++ b/TRAP/src/Utils/Utils.cpp
@@ -134,9 +134,9 @@ const TRAP::Utils::CPUInfo& TRAP::Utils::GetCPUInfo()
 	std::array<uint32_t, 4> regs = CPUID(0, 0);
 	const uint32_t HFS = regs[0];
 	//Get Vendor
-	const std::string vendorID = std::string(reinterpret_cast<const char*>(&regs[1]), 4) +
-		                         std::string(reinterpret_cast<const char*>(&regs[3]), 4) +
-		                         std::string(reinterpret_cast<const char*>(&regs[2]), 4);
+	const std::string vendorID = std::string(reinterpret_cast<char*>(&regs[1]), sizeof(uint32_t)) +
+		                         std::string(reinterpret_cast<char*>(&regs[3]), sizeof(uint32_t)) +
+		                         std::string(reinterpret_cast<char*>(&regs[2]), sizeof(uint32_t));
 	regs = CPUID(1, 0);
 	cpu.HyperThreaded = regs[3] & 0x10000000; //Get Hyper-threading
 
@@ -241,10 +241,10 @@ const TRAP::Utils::CPUInfo& TRAP::Utils::GetCPUInfo()
 	for (uint32_t i = 0x80000002; i < 0x80000005; ++i)
 	{
 		std::array<uint32_t, 4> regs1 = CPUID(i, 0);
-		cpu.Model += std::string(reinterpret_cast<const char*>(&regs1[0]), 4);
-		cpu.Model += std::string(reinterpret_cast<const char*>(&regs1[1]), 4);
-		cpu.Model += std::string(reinterpret_cast<const char*>(&regs1[2]), 4);
-		cpu.Model += std::string(reinterpret_cast<const char*>(&regs1[3]), 4);
+		cpu.Model += std::string(reinterpret_cast<const char*>(&regs1[0]), sizeof(uint32_t));
+		cpu.Model += std::string(reinterpret_cast<const char*>(&regs1[1]), sizeof(uint32_t));
+		cpu.Model += std::string(reinterpret_cast<const char*>(&regs1[2]), sizeof(uint32_t));
+		cpu.Model += std::string(reinterpret_cast<const char*>(&regs1[3]), sizeof(uint32_t));
 	}
 
 	uint32_t lastAlphaChar = 0;

--- a/TRAP/src/Utils/Utils.cpp
+++ b/TRAP/src/Utils/Utils.cpp
@@ -47,7 +47,7 @@ std::array<uint8_t, 16> TRAP::Utils::UUIDFromString(const std::string_view uuid)
 		return {};
 
 	std::array<uint8_t, 16> result{};
-	for (uint8_t i : uuid)
+	for (const uint8_t i : uuid)
 	{
 		if (i == '-')
 			continue;
@@ -96,8 +96,8 @@ std::array<uint8_t, 16> TRAP::Utils::UUIDFromString(const std::string_view uuid)
 TRAP::Utils::Endian TRAP::Utils::GetEndian()
 {
 	//Check if machine is using little-endian or big-endian
-	int32_t intVal = 1;
-	uint8_t* uVal = reinterpret_cast<uint8_t*>(&intVal);
+	const int32_t intVal = 1;
+	const uint8_t* uVal = reinterpret_cast<const uint8_t*>(&intVal);
 #if __cpp_lib_endian
 	static Endian endian = static_cast<Endian>(std::endian::native == std::endian::little);
 #else
@@ -151,7 +151,7 @@ const TRAP::Utils::CPUInfo& TRAP::Utils::GetCPUInfo()
 			int32_t numSMT = 0;
 			for (int32_t lvl = 0; lvl < MAX_INTEL_TOP_LVL; ++lvl)
 			{
-				std::array<uint32_t, 4> regs1 = CPUID(0x0B, lvl);
+				const std::array<uint32_t, 4> regs1 = CPUID(0x0B, lvl);
 				const uint32_t currentLevel = (LVL_TYPE & regs1[2]) >> 8;
 				switch (currentLevel)
 				{
@@ -176,7 +176,7 @@ const TRAP::Utils::CPUInfo& TRAP::Utils::GetCPUInfo()
 				cpu.LogicalCores = (regs[1] >> 16) & 0xFF;
 				if (HFS >= 4)
 				{
-					std::array<uint32_t, 4> regs1 = CPUID(4, 0);
+					const std::array<uint32_t, 4> regs1 = CPUID(4, 0);
 					cpu.Cores = (1 + (regs1[0] >> 26)) & 0x3F;
 				}
 			}
@@ -270,14 +270,14 @@ TRAP::Utils::LinuxWindowManager TRAP::Utils::GetLinuxWindowManager()
 	if(windowManager != LinuxWindowManager::Unknown)
 		return windowManager;
 
-	std::string wl = "wayland";
-	std::string x = "x11";
+	const std::string wl = "wayland";
+	const std::string x = "x11";
 	std::string session;
-	if(std::getenv("XDG_SESSION_TYPE"))
-		session = std::getenv("XDG_SESSION_TYPE");
-	if (std::getenv("WAYLAND_DISPLAY") || session == wl)
+	if(getenv("XDG_SESSION_TYPE"))
+		session = getenv("XDG_SESSION_TYPE");
+	if (getenv("WAYLAND_DISPLAY") || session == wl)
 		windowManager = LinuxWindowManager::Wayland;
-	else if (std::getenv("DISPLAY") || session == x)
+	else if (getenv("DISPLAY") || session == x)
 		windowManager = LinuxWindowManager::X11;
 	else
 	{
@@ -299,40 +299,3 @@ TRAP::Utils::LinuxWindowManager TRAP::Utils::GetLinuxWindowManager()
 
 	return windowManager;
 }
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-std::string TRAP::Utils::LinuxWindowManagerToString(const TRAP::Utils::LinuxWindowManager lwm)
-{
-	switch(lwm)
-	{
-	case LinuxWindowManager::X11:
-		return "X11";
-
-	case LinuxWindowManager::Wayland:
-		return "Wayland";
-
-	default:
-		return "Unknown";
-	}
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-#ifdef TRAP_PLATFORM_LINUX
-std::string TRAP::Utils::GetStrError()
-{
-    std::string error(1024, '\0');
-    #if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
-        strerror_r(errno, error.data(), error.size());
-        //Remove trailing terminating null characters
-        error.resize(error.find('\0'));
-        return error;
-    #else
-        char* errorCStr = strerror_r(errno, error.data(), error.size());
-        return std::string(errorCStr);
-    #endif
-
-    return "";
-}
-#endif

--- a/TRAP/src/Utils/Utils.h
+++ b/TRAP/src/Utils/Utils.h
@@ -4,7 +4,6 @@
 #include <array>
 #include <string>
 #include <type_traits>
-#include <bit>
 
 namespace TRAP::Utils
 {

--- a/TRAP/src/Utils/Utils.h
+++ b/TRAP/src/Utils/Utils.h
@@ -3,6 +3,8 @@
 
 #include <array>
 #include <string>
+#include <type_traits>
+#include <bit>
 
 namespace TRAP::Utils
 {
@@ -103,6 +105,21 @@ namespace TRAP::Utils
 	/// </summary>
 	/// <returns>errno string.</returns>
 	std::string GetStrError();
+#endif
+
+#ifdef __cpp_lib_bit_cast
+	using BitCast = std::bit_cast;
+#else
+	template<typename From, typename To>
+	inline typename std::enable_if<std::integral_constant<bool, (sizeof(From) == sizeof(To)) &&
+	                                                            std::is_trivially_copyable<From>::value &&
+																std::is_trivially_copyable<To>::value>::value, To>::type
+	BitCast(const From& from) noexcept
+	{
+		union U{U(){}; char storage[sizeof(To)]; typename std::remove_const<To>::type dest;} u; //Instead of To dest; because To doesn't require DefaultConstructible.
+		memcpy(&u.dest, &from, sizeof(from));
+		return u.dest;
+	}
 #endif
 }
 

--- a/TRAP/src/Utils/Utils.h
+++ b/TRAP/src/Utils/Utils.h
@@ -33,7 +33,7 @@ namespace TRAP::Utils
 	template<typename T, typename... Rest>
 	constexpr void HashCombine(std::size_t& seed, const T& v, Rest... rest)
 	{
-		std::hash<T> hasher;
+		const std::hash<T> hasher;
 		seed ^= hasher(v) + 0x9E3779B9 + (seed << 6) + (seed >> 2);
 		HashCombine(seed, rest...);
 	}
@@ -90,21 +90,6 @@ namespace TRAP::Utils
 	/// is not Linux based Windows).
 	/// </returns>
 	LinuxWindowManager GetLinuxWindowManager();
-
-	/// <summary>
-	/// Get a string representation of the Linux window manager.
-	/// </summary>
-	/// <param name="lwm">LinuxWindowManager to convert to a string.</param>
-	/// <returns>String representation.</returns>
-	std::string LinuxWindowManagerToString(LinuxWindowManager lwm);
-
-#ifdef TRAP_PLATFORM_LINUX
-	/// <summary>
-	/// Retrieve the errno string in a thread safe way.
-	/// </summary>
-	/// <returns>errno string.</returns>
-	std::string GetStrError();
-#endif
 
 #ifdef __cpp_lib_bit_cast
 	using BitCast = std::bit_cast;

--- a/TRAP/src/Window/Monitor.cpp
+++ b/TRAP/src/Window/Monitor.cpp
@@ -1,13 +1,6 @@
 #include "TRAPPCH.h"
 #include "Monitor.h"
 
-TRAP::Monitor::VideoMode::VideoMode(const int32_t width, const int32_t height, const int32_t refreshRate)
-	: Width(width), Height(height), RefreshRate(refreshRate)
-{
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 TRAP::Monitor::Monitor(const uint32_t monitor)
 {
 	TP_PROFILE_FUNCTION();
@@ -36,13 +29,6 @@ std::vector<TRAP::Monitor::VideoMode> TRAP::Monitor::GetVideoModes() const
 		modes.emplace_back(i->Width, i->Height, i->RefreshRate);
 
 	return modes;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-TRAP::Monitor::VideoMode TRAP::Monitor::GetCurrentVideoMode() const
-{
-	return VideoMode{ m_handle->CurrentMode.Width, m_handle->CurrentMode.Height, m_handle->CurrentMode.RefreshRate };
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -104,7 +90,8 @@ TRAP::Math::Vec4i TRAP::Monitor::GetWorkArea() const
 	TP_PROFILE_FUNCTION();
 
 	TRAP::Math::Vec4i workArea{};
-	INTERNAL::WindowingAPI::GetMonitorWorkArea(m_handle, workArea.x, workArea.y, workArea.z, workArea.w);
+	INTERNAL::WindowingAPI::GetMonitorWorkArea(m_handle, workArea.x, workArea.y,
+	                                           workArea.z, workArea.w);
 
 	return workArea;
 }
@@ -139,13 +126,6 @@ int32_t TRAP::Monitor::GetWorkAreaY() const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::Monitor::IsInUse() const
-{
-	return m_handle->Window;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 uint32_t TRAP::Monitor::GetID() const
 {
 	TP_PROFILE_FUNCTION();
@@ -158,13 +138,6 @@ uint32_t TRAP::Monitor::GetID() const
 	}
 
 	return 0; //Primary Monitor as fallback
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-void* TRAP::Monitor::GetInternalMonitor() const
-{
-	return m_handle;
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Window/Monitor.cpp
+++ b/TRAP/src/Window/Monitor.cpp
@@ -11,7 +11,7 @@ TRAP::Monitor::Monitor(const uint32_t monitor)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Monitor::GetName() const
+std::string TRAP::Monitor::GetName() const
 {
 	return m_handle->Name;
 }

--- a/TRAP/src/Window/Monitor.cpp
+++ b/TRAP/src/Window/Monitor.cpp
@@ -5,7 +5,7 @@ TRAP::Monitor::Monitor(const uint32_t monitor)
 {
 	TP_PROFILE_FUNCTION();
 
-	std::vector<INTERNAL::WindowingAPI::InternalMonitor*> monitors = INTERNAL::WindowingAPI::GetMonitors();
+	const std::vector<INTERNAL::WindowingAPI::InternalMonitor*> monitors = INTERNAL::WindowingAPI::GetMonitors();
 	m_handle = monitors[monitor];
 }
 
@@ -130,7 +130,7 @@ uint32_t TRAP::Monitor::GetID() const
 {
 	TP_PROFILE_FUNCTION();
 
-	std::vector<INTERNAL::WindowingAPI::InternalMonitor*> monitors = INTERNAL::WindowingAPI::GetMonitors();
+	const std::vector<INTERNAL::WindowingAPI::InternalMonitor*> monitors = INTERNAL::WindowingAPI::GetMonitors();
 	for(uint32_t i = 0; i < monitors.size(); i++)
 	{
 		if (monitors[i] == m_handle)

--- a/TRAP/src/Window/Monitor.h
+++ b/TRAP/src/Window/Monitor.h
@@ -23,12 +23,34 @@ namespace TRAP
 			/// <param name="width">Width.</param>
 			/// <param name="height">Height.</param>
 			/// <param name="refreshRate">Refresh rate.</param>
-			VideoMode(int32_t width, int32_t height, int32_t refreshRate);
+			constexpr VideoMode(int32_t width, int32_t height, int32_t refreshRate);
 
 			int32_t Width = 0;
 			int32_t Height = 0;
 			int32_t RefreshRate = 0;
 		};
+
+
+		/// <summary>
+		/// Destructor.
+		/// </summary>
+		~Monitor() = default;
+		/// <summary>
+		/// Copy constructor.
+		/// </summary>
+		Monitor(const Monitor&) = default;
+		/// <summary>
+		/// Copy assignment operator.
+		/// </summary>
+		Monitor& operator=(const Monitor&) = default;
+		/// <summary>
+		/// Move constructor.
+		/// </summary>
+		Monitor(Monitor&&) = default;
+		/// <summary>
+		/// Move assignment operator.
+		/// </summary>
+		Monitor& operator=(Monitor&&) = default;
 
 		/// <summary>
 		/// Retrieve the name of a monitor.
@@ -44,7 +66,7 @@ namespace TRAP
 		/// Retrieve the current video mode.
 		/// </summary>
 		/// <returns>Current video mode</returns>
-		VideoMode GetCurrentVideoMode() const;
+		constexpr VideoMode GetCurrentVideoMode() const;
 		/// <summary>
 		/// Retrieve the monitors content scale.
 		/// </summary>
@@ -106,7 +128,7 @@ namespace TRAP
 		/// Check whether the monitor is currently used by a window.
 		/// </summary>
 		/// <returns>True if monitor is currently used, false otherwise.</returns>
-		bool IsInUse() const;
+		constexpr bool IsInUse() const;
 		/// <summary>
 		/// Retrieve the monitors ID.
 		///
@@ -119,7 +141,7 @@ namespace TRAP
 		/// Retrieve a pointer to the internal monitor.
 		/// </summary>
 		/// <returns>Pointer to the internal monitor of the Monitor.</returns>
-		void* GetInternalMonitor() const;
+		constexpr void* GetInternalMonitor() const;
 
 		/// <summary>
 		/// Retrieve all currently connected monitors.
@@ -143,6 +165,34 @@ namespace TRAP
 
 		friend TRAP::Monitor TRAP::Window::GetMonitor() const;
 	};
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Monitor::VideoMode::VideoMode(const int32_t width, const int32_t height, const int32_t refreshRate)
+	: Width(width), Height(height), RefreshRate(refreshRate)
+{}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr TRAP::Monitor::VideoMode TRAP::Monitor::GetCurrentVideoMode() const
+{
+	return VideoMode{ m_handle->CurrentMode.Width, m_handle->CurrentMode.Height,
+	                  m_handle->CurrentMode.RefreshRate };
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr bool TRAP::Monitor::IsInUse() const
+{
+	return m_handle->Window;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+constexpr void* TRAP::Monitor::GetInternalMonitor() const
+{
+	return m_handle;
 }
 
 #endif /*TRAP_MONITOR_H*/

--- a/TRAP/src/Window/Monitor.h
+++ b/TRAP/src/Window/Monitor.h
@@ -56,7 +56,7 @@ namespace TRAP
 		/// Retrieve the name of a monitor.
 		/// </summary>
 		/// <returns>Name of the monitor.</returns>
-		const std::string& GetName() const;
+		std::string GetName() const;
 		/// <summary>
 		/// Retrieve a list of available video modes for the monitor.
 		/// </summary>

--- a/TRAP/src/Window/Window.cpp
+++ b/TRAP/src/Window/Window.cpp
@@ -90,7 +90,7 @@ uint32_t TRAP::Window::GetActiveWindows() noexcept
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const std::string& TRAP::Window::GetTitle() const noexcept
+std::string TRAP::Window::GetTitle() const noexcept
 {
 	return m_data.Title;
 }

--- a/TRAP/src/Window/Window.cpp
+++ b/TRAP/src/Window/Window.cpp
@@ -1,4 +1,5 @@
 #include "TRAPPCH.h"
+#include "Utils/String/String.h"
 #include "Window.h"
 
 #include "Core/PlatformDetection.h"
@@ -224,7 +225,7 @@ void TRAP::Window::SetTitle(const std::string& title)
 						   "." + std::to_string(TRAP_VERSION_PATCH(TRAP_VERSION)) +
 		                   "[INDEV]" + Log::WindowVersion + Graphics::Renderer::GetTitle();
 #ifdef TRAP_PLATFORM_LINUX
-		newTitle += "[" + Utils::LinuxWindowManagerToString(Utils::GetLinuxWindowManager()) + "]";
+		newTitle += "[" + Utils::String::ConvertToString(Utils::GetLinuxWindowManager()) + "]";
 #endif
 	//Add additional information to the given title for non release builds
 	INTERNAL::WindowingAPI::SetWindowTitle(m_window.get(), newTitle);
@@ -239,14 +240,6 @@ void TRAP::Window::SetTitle(const std::string& title)
 void TRAP::Window::SetDisplayMode(const DisplayMode& mode, uint32_t width, uint32_t height, uint32_t refreshRate)
 {
 	TP_PROFILE_FUNCTION();
-
-	constexpr auto GetModeStr = [&](const DisplayMode displayMode)
-	{
-		if (displayMode == DisplayMode::Windowed)
-			return "Windowed";
-
-		return displayMode == DisplayMode::Borderless ? "Borderless" : "Fullscreen";
-	}; //Little hack to convert enum class DisplayMode to string
 
 	if(mode == DisplayMode::Windowed) //Check if new mode will also be windowed
 	{
@@ -332,8 +325,9 @@ void TRAP::Window::SetDisplayMode(const DisplayMode& mode, uint32_t width, uint3
 			if(s_fullscreenWindows[m_data.Monitor] != this)
 			{
 				TP_ERROR(Log::WindowPrefix, "\"", m_data.Title,
-						 "\" couldn't set display mode to ", GetModeStr(mode), " because monitor: ", m_data.Monitor,
-						 '(', INTERNAL::WindowingAPI::GetMonitorName(m_useMonitor), ')',
+						 "\" couldn't set display mode to ", Utils::String::ConvertToString(mode),
+						 " because monitor: ", m_data.Monitor, '(',
+						 INTERNAL::WindowingAPI::GetMonitorName(m_useMonitor), ')',
 						 " is already used by window: \"", s_fullscreenWindows[m_data.Monitor]->GetTitle(), "\"!");
 				return;
 			}
@@ -342,7 +336,7 @@ void TRAP::Window::SetDisplayMode(const DisplayMode& mode, uint32_t width, uint3
 			   mode == DisplayMode::Borderless)
 			{
 				TP_WARN(Log::WindowPrefix, "\"", m_data.Title, "\" already uses display mode ",
-						GetModeStr(m_data.displayMode), " on monitor: ", m_data.Monitor,
+						Utils::String::ConvertToString(m_data.displayMode), " on monitor: ", m_data.Monitor,
 						"(", INTERNAL::WindowingAPI::GetMonitorName(m_useMonitor), ")!");
 				return;
 			}
@@ -439,7 +433,8 @@ void TRAP::Window::SetDisplayMode(const DisplayMode& mode, uint32_t width, uint3
 	}
 
 	TP_INFO(Log::WindowPrefix, "\"", m_data.Title, "\" changing display mode from ",
-	        GetModeStr(m_data.displayMode), " to ", GetModeStr(mode), ": ",
+	        Utils::String::ConvertToString(m_data.displayMode), " to ",
+			Utils::String::ConvertToString(mode), ": ",
 	        m_data.Width, 'x', m_data.Height, '@', m_data.RefreshRate, "Hz");
 
 	//Save new display mode
@@ -501,7 +496,7 @@ void TRAP::Window::SetCursorType(const CursorType& cursor) const
 {
 	TP_PROFILE_FUNCTION();
 
-	Scope<INTERNAL::WindowingAPI::InternalCursor> internalCursor = INTERNAL::WindowingAPI::CreateStandardCursor(cursor);
+	const Scope<INTERNAL::WindowingAPI::InternalCursor> internalCursor = INTERNAL::WindowingAPI::CreateStandardCursor(cursor);
 	INTERNAL::WindowingAPI::SetCursor(m_window.get(), internalCursor.get());
 }
 
@@ -511,7 +506,7 @@ void TRAP::Window::SetCursorIcon(const Image* const image, const int32_t xHotspo
 {
 	TP_PROFILE_FUNCTION();
 
-	Scope<INTERNAL::WindowingAPI::InternalCursor> cursor = INTERNAL::WindowingAPI::CreateCursor
+	const Scope<INTERNAL::WindowingAPI::InternalCursor> cursor = INTERNAL::WindowingAPI::CreateCursor
 		(
 			image, xHotspot, yHotspot
 		);

--- a/TRAP/src/Window/Window.h
+++ b/TRAP/src/Window/Window.h
@@ -88,7 +88,7 @@ namespace TRAP
 		/// Get the current title of the window.
 		/// </summary>
 		/// <returns>Title of the window.</returns>
-		const std::string& GetTitle() const noexcept;
+		std::string GetTitle() const noexcept;
 		/// <summary>
 		/// Get the current width of the window.
 		/// </summary>

--- a/TRAP/src/Window/WindowingAPI.cpp
+++ b/TRAP/src/Window/WindowingAPI.cpp
@@ -32,6 +32,7 @@ Modified by: Jan "GamesTrap" Schuerkamp
 #include "Window.h"
 #include "Events/KeyEvent.h"
 #include "Layers/ImGui/ImGuiWindowing.h"
+#include <limits>
 
 TRAP::INTERNAL::WindowingAPI::Data TRAP::INTERNAL::WindowingAPI::s_Data{};
 
@@ -588,7 +589,7 @@ void TRAP::INTERNAL::WindowingAPI::SetWindowIcon(InternalWindow* window, const I
 	}
 
 	if(!((image->GetColorFormat() == Image::ColorFormat::RGB && image->GetBitsPerPixel() == 24) ||
-			(image->GetColorFormat() == Image::ColorFormat::RGBA && image->GetBitsPerPixel() == 32)))
+		 (image->GetColorFormat() == Image::ColorFormat::RGBA && image->GetBitsPerPixel() == 32)))
 	{
 		InputError(Error::Invalid_Value, "[Icon] Unsupported BPP or format used!");
 		return;
@@ -774,7 +775,6 @@ void TRAP::INTERNAL::WindowingAPI::SetWindowHint(InternalWindow* window, const H
 	{
 	case Hint::Resizable:
 		window->Resizable = value;
-
 		if (!window->Monitor)
 			PlatformSetWindowResizable(window, value);
 		break;
@@ -1464,7 +1464,7 @@ const char* TRAP::INTERNAL::WindowingAPI::GetKeyName(const Input::Key key, int32
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Returns the last reported state of a keyboard key for the specified window.
-TRAP::Input::KeyState TRAP::INTERNAL::WindowingAPI::GetKey(const InternalWindow* window, Input::Key key)
+TRAP::Input::KeyState TRAP::INTERNAL::WindowingAPI::GetKey(const InternalWindow* window, const Input::Key key)
 {
 	TRAP_ASSERT(window, "[Window] Window is nullptr!");
 
@@ -1486,7 +1486,7 @@ TRAP::Input::KeyState TRAP::INTERNAL::WindowingAPI::GetKey(const InternalWindow*
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Returns the last reported state of a mouse button for the specified window.
-TRAP::Input::KeyState TRAP::INTERNAL::WindowingAPI::GetMouseButton(const InternalWindow* window, Input::MouseButton button)
+TRAP::Input::KeyState TRAP::INTERNAL::WindowingAPI::GetMouseButton(const InternalWindow* window, const Input::MouseButton button)
 {
 	TRAP_ASSERT(window, "[Window] Window is nullptr!");
 
@@ -2037,7 +2037,7 @@ void TRAP::INTERNAL::WindowingAPI::InputChar(const InternalWindow* window, const
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Notifies shared code of a mouse button click event
-void TRAP::INTERNAL::WindowingAPI::InputMouseClick(InternalWindow* window, Input::MouseButton button,
+void TRAP::INTERNAL::WindowingAPI::InputMouseClick(InternalWindow* window, const Input::MouseButton button,
                                                    const Input::KeyState state)
 {
 	TRAP_ASSERT(window != nullptr);
@@ -2348,9 +2348,9 @@ void TRAP::INTERNAL::WindowingAPI::SplitBPP(int32_t bpp, int32_t& red, int32_t& 
 TRAP::INTERNAL::WindowingAPI::InternalVideoMode* TRAP::INTERNAL::WindowingAPI::ChooseVideoMode(InternalMonitor* monitor,
                                                                                                const InternalVideoMode& desired)
 {
-	uint32_t leastSizeDiff = UINT_MAX;
-	uint32_t rateDiff = 0, leastRateDiff = UINT_MAX;
-	uint32_t leastColorDiff = UINT_MAX;
+	uint32_t leastSizeDiff = std::numeric_limits<uint32_t>::max();
+	uint32_t rateDiff = 0, leastRateDiff = std::numeric_limits<uint32_t>::max();
+	uint32_t leastColorDiff = std::numeric_limits<uint32_t>::max();
 	InternalVideoMode* closest = nullptr;
 
 	if (!RefreshVideoModes(monitor))
@@ -2377,7 +2377,7 @@ TRAP::INTERNAL::WindowingAPI::InternalVideoMode* TRAP::INTERNAL::WindowingAPI::C
 		if (desired.RefreshRate != -1)
 			rateDiff = abs(current->RefreshRate - desired.RefreshRate);
 		else
-			rateDiff = UINT_MAX - current->RefreshRate;
+			rateDiff = std::numeric_limits<uint32_t>::max() - current->RefreshRate;
 
 		if ((colorDiff < leastColorDiff) ||
 			(colorDiff == leastColorDiff && sizeDiff < leastSizeDiff) ||
@@ -2403,7 +2403,7 @@ void TRAP::INTERNAL::WindowingAPI::InputMonitor(Scope<InternalMonitor> monitor, 
 
 	if (connected)
 	{
-		InternalMonitor* mon = nullptr;
+		const InternalMonitor* mon = nullptr;
 
 		if (placement == 0)
 		{
@@ -2438,9 +2438,9 @@ void TRAP::INTERNAL::WindowingAPI::InputMonitor(Scope<InternalMonitor> monitor, 
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Notifies shared code of a monitor disconnection
-void TRAP::INTERNAL::WindowingAPI::InputMonitorDisconnect(const uint32_t monitorIndex, const uint32_t)
+void TRAP::INTERNAL::WindowingAPI::InputMonitorDisconnect(const uint32_t monitorIndex, const uint32_t /*placement*/)
 {
-	Scope<InternalMonitor>& monitor = s_Data.Monitors[monitorIndex];
+	const Scope<InternalMonitor>& monitor = s_Data.Monitors[monitorIndex];
 
 	if (s_Data.Callbacks.Monitor)
 		s_Data.Callbacks.Monitor(monitor.get(), false);

--- a/TRAP/src/Window/WindowingAPI.cpp
+++ b/TRAP/src/Window/WindowingAPI.cpp
@@ -1855,32 +1855,6 @@ VkResult TRAP::INTERNAL::WindowingAPI::CreateWindowSurface(VkInstance instance,
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-//Searches an extension string for the specified extension
-bool TRAP::INTERNAL::WindowingAPI::StringInExtensionString(const char* string, const char* extensions)
-{
-	const char* start = extensions;
-
-	while(true)
-	{
-		const char* where = strstr(start, string);
-		if (!where)
-			return false;
-
-		const char* terminator = where + strlen(string);
-		if (where == start || *(where - 1) == ' ')
-		{
-			if (*terminator == ' ' || *terminator == '\0')
-				break;
-		}
-
-		start = terminator;
-	}
-
-	return true;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 std::string TRAP::INTERNAL::WindowingAPI::GetVulkanResultString(const VkResult result)
 {
 	switch (result)

--- a/TRAP/src/Window/WindowingAPI.cpp
+++ b/TRAP/src/Window/WindowingAPI.cpp
@@ -333,7 +333,7 @@ void TRAP::INTERNAL::WindowingAPI::SetWindowShouldClose(InternalWindow* window, 
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::SetWindowTitle(const InternalWindow* window, std::string& title)
+void TRAP::INTERNAL::WindowingAPI::SetWindowTitle(const InternalWindow* window, const std::string& title)
 {
 	TRAP_ASSERT(window, "[Window] Window is nullptr!");
 

--- a/TRAP/src/Window/WindowingAPI.cpp
+++ b/TRAP/src/Window/WindowingAPI.cpp
@@ -255,7 +255,7 @@ std::vector<TRAP::INTERNAL::WindowingAPI::InternalVideoMode> TRAP::INTERNAL::Win
 
 TRAP::Scope<TRAP::INTERNAL::WindowingAPI::InternalWindow> TRAP::INTERNAL::WindowingAPI::CreateWindow(const uint32_t width,
 	                                                                                                 const uint32_t height,
-	                                                                                                 const std::string& title,
+	                                                                                                 const std::string title,
 	                                                                                                 InternalMonitor* monitor)
 {
 	TRAP_ASSERT(!title.empty(), "[Window] Empty title provided!");
@@ -279,7 +279,7 @@ TRAP::Scope<TRAP::INTERNAL::WindowingAPI::InternalWindow> TRAP::INTERNAL::Window
 
 	WNDConfig.Width = width;
 	WNDConfig.Height = height;
-	WNDConfig.Title = title;
+	WNDConfig.Title = std::move(title);
 
 	Scope<InternalWindow> window = MakeScope<InternalWindow>();
 

--- a/TRAP/src/Window/WindowingAPI.h
+++ b/TRAP/src/Window/WindowingAPI.h
@@ -1347,7 +1347,7 @@ namespace TRAP::INTERNAL
 		/// <param name="title">UTF-8 encoded title for the new window.</param>
 		/// <param name="monitor">Optional monitor to use for the new window.</param>
 		/// <returns>On success a new internal window, or nullptr if an error occurred.</returns>
-		static Scope<InternalWindow> CreateWindow(uint32_t width, uint32_t height, const std::string& title,
+		static Scope<InternalWindow> CreateWindow(uint32_t width, uint32_t height, std::string title,
 		                                          InternalMonitor* monitor);
 		/// <summary>
 		/// This function sets the value of the close flag of the specified window. This can be used

--- a/TRAP/src/Window/WindowingAPI.h
+++ b/TRAP/src/Window/WindowingAPI.h
@@ -1367,7 +1367,7 @@ namespace TRAP::INTERNAL
 		/// </summary>
 		/// <param name="window">Internal window whose title to change.</param>
 		/// <param name="title">New UTF-8 encoded title for the window.</param>
-		static void SetWindowTitle(const InternalWindow* window, std::string& title);
+		static void SetWindowTitle(const InternalWindow* window, const std::string& title);
 		/// <summary>
 		/// This function retrieves the content scale for the specified monitor.
 		/// The content scale is the ratio between the current DPI and the platform's default DPI.
@@ -2788,7 +2788,7 @@ namespace TRAP::INTERNAL
 		/// </summary>
 		/// <param name="window">Internal window whose title to change.</param>
 		/// <param name="title">New UTF-8 encoded title for the window.</param>
-		static void PlatformSetWindowTitle(const InternalWindow* window, std::string& title);
+		static void PlatformSetWindowTitle(const InternalWindow* window, const std::string& title);
 		/// <summary>
 		/// Creates a new custom cursor image that can be set for a window with SetCursor. The cursor can
 		/// be destroyed with DestroyCursor. Any remaining cursors are destroyed by WindowingAPI::Shutdown.
@@ -3936,7 +3936,7 @@ namespace TRAP::INTERNAL
 		/// <param name="atomCount">Number of supported atoms.</param>
 		/// <param name="atomName">Atom to check.</param>
 		/// <returns>Atom on success, 0 otherwise.</returns>
-		static Atom GetAtomIfSupported(const Atom* supportedAtoms, uint64_t atomCount, const char* atomName);
+		static Atom GetAtomIfSupported(const Atom* supportedAtoms, uint64_t atomCount, std::string_view atomName);
 		/// <summary>
 		/// Create a blank cursor for hidden and disabled cursor modes.
 		/// </summary>
@@ -4061,13 +4061,13 @@ namespace TRAP::INTERNAL
 		/// </summary>
 		/// <param name="source">Latin-1 string.</param>
 		/// <returns>UTF-8 string.</returns>
-		static std::string ConvertLatin1ToUTF8(const char* source);
+		static std::string ConvertLatin1ToUTF8(std::string_view source);
 		/// <summary>
 		/// Reports the specified error, appending information about the last X error.
 		/// </summary>
 		/// <param name="error">Error code.</param>
 		/// <param name="message">Description of error.</param>
-		static void InputErrorX11(Error error, const char* message);
+		static void InputErrorX11(Error error, const std::string& message);
 		/// <summary>
 		/// Process the specified X event.
 		/// </summary>

--- a/TRAP/src/Window/WindowingAPI.h
+++ b/TRAP/src/Window/WindowingAPI.h
@@ -3423,13 +3423,6 @@ namespace TRAP::INTERNAL
 		/// <returns>Index for the sorted internal video mode.</returns>
 		static int32_t CompareVideoModes(const void* fp, const void* sp);
 		/// <summary>
-		/// Searches an extension string for the specified extension.
-		/// </summary>
-		/// <param name="string">String to search in given extension.</param>
-		/// <param name="extensions">Extension to test.</param>
-		/// <returns>True if given string is inside the given extension.</returns>
-		static bool StringInExtensionString(const char* string, const char* extensions);
-		/// <summary>
 		/// Updates the cursor image according to its cursor mode.
 		/// </summary>
 		/// <param name="window">Internal window to update.</param>

--- a/TRAP/src/Window/WindowingAPILinuxX11.cpp
+++ b/TRAP/src/Window/WindowingAPILinuxX11.cpp
@@ -1401,7 +1401,7 @@ Cursor TRAP::INTERNAL::WindowingAPI::CreateCursorX11(const TRAP::Image* const im
 	native->xhot = xHotSpot;
 	native->yhot = yHotSpot;
 
-	const uint8_t* source = reinterpret_cast<const uint8_t*>(image->GetPixelData());
+	const uint8_t* source = static_cast<const uint8_t*>(image->GetPixelData());
 	XcursorPixel* target = native->pixels;
 
 	for(uint32_t i = 0; i < image->GetWidth() * image->GetHeight(); i++, target++, source += 4)
@@ -2745,8 +2745,8 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowIcon(InternalWindow* window,
 		std::vector<uint64_t> icon{};
 		icon.resize(longCount);
 		uint64_t* target = icon.data();
-		std::vector<uint8_t> imgData(reinterpret_cast<const uint8_t*>(image->GetPixelData()),
-		                             reinterpret_cast<const uint8_t*>(image->GetPixelData()) +
+		std::vector<uint8_t> imgData(static_cast<const uint8_t*>(image->GetPixelData()),
+		                             static_cast<const uint8_t*>(image->GetPixelData()) +
 									 image->GetPixelDataSize());
 
 		*target++ = image->GetWidth();

--- a/TRAP/src/Window/WindowingAPILinuxX11.cpp
+++ b/TRAP/src/Window/WindowingAPILinuxX11.cpp
@@ -3243,7 +3243,7 @@ const char* TRAP::INTERNAL::WindowingAPI::PlatformGetScanCodeName(int32_t scanCo
 
 void TRAP::INTERNAL::WindowingAPI::PlatformSetClipboardString(const std::string& string)
 {
-	s_Data.ClipboardString = std::string(string);
+	s_Data.ClipboardString = string;
 
 	s_Data.XLIB.SetSelectionOwner(s_Data.display, s_Data.CLIPBOARD, s_Data.HelperWindowHandle, CurrentTime);
 

--- a/TRAP/src/Window/WindowingAPILinuxX11.cpp
+++ b/TRAP/src/Window/WindowingAPILinuxX11.cpp
@@ -3311,7 +3311,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 			return VK_ERROR_EXTENSION_NOT_PRESENT;
 		}
 
-		std::memset(&sci, 0, sizeof(sci));
+		memset(&sci, 0, sizeof(sci));
 		sci.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
 		sci.connection = connection;
 		sci.window = window->Handle;
@@ -3337,7 +3337,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 		return VK_ERROR_EXTENSION_NOT_PRESENT;
 	}
 
-	std::memset(&sci, 0, sizeof(sci));
+	memset(&sci, 0, sizeof(sci));
 	sci.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
 	sci.dpy = s_Data.display;
 	sci.window = window->Handle;

--- a/TRAP/src/Window/WindowingAPILinuxX11.cpp
+++ b/TRAP/src/Window/WindowingAPILinuxX11.cpp
@@ -99,8 +99,8 @@ TRAP::INTERNAL::WindowingAPI::InternalVideoMode TRAP::INTERNAL::WindowingAPI::Vi
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Sends an EWMH or ICCCM event to the window manager
-void TRAP::INTERNAL::WindowingAPI::SendEventToWM(const InternalWindow* window, Atom type, int64_t a, int64_t b,
-                                                 int64_t c, int64_t d, int64_t e)
+void TRAP::INTERNAL::WindowingAPI::SendEventToWM(const InternalWindow* window, const Atom type, const int64_t a,
+												 const int64_t b, const int64_t c, const int64_t d, const int64_t e)
 {
 	XEvent event = { ClientMessage };
 	event.xclient.window = window->Handle;
@@ -121,7 +121,7 @@ void TRAP::INTERNAL::WindowingAPI::SendEventToWM(const InternalWindow* window, A
 //Returns whether it is a _NET_FRAME_EXTENTS event for the specified window
 bool TRAP::INTERNAL::WindowingAPI::IsFrameExtentsEvent(Display*, XEvent* event, XPointer pointer)
 {
-	InternalWindow* window = reinterpret_cast<InternalWindow*>(pointer);
+	const InternalWindow* window = reinterpret_cast<InternalWindow*>(pointer);
 
 	return event->type             == PropertyNotify   &&
 	       event->xproperty.state  == PropertyNewValue &&
@@ -132,7 +132,7 @@ bool TRAP::INTERNAL::WindowingAPI::IsFrameExtentsEvent(Display*, XEvent* event, 
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Wait for data to arrive on any of the specified file descriptors
-bool TRAP::INTERNAL::WindowingAPI::WaitForData(pollfd* fds, nfds_t count, double* timeout)
+bool TRAP::INTERNAL::WindowingAPI::WaitForData(pollfd* fds, const nfds_t count, double* timeout)
 {
 	while(true)
 	{
@@ -222,7 +222,7 @@ bool TRAP::INTERNAL::WindowingAPI::CreateEmptyEventPipe()
 {
 	if(pipe(s_Data.EmptyEventPipe.data()) != 0)
 	{
-		InputError(Error::Platform_Error, "X11: Failed to create empty event pipe: " + Utils::GetStrError());
+		InputError(Error::Platform_Error, "X11: Failed to create empty event pipe: " + Utils::String::GetStrError());
 		return false;
 	}
 
@@ -235,7 +235,7 @@ bool TRAP::INTERNAL::WindowingAPI::CreateEmptyEventPipe()
 		   fcntl(fd, F_SETFL, sf | O_NONBLOCK) == -1 ||
 		   fcntl(fd, F_SETFD, df | FD_CLOEXEC) == -1)
 		{
-			InputError(Error::Platform_Error, "X11: Failed to set flags for empty event pipe: " + Utils::GetStrError());
+			InputError(Error::Platform_Error, "X11: Failed to set flags for empty event pipe: " + Utils::String::GetStrError());
 			return false;
 		}
 	}
@@ -246,25 +246,15 @@ bool TRAP::INTERNAL::WindowingAPI::CreateEmptyEventPipe()
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Retrieve a single window property of the specified type
-uint64_t TRAP::INTERNAL::WindowingAPI::GetWindowPropertyX11(::Window window, Atom property, Atom type,
-                                                                 uint8_t** value)
+uint64_t TRAP::INTERNAL::WindowingAPI::GetWindowPropertyX11(::Window window, const Atom property, const Atom type,
+                                                            uint8_t** value)
 {
 	Atom actualType{};
 	int32_t actualFormat{};
 	uint64_t itemCount{}, bytesAfter{};
 
-	s_Data.XLIB.GetWindowProperty(s_Data.display,
-					              window,
-					              property,
-					              0,
-					              LONG_MAX,
-					              0,
-					              type,
-					              &actualType,
-					              &actualFormat,
-					              &itemCount,
-					              &bytesAfter,
-					              value);
+	s_Data.XLIB.GetWindowProperty(s_Data.display, window, property, 0, std::numeric_limits<long>::max(), 0, type, &actualType,
+					              &actualFormat, &itemCount, &bytesAfter, value);
 
 	return itemCount;
 }
@@ -272,7 +262,7 @@ uint64_t TRAP::INTERNAL::WindowingAPI::GetWindowPropertyX11(::Window window, Ato
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Updates the normal hints according to the window settings
-void TRAP::INTERNAL::WindowingAPI::UpdateNormalHints(InternalWindow* window, int32_t width, int32_t height)
+void TRAP::INTERNAL::WindowingAPI::UpdateNormalHints(InternalWindow* window, const int32_t width, const int32_t height)
 {
 	XSizeHints* hints = s_Data.XLIB.AllocSizeHints();
 
@@ -408,7 +398,7 @@ void TRAP::INTERNAL::WindowingAPI::UpdateWindowMode(InternalWindow* window)
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Returns the mode info for a RandR mode XID
-const XRRModeInfo* TRAP::INTERNAL::WindowingAPI::GetModeInfo(const XRRScreenResources* sr, RRMode id)
+const XRRModeInfo* TRAP::INTERNAL::WindowingAPI::GetModeInfo(const XRRScreenResources* sr, const RRMode id)
 {
 	for(int32_t i = 0; i < sr->nmode; i++)
 	{
@@ -431,10 +421,10 @@ void TRAP::INTERNAL::WindowingAPI::GetSystemContentScale(float& xScale, float& y
 
 	//NOTE: Basing the scale on Xft.dpi where available should provide the most consistent user experience
 	//      (matches Qt, Gtk, etc), although not always the most accurate one
-	char* rms = s_Data.XLIB.ResourceManagerString(s_Data.display);
+	const char* rms = s_Data.XLIB.ResourceManagerString(s_Data.display);
 	if(rms)
 	{
-		XrmDatabase db = s_Data.XRM.GetStringDatabase(rms);
+		const XrmDatabase db = s_Data.XRM.GetStringDatabase(rms);
 		if(db)
 		{
 			XrmValue value;
@@ -851,7 +841,8 @@ void TRAP::INTERNAL::WindowingAPI::ReleaseErrorHandlerX11()
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Return the atom ID only if it is listed in the specified array
-Atom TRAP::INTERNAL::WindowingAPI::GetAtomIfSupported(const Atom* supportedAtoms, uint64_t atomCount, const std::string_view atomName)
+Atom TRAP::INTERNAL::WindowingAPI::GetAtomIfSupported(const Atom* supportedAtoms, const uint64_t atomCount,
+                                                      const std::string_view atomName)
 {
 	const Atom atom = s_Data.XLIB.InternAtom(s_Data.display, atomName.data(), 0);
 
@@ -869,7 +860,7 @@ Atom TRAP::INTERNAL::WindowingAPI::GetAtomIfSupported(const Atom* supportedAtoms
 //Create a blank cursor for hidden and disabled cursor modes
 Cursor TRAP::INTERNAL::WindowingAPI::CreateHiddenCursor()
 {
-	std::array<uint8_t, static_cast<std::size_t>(16) * 16 * 4> pixels = {0};
+	const std::array<uint8_t, static_cast<std::size_t>(16) * 16 * 4> pixels = {0};
 	return CreateCursorX11(TRAP::Image::LoadFromMemory(16, 16, TRAP::Image::ColorFormat::RGBA,
 	                                                           std::vector<uint8_t>(pixels.begin(),
 															   pixels.end())).get(), 0, 0);
@@ -950,7 +941,7 @@ void TRAP::INTERNAL::WindowingAPI::PollMonitorsX11()
 	std::vector<InternalMonitor*> disconnected{};
 	XineramaScreenInfo* screens = nullptr;
 	XRRScreenResources* sr = s_Data.RandR.GetScreenResourcesCurrent(s_Data.display, s_Data.Root);
-	RROutput primary = s_Data.RandR.GetOutputPrimary(s_Data.display, s_Data.Root);
+	const RROutput primary = s_Data.RandR.GetOutputPrimary(s_Data.display, s_Data.Root);
 
 	if(s_Data.Xinerama.Available)
 		screens = s_Data.Xinerama.QueryScreens(s_Data.display, &screenCount);
@@ -1083,8 +1074,8 @@ Atom TRAP::INTERNAL::WindowingAPI::WriteTargetToProperty(const XSelectionRequest
 
 		Atom* targets = nullptr;
 
-		uint64_t count = GetWindowPropertyX11(request->requestor, request->property, s_Data.ATOM_PAIR,
-		                                      reinterpret_cast<uint8_t**>(&targets));
+		const uint64_t count = GetWindowPropertyX11(request->requestor, request->property, s_Data.ATOM_PAIR,
+		                                            reinterpret_cast<uint8_t**>(&targets));
 
 		for(uint64_t i = 0; i < count; i += 2)
 		{
@@ -1235,7 +1226,7 @@ bool TRAP::INTERNAL::WindowingAPI::IsVisualTransparentX11(Visual* visual)
 	if(!s_Data.XRender.Available)
 		return false;
 
-	XRenderPictFormat* pf = s_Data.XRender.FindVisualFormat(s_Data.display, visual);
+	const XRenderPictFormat* pf = s_Data.XRender.FindVisualFormat(s_Data.display, visual);
 	return pf && pf->direct.alphaMask;
 }
 
@@ -1245,8 +1236,8 @@ bool TRAP::INTERNAL::WindowingAPI::IsVisualTransparentX11(Visual* visual)
 bool TRAP::INTERNAL::WindowingAPI::CreateNativeWindow(InternalWindow* window, WindowConfig& WNDConfig,
                                                       Visual* visual, int32_t depth)
 {
-	int32_t width = static_cast<int32_t>(WNDConfig.Width);
-	int32_t height = static_cast<int32_t>(WNDConfig.Height);
+	const int32_t width = static_cast<int32_t>(WNDConfig.Width);
+	const int32_t height = static_cast<int32_t>(WNDConfig.Height);
 
 	//Create a colormap based on the visual used by the current context
 	window->colormap = s_Data.XLIB.CreateColormap(s_Data.display, s_Data.Root, visual, AllocNone);
@@ -1387,8 +1378,8 @@ bool TRAP::INTERNAL::WindowingAPI::CreateNativeWindow(InternalWindow* window, Wi
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Creates a native cursor object from the specified image and hotspot
-Cursor TRAP::INTERNAL::WindowingAPI::CreateCursorX11(const TRAP::Image* const image, int32_t xHotSpot,
-                                                     int32_t yHotSpot)
+Cursor TRAP::INTERNAL::WindowingAPI::CreateCursorX11(const TRAP::Image* const image, int32_t const xHotSpot,
+                                                     const int32_t yHotSpot)
 {
 	if(!s_Data.XCursor.Handle)
 		return 0;
@@ -1406,7 +1397,7 @@ Cursor TRAP::INTERNAL::WindowingAPI::CreateCursorX11(const TRAP::Image* const im
 
 	for(uint32_t i = 0; i < image->GetWidth() * image->GetHeight(); i++, target++, source += 4)
 	{
-		uint32_t alpha = source[3];
+		const uint32_t alpha = source[3];
 
 		*target = (alpha << 24) |
 		          (static_cast<uint8_t>((source[0] * alpha) / 255) << 16) |
@@ -1414,7 +1405,7 @@ Cursor TRAP::INTERNAL::WindowingAPI::CreateCursorX11(const TRAP::Image* const im
 				  (static_cast<uint8_t>((source[2] * alpha) / 255) <<  0);
 	}
 
-	Cursor cursor = s_Data.XCursor.ImageLoadCursor(s_Data.display, native);
+	const Cursor cursor = s_Data.XCursor.ImageLoadCursor(s_Data.display, native);
 	s_Data.XCursor.ImageDestroy(native);
 
 	return cursor;
@@ -1689,7 +1680,7 @@ const std::array<TRAP::INTERNAL::WindowingAPI::CodePair, 828> TRAP::INTERNAL::Wi
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Encode a Unicode code point to a UTF-8 stream
-std::size_t TRAP::INTERNAL::WindowingAPI::EncodeUTF8(char* s, uint32_t ch)
+std::size_t TRAP::INTERNAL::WindowingAPI::EncodeUTF8(char* s, const uint32_t ch)
 {
 	std::size_t count = 0;
 
@@ -1719,7 +1710,7 @@ std::size_t TRAP::INTERNAL::WindowingAPI::EncodeUTF8(char* s, uint32_t ch)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-std::string TRAP::INTERNAL::WindowingAPI::GetSelectionString(Atom selection)
+std::string TRAP::INTERNAL::WindowingAPI::GetSelectionString(const Atom selection)
 {
 	std::string* selectionString = nullptr;
 	const std::array<Atom, 2> targets = {s_Data.UTF8_STRING, XA_STRING};
@@ -1760,13 +1751,12 @@ std::string TRAP::INTERNAL::WindowingAPI::GetSelectionString(Atom selection)
 		                         reinterpret_cast<XPointer>(&notification));
 
 		s_Data.XLIB.GetWindowProperty(s_Data.display, notification.xselection.requestor,
-		                              notification.xselection.property, 0, LONG_MAX, 1, AnyPropertyType,
+		                              notification.xselection.property, 0, std::numeric_limits<long>::max(), 1, AnyPropertyType,
 									  &actualType, &actualFormat, &itemCount, &bytesAfter,
 									  reinterpret_cast<uint8_t**>(&data));
 
 		if(actualType == s_Data.INCR)
 		{
-			std::size_t size = 1;
 			std::string string{};
 
 			while(true)
@@ -1777,15 +1767,12 @@ std::string TRAP::INTERNAL::WindowingAPI::GetSelectionString(Atom selection)
 
 				s_Data.XLIB.Free(data);
 				s_Data.XLIB.GetWindowProperty(s_Data.display, notification.xselection.requestor,
-				                              notification.xselection.property, 0, LONG_MAX, 1, AnyPropertyType,
+				                              notification.xselection.property, 0, std::numeric_limits<long>::max(), 1, AnyPropertyType,
 											  &actualType, &actualFormat, &itemCount, &bytesAfter,
 											  reinterpret_cast<uint8_t**>(&data));
 
 				if(itemCount)
-				{
-					size += itemCount;
 					string = data;
-				}
 
 				if(!itemCount)
 				{
@@ -1827,7 +1814,7 @@ std::string TRAP::INTERNAL::WindowingAPI::GetSelectionString(Atom selection)
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Convert XKB KeySym to Unicode
-uint32_t TRAP::INTERNAL::WindowingAPI::KeySymToUnicode(uint32_t keySym)
+uint32_t TRAP::INTERNAL::WindowingAPI::KeySymToUnicode(const uint32_t keySym)
 {
 	int32_t min = 0;
 	int32_t max = KeySymTab.size() - 1;
@@ -1865,7 +1852,7 @@ uint32_t TRAP::INTERNAL::WindowingAPI::KeySymToUnicode(uint32_t keySym)
 //Returns whether it is a property event for the specified selection transfer
 int32_t TRAP::INTERNAL::WindowingAPI::IsSelPropNewValueNotify(Display*, XEvent* event, XPointer pointer)
 {
-	XEvent* notification = reinterpret_cast<XEvent*>(pointer);
+	const XEvent* notification = reinterpret_cast<XEvent*>(pointer);
 
 	return event->type == PropertyNotify &&
 	       event->xproperty.state == PropertyNewValue &&
@@ -1942,7 +1929,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformGetWindowSize(const InternalWindow* w
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowPos(const InternalWindow* window, int32_t xPos, int32_t yPos)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowPos(const InternalWindow* window, const int32_t xPos, const int32_t yPos)
 {
 	//HACK: Explicitly setting PPosition to any value causes some WMs, notably Compiz and Metacity, to honor
 	//      the position of unmapped windows
@@ -1969,8 +1956,8 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowPos(const InternalWindow* wi
 //-------------------------------------------------------------------------------------------------------------------//
 
 void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowMonitor(InternalWindow* window, InternalMonitor* monitor,
-														    int32_t xPos, int32_t yPos, int32_t width,
-															int32_t height, int32_t)
+														    const int32_t xPos, const int32_t yPos, const int32_t width,
+															const int32_t height, int32_t /*refreshRate*/)
 {
 	if(window->Monitor == monitor)
 	{
@@ -2066,7 +2053,7 @@ std::vector<TRAP::INTERNAL::WindowingAPI::InternalVideoMode> TRAP::INTERNAL::Win
 			if(!static_cast<bool>((mi->modeFlags & RR_Interlace) == 0))
 				continue;
 
-			InternalVideoMode mode = VideoModeFromModeInfo(mi, ci);
+			const InternalVideoMode mode = VideoModeFromModeInfo(mi, ci);
 			uint32_t j = 0;
 
 			for(j = 0; j < count; j++)
@@ -2265,7 +2252,7 @@ bool TRAP::INTERNAL::WindowingAPI::PlatformInit()
 	s_Data.display = s_Data.XLIB.OpenDisplay(nullptr);
 	if(!s_Data.display)
 	{
-		const char* display = std::getenv("DISPLAY");
+		const char* display = getenv("DISPLAY");
 		if(display)
 			InputError(Error::Platform_Error, std::string("[X11] Failed to open display: ") + display);
 		else
@@ -2560,7 +2547,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowTitle(const InternalWindow* 
 //-------------------------------------------------------------------------------------------------------------------//
 
 bool TRAP::INTERNAL::WindowingAPI::PlatformCreateCursor(InternalCursor* cursor, const Image* const image,
-                                                        int32_t xHotspot, int32_t yHotspot)
+                                                        const int32_t xHotspot, const int32_t yHotspot)
 {
 	cursor->Handle = CreateCursorX11(image, xHotspot, yHotspot);
 
@@ -2573,7 +2560,7 @@ bool TRAP::INTERNAL::WindowingAPI::PlatformCreateStandardCursor(InternalCursor* 
 {
 	if(s_Data.XCursor.Handle)
 	{
-		char* theme = s_Data.XCursor.GetTheme(s_Data.display);
+		const char* theme = s_Data.XCursor.GetTheme(s_Data.display);
 		if(theme)
 		{
 			const int32_t size = s_Data.XCursor.GetDefaultSize(s_Data.display);
@@ -2660,7 +2647,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformDestroyCursor(InternalCursor* cursor)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetCursor(const InternalWindow* window, const InternalCursor*)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetCursor(const InternalWindow* window, const InternalCursor* /*cursor*/)
 {
 	if(window->cursorMode != CursorMode::Normal)
 		return;
@@ -2671,7 +2658,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetCursor(const InternalWindow* windo
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetCursorMode(InternalWindow* window, CursorMode mode)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetCursorMode(InternalWindow* window, const CursorMode mode)
 {
 	if (PlatformWindowFocused(window))
 	{
@@ -2708,7 +2695,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetCursorMode(InternalWindow* window,
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetCursorPos(InternalWindow* window, double xPos, double yPos)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetCursorPos(InternalWindow* window, const double xPos, const double yPos)
 {
 	//Store the new position so it can be recognized later
 	window->WarpCursorPosX = static_cast<int32_t>(xPos);
@@ -2745,9 +2732,9 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowIcon(InternalWindow* window,
 		std::vector<uint64_t> icon{};
 		icon.resize(longCount);
 		uint64_t* target = icon.data();
-		std::vector<uint8_t> imgData(static_cast<const uint8_t*>(image->GetPixelData()),
-		                             static_cast<const uint8_t*>(image->GetPixelData()) +
-									 image->GetPixelDataSize());
+		const std::vector<uint8_t> imgData(static_cast<const uint8_t*>(image->GetPixelData()),
+		                                   static_cast<const uint8_t*>(image->GetPixelData()) +
+									       image->GetPixelDataSize());
 
 		*target++ = image->GetWidth();
 		*target++ = image->GetHeight();
@@ -2791,7 +2778,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformGetWindowPos(const InternalWindow* wi
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowSize(InternalWindow* window, int32_t width, int32_t height)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowSize(InternalWindow* window, const int32_t width, const int32_t height)
 {
 	if(window->Monitor && window->Monitor->Window == window)
 	{
@@ -2813,7 +2800,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowSize(InternalWindow* window,
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowResizable(InternalWindow* window, bool)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowResizable(InternalWindow* window, bool /*enabled*/)
 {
 	int32_t width = 0, height = 0;
 
@@ -2823,7 +2810,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowResizable(InternalWindow* wi
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowDecorated(const InternalWindow* window, bool enabled)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowDecorated(const InternalWindow* window, const bool enabled)
 {
 	struct Hints
 	{
@@ -2843,7 +2830,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowDecorated(const InternalWind
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowFloating(const InternalWindow* window, bool enabled)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowFloating(const InternalWindow* window, const bool enabled)
 {
 	if(!s_Data.NET_WM_STATE || !s_Data.NET_WM_STATE_ABOVE)
 		return;
@@ -2902,7 +2889,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowFloating(const InternalWindo
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowOpacity(const InternalWindow* window, float opacity)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowOpacity(const InternalWindow* window, const float opacity)
 {
 	const CARD32 value = static_cast<CARD32>(0xFFFFFFFFu * static_cast<double>(opacity));
 	s_Data.XLIB.ChangeProperty(s_Data.display, window->Handle, s_Data.NET_WM_WINDOW_OPACITY, XA_CARDINAL, 32,
@@ -2911,14 +2898,14 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowOpacity(const InternalWindow
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowMousePassthrough(InternalWindow* window, bool enabled)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowMousePassthrough(InternalWindow* window, const bool enabled)
 {
 	if(!s_Data.XShape.Available)
 		return;
 
 	if (enabled)
 	{
-		Region region = s_Data.XLIB.CreateRegion();
+		const Region region = s_Data.XLIB.CreateRegion();
 		s_Data.XShape.CombineRegion(s_Data.display, window->Handle, ShapeInput, 0, 0, region, ShapeSet);
 		s_Data.XLIB.DestroyRegion(region);
 	}
@@ -2928,7 +2915,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowMousePassthrough(InternalWin
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformHideWindowFromTaskbar(InternalWindow*)
+void TRAP::INTERNAL::WindowingAPI::PlatformHideWindowFromTaskbar(InternalWindow* /*window*/)
 {
 }
 
@@ -3179,7 +3166,7 @@ bool TRAP::INTERNAL::WindowingAPI::PlatformRawMouseMotionSupported()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetRawMouseMotion(const InternalWindow* window, bool enabled)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetRawMouseMotion(const InternalWindow* window, const bool enabled)
 {
 	if(!s_Data.XI.Available)
 		return;
@@ -3202,14 +3189,14 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetProgress(const InternalWindow* /*w
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-int32_t TRAP::INTERNAL::WindowingAPI::PlatformGetKeyScanCode(Input::Key key)
+int32_t TRAP::INTERNAL::WindowingAPI::PlatformGetKeyScanCode(const Input::Key key)
 {
 	return s_Data.ScanCodes[static_cast<uint32_t>(key)];
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-const char* TRAP::INTERNAL::WindowingAPI::PlatformGetScanCodeName(int32_t scanCode)
+const char* TRAP::INTERNAL::WindowingAPI::PlatformGetScanCodeName(const int32_t scanCode)
 {
 	if(!s_Data.XKB.Available)
 		return nullptr;
@@ -3221,8 +3208,8 @@ const char* TRAP::INTERNAL::WindowingAPI::PlatformGetScanCodeName(int32_t scanCo
 	}
 
 	const int32_t key = static_cast<int32_t>(s_Data.KeyCodes[scanCode]);
-	KeySym keySym = s_Data.XKB.KeycodeToKeysym(s_Data.display, scanCode,
-											   static_cast<int32_t>(s_Data.XKB.Group), 0);
+	const KeySym keySym = s_Data.XKB.KeycodeToKeysym(s_Data.display, scanCode,
+											         static_cast<int32_t>(s_Data.XKB.Group), 0);
 	if(keySym == NoSymbol)
 		return nullptr;
 
@@ -3298,7 +3285,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 			return VK_ERROR_EXTENSION_NOT_PRESENT;
 		}
 
-		PFN_vkCreateXcbSurfaceKHR vkCreateXcbSurfaceKHR = reinterpret_cast<PFN_vkCreateXcbSurfaceKHR>(vkGetInstanceProcAddr
+		const PFN_vkCreateXcbSurfaceKHR vkCreateXcbSurfaceKHR = reinterpret_cast<PFN_vkCreateXcbSurfaceKHR>(vkGetInstanceProcAddr
 			(
 				instance, "vkCreateXcbSurfaceKHR"
 			));
@@ -3313,7 +3300,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 		sci.connection = connection;
 		sci.window = window->Handle;
 
-		VkResult err = vkCreateXcbSurfaceKHR(instance, &sci, allocator, &surface);
+		const VkResult err = vkCreateXcbSurfaceKHR(instance, &sci, allocator, &surface);
 		if(err)
 			InputError(Error::Platform_Error,
 			           std::string("[X11] Failed to create Vulkan XCB surface: ") + GetVulkanResultString(err));
@@ -3321,7 +3308,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 		return err;
 	}
 
-	PFN_vkCreateXlibSurfaceKHR vkCreateXlibSurfaceKHR = reinterpret_cast<PFN_vkCreateXlibSurfaceKHR>(vkGetInstanceProcAddr
+	const PFN_vkCreateXlibSurfaceKHR vkCreateXlibSurfaceKHR = reinterpret_cast<PFN_vkCreateXlibSurfaceKHR>(vkGetInstanceProcAddr
 		(
 			instance, "vkCreateXlibSurfaceKHR"
 		));
@@ -3336,7 +3323,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 	sci.dpy = s_Data.display;
 	sci.window = window->Handle;
 
-	VkResult err = vkCreateXlibSurfaceKHR(instance, &sci, allocator, &surface);
+	const VkResult err = vkCreateXlibSurfaceKHR(instance, &sci, allocator, &surface);
 	if(err)
 		InputError(Error::Platform_Error,
 					std::string("[X11] Failed to create Vulkan X11 surface: ") + GetVulkanResultString(err));
@@ -3360,8 +3347,8 @@ void TRAP::INTERNAL::WindowingAPI::PlatformMaximizeWindow(const InternalWindow* 
 	else
 	{
 		Atom* states = nullptr;
-		uint64_t count = GetWindowPropertyX11(window->Handle, s_Data.NET_WM_STATE, XA_ATOM,
-		                                           reinterpret_cast<uint8_t**>(&states));
+		const uint64_t count = GetWindowPropertyX11(window->Handle, s_Data.NET_WM_STATE, XA_ATOM,
+		                                            reinterpret_cast<uint8_t**>(&states));
 
 		//NOTE: We don't check for failure as this property may not exist yet and that's fine (and we'll create it
 		//      implicitly with append)
@@ -3464,8 +3451,9 @@ void TRAP::INTERNAL::WindowingAPI::PlatformRestoreWindow(InternalWindow* window)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowSizeLimits(InternalWindow* window, int32_t, int32_t, int32_t,
-                                                               int32_t)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowSizeLimits(InternalWindow* window, int32_t /*minWidth*/,
+                                                               int32_t /*minHeight*/, int32_t /*maxWidth*/,
+                                                               int32_t /*maxHeight*/)
 {
 	int32_t width = 0, height = 0;
 	PlatformGetWindowSize(window, width, height);
@@ -3476,7 +3464,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowSizeLimits(InternalWindow* w
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Enable XI2 raw mouse motion events
-void TRAP::INTERNAL::WindowingAPI::EnableRawMouseMotion(const InternalWindow*)
+void TRAP::INTERNAL::WindowingAPI::EnableRawMouseMotion(const InternalWindow* /*window*/)
 {
 	XIEventMask em;
 	std::array<uint8_t, XIMaskLen(XI_RawMotion)> mask = {0};
@@ -3492,7 +3480,7 @@ void TRAP::INTERNAL::WindowingAPI::EnableRawMouseMotion(const InternalWindow*)
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Disable XI2 raw mouse motion events
-void TRAP::INTERNAL::WindowingAPI::DisableRawMouseMotion(const InternalWindow*)
+void TRAP::INTERNAL::WindowingAPI::DisableRawMouseMotion(const InternalWindow* /*window*/)
 {
 	XIEventMask em;
 	std::array<uint8_t, 1> mask = {0};
@@ -3507,7 +3495,7 @@ void TRAP::INTERNAL::WindowingAPI::DisableRawMouseMotion(const InternalWindow*)
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Reports the specified error, appending information about the last X Error
-void TRAP::INTERNAL::WindowingAPI::InputErrorX11(Error error, const std::string& message)
+void TRAP::INTERNAL::WindowingAPI::InputErrorX11(const Error error, const std::string& message)
 {
 	std::vector<char> buffer{};
 	buffer.resize(1024);
@@ -3568,7 +3556,7 @@ void TRAP::INTERNAL::WindowingAPI::ProcessEvent(XEvent& event)
 			if(window && window->RawMouseMotion && event.xcookie.extension == s_Data.XI.MajorOPCode &&
 			   s_Data.XLIB.GetEventData(s_Data.display, &event.xcookie) && event.xcookie.evtype == XI_RawMotion)
 			{
-				XIRawEvent* re = reinterpret_cast<XIRawEvent*>(event.xcookie.data);
+				const XIRawEvent* re = reinterpret_cast<XIRawEvent*>(event.xcookie.data);
 				if(re->valuators.mask_len)
 				{
 					const double* values = re->raw_values;
@@ -3627,7 +3615,7 @@ void TRAP::INTERNAL::WindowingAPI::ProcessEvent(XEvent& event)
 			//NOTE: Always allow the first event for each key through
 			//      (the server never sends a timestamp of zero)
 			//NOTE: Timestamp difference is compared to handle wrap-around
-			Time diff = event.xkey.time - window->KeyPressTimes[keyCode];
+			const Time diff = event.xkey.time - window->KeyPressTimes[keyCode];
 			if(diff == event.xkey.time || (diff > 0 && diff < (static_cast<Time>(1u) << 31u)))
 			{
 				if(keyCode)
@@ -4001,7 +3989,7 @@ void TRAP::INTERNAL::WindowingAPI::ProcessEvent(XEvent& event)
 			if(result)
 			{
 				int32_t count = 0;
-				std::vector<std::string> paths = ParseUriList(data, count);
+				const std::vector<std::string> paths = ParseUriList(data, count);
 
 				InputDrop(window, paths);
 			}
@@ -4129,7 +4117,7 @@ void TRAP::INTERNAL::WindowingAPI::ProcessEvent(XEvent& event)
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Translates an X11 key code to a TRAP key token
-TRAP::Input::Key TRAP::INTERNAL::WindowingAPI::TranslateKey(int32_t scanCode)
+TRAP::Input::Key TRAP::INTERNAL::WindowingAPI::TranslateKey(const int32_t scanCode)
 {
 	//Use the pre-filled LUT (see CreateKeyTables())
 	if(scanCode < 0 || scanCode > 255)
@@ -4167,9 +4155,9 @@ uint32_t TRAP::INTERNAL::WindowingAPI::DecodeUTF8(const char** s)
 //Splits and translates a text/uri-list into separate file paths
 std::vector<std::string> TRAP::INTERNAL::WindowingAPI::ParseUriList(char* text, int32_t& count)
 {
-	std::string prefix = "file://";
+	const std::string prefix = "file://";
 	std::vector<std::string> paths{};
-	char* line = nullptr;
+	const char* line = nullptr;
 
 	count = 0;
 
@@ -4465,7 +4453,7 @@ void TRAP::INTERNAL::WindowingAPI::CreateKeyTables()
 	{
 		//Use XKB to determine physical key locations independently of the current keyboard layout
 
-		XkbDescPtr desc = s_Data.XKB.GetMap(s_Data.display, 0, XkbUseCoreKbd);
+		const XkbDescPtr desc = s_Data.XKB.GetMap(s_Data.display, 0, XkbUseCoreKbd);
 		s_Data.XKB.GetNames(s_Data.display, XkbKeyNamesMask | XkbKeyAliasesMask, desc);
 
 		scanCodeMin = desc->min_key_code;
@@ -4477,7 +4465,7 @@ void TRAP::INTERNAL::WindowingAPI::CreateKeyTables()
 			std::string Name;
 		};
 
-		std::array<Keys, 121> KeyMap =
+		const std::array<Keys, 121> KeyMap =
 		{
             {
                 { TRAP::Input::Key::Grave_Accent, "TLDE"}, { TRAP::Input::Key::One, "AE01"},
@@ -4637,7 +4625,7 @@ void TRAP::INTERNAL::WindowingAPI::ReleaseCursor()
 //Translate the X11 KeySyms for a key to a TRAP key
 //NOTE: This is only used as a fallback, in case the XKB method fails
 //      It is layout-dependent and will fail partially on most non-US layouts
-TRAP::Input::Key TRAP::INTERNAL::WindowingAPI::TranslateKeySyms(const KeySym* keySyms, int32_t width)
+TRAP::Input::Key TRAP::INTERNAL::WindowingAPI::TranslateKeySyms(const KeySym* keySyms, const int32_t width)
 {
 	if(width > 1)
 	{
@@ -5074,7 +5062,7 @@ std::string TRAP::INTERNAL::WindowingAPI::GetX11KeyboardLayoutName()
 	XkbStateRec state{};
 	s_Data.XKB.GetState(s_Data.display, XkbUseCoreKbd, &state);
 
-	XkbDescPtr desc = s_Data.XKB.AllocKeyboard();
+	const XkbDescPtr desc = s_Data.XKB.AllocKeyboard();
 	if (s_Data.XKB.GetNames(s_Data.display, XkbGroupNamesMask, desc) != 0) //0 = Success
 	{
 		s_Data.XKB.FreeKeyboard(desc, 0, 1);
@@ -5096,7 +5084,7 @@ std::string TRAP::INTERNAL::WindowingAPI::GetX11KeyboardLayoutName()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetDragAndDrop(InternalWindow* window, bool value)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetDragAndDrop(InternalWindow* window, const bool value)
 {
 	if(value)
 	{

--- a/TRAP/src/Window/WindowingAPILinuxX11.cpp
+++ b/TRAP/src/Window/WindowingAPILinuxX11.cpp
@@ -3291,9 +3291,6 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 {
 	if(s_Data.VK.KHR_XCB_Surface && s_Data.XCB.Handle)
 	{
-		VkXcbSurfaceCreateInfoKHR sci{};
-		PFN_vkCreateXcbSurfaceKHR vkCreateXcbSurfaceKHR = nullptr;
-
 		xcb_connection_t* connection = s_Data.XCB.GetXCBConnection(s_Data.display);
 		if(!connection)
 		{
@@ -3301,7 +3298,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 			return VK_ERROR_EXTENSION_NOT_PRESENT;
 		}
 
-		vkCreateXcbSurfaceKHR = reinterpret_cast<PFN_vkCreateXcbSurfaceKHR>(vkGetInstanceProcAddr
+		PFN_vkCreateXcbSurfaceKHR vkCreateXcbSurfaceKHR = reinterpret_cast<PFN_vkCreateXcbSurfaceKHR>(vkGetInstanceProcAddr
 			(
 				instance, "vkCreateXcbSurfaceKHR"
 			));
@@ -3311,7 +3308,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 			return VK_ERROR_EXTENSION_NOT_PRESENT;
 		}
 
-		memset(&sci, 0, sizeof(sci));
+		VkXcbSurfaceCreateInfoKHR sci{};
 		sci.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
 		sci.connection = connection;
 		sci.window = window->Handle;
@@ -3324,10 +3321,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 		return err;
 	}
 
-	VkXlibSurfaceCreateInfoKHR sci{};
-	PFN_vkCreateXlibSurfaceKHR vkCreateXlibSurfaceKHR = nullptr;
-
-	vkCreateXlibSurfaceKHR = reinterpret_cast<PFN_vkCreateXlibSurfaceKHR>(vkGetInstanceProcAddr
+	PFN_vkCreateXlibSurfaceKHR vkCreateXlibSurfaceKHR = reinterpret_cast<PFN_vkCreateXlibSurfaceKHR>(vkGetInstanceProcAddr
 		(
 			instance, "vkCreateXlibSurfaceKHR"
 		));
@@ -3337,7 +3331,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 		return VK_ERROR_EXTENSION_NOT_PRESENT;
 	}
 
-	memset(&sci, 0, sizeof(sci));
+	VkXlibSurfaceCreateInfoKHR sci{};
 	sci.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
 	sci.dpy = s_Data.display;
 	sci.window = window->Handle;

--- a/TRAP/src/Window/WindowingAPIWin32.cpp
+++ b/TRAP/src/Window/WindowingAPIWin32.cpp
@@ -2232,7 +2232,7 @@ bool TRAP::INTERNAL::WindowingAPI::PlatformCreateWindow(InternalWindow* window, 
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowTitle(const InternalWindow* window, std::string& title)
+void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowTitle(const InternalWindow* window, const std::string& title)
 {
 	std::wstring wideTitle = CreateWideStringFromUTF8StringWin32(title);
 	if (wideTitle.empty())

--- a/TRAP/src/Window/WindowingAPIWin32.cpp
+++ b/TRAP/src/Window/WindowingAPIWin32.cpp
@@ -285,7 +285,7 @@ void TRAP::INTERNAL::WindowingAPI::UpdateKeyNamesWin32()
 
 		if (key >= static_cast<uint32_t>(Input::Key::KP_0) && key <= static_cast<uint32_t>(Input::Key::KP_Add))
 		{
-			const std::array<uint32_t, 15> virtualKeys =
+			constexpr std::array<uint32_t, 15> virtualKeys =
 			{
 				VK_NUMPAD0,  VK_NUMPAD1,  VK_NUMPAD2, VK_NUMPAD3,
 				VK_NUMPAD4,  VK_NUMPAD5,  VK_NUMPAD6, VK_NUMPAD7,
@@ -677,7 +677,7 @@ LRESULT CALLBACK TRAP::INTERNAL::WindowingAPI::WindowProc(HWND hWnd, const UINT 
 	case WM_INPUT:
 	{
 		UINT size = 0;
-		HRAWINPUT ri = reinterpret_cast<HRAWINPUT>(lParam);
+		const HRAWINPUT ri = reinterpret_cast<HRAWINPUT>(lParam);
 		int32_t dx, dy;
 
 		if (s_Data.DisabledCursorWindow != windowPtr)
@@ -701,7 +701,7 @@ LRESULT CALLBACK TRAP::INTERNAL::WindowingAPI::WindowProc(HWND hWnd, const UINT 
 			break;
 		}
 
-		std::vector<RAWINPUT> data = s_Data.RawInput;
+		const std::vector<RAWINPUT> data = s_Data.RawInput;
 		if (data[0].data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE)
 		{
 			dx = data[0].data.mouse.lLastX - windowPtr->LastCursorPosX;
@@ -848,7 +848,7 @@ LRESULT CALLBACK TRAP::INTERNAL::WindowingAPI::WindowProc(HWND hWnd, const UINT 
 		if(!windowPtr->Decorated)
 		{
 			MONITORINFO mi;
-			HMONITOR mh = MonitorFromWindow(windowPtr->Handle, MONITOR_DEFAULTTONEAREST);
+			const HMONITOR mh = MonitorFromWindow(windowPtr->Handle, MONITOR_DEFAULTTONEAREST);
 
 			ZeroMemory(&mi, sizeof(mi));
 			mi.cbSize = sizeof(mi);
@@ -921,7 +921,7 @@ LRESULT CALLBACK TRAP::INTERNAL::WindowingAPI::WindowProc(HWND hWnd, const UINT 
 
 			if (!EqualRect(&windowArea, &monitorArea))
 			{
-				RECT* suggested = reinterpret_cast<RECT*>(lParam);
+				const RECT* suggested = reinterpret_cast<RECT*>(lParam);
 				::SetWindowPos(windowPtr->Handle, HWND_TOP, suggested->left, suggested->top,
 				               suggested->right - suggested->left, suggested->bottom - suggested->top,
 					           SWP_NOACTIVATE | SWP_NOZORDER);
@@ -945,7 +945,7 @@ LRESULT CALLBACK TRAP::INTERNAL::WindowingAPI::WindowProc(HWND hWnd, const UINT 
 
 	case WM_DROPFILES:
 	{
-		HDROP drop = reinterpret_cast<HDROP>(wParam);
+		const HDROP drop = reinterpret_cast<HDROP>(wParam);
 		POINT pt;
 
 		const uint32_t count = DragQueryFileW(drop, 0xFFFFFFFF, nullptr, 0);
@@ -1302,7 +1302,7 @@ void TRAP::INTERNAL::WindowingAPI::GetMonitorContentScaleWin32(HMONITOR handle, 
 	}
 	else
 	{
-		HDC dc = GetDC(nullptr);
+		const HDC dc = GetDC(nullptr);
 		xDPI = GetDeviceCaps(dc, LOGPIXELSX);
 		yDPI = GetDeviceCaps(dc, LOGPIXELSY);
 		ReleaseDC(nullptr, dc);
@@ -1413,7 +1413,7 @@ bool TRAP::INTERNAL::WindowingAPI::CreateNativeWindow(InternalWindow* window, co
 			              USER_DEFAULT_SCREEN_DPI);
 	}
 
-	std::wstring wideTitle = CreateWideStringFromUTF8StringWin32(WNDConfig.Title);
+	const std::wstring wideTitle = CreateWideStringFromUTF8StringWin32(WNDConfig.Title);
 	if (wideTitle.empty())
 		return false;
 
@@ -1555,13 +1555,13 @@ LRESULT CALLBACK TRAP::INTERNAL::WindowingAPI::HelperWindowProc(HWND hWnd, UINT 
 	{
 		if (wParam == DBT_DEVICEARRIVAL)
 		{
-			DEV_BROADCAST_HDR* dbh = reinterpret_cast<DEV_BROADCAST_HDR*>(lParam);
+			const DEV_BROADCAST_HDR* dbh = reinterpret_cast<DEV_BROADCAST_HDR*>(lParam);
 			if (dbh && dbh->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
 				Input::DetectControllerConnectionWin32();
 		}
 		else if (wParam == DBT_DEVICEREMOVECOMPLETE)
 		{
-			DEV_BROADCAST_HDR* dbh = reinterpret_cast<DEV_BROADCAST_HDR*>(lParam);
+			const DEV_BROADCAST_HDR* dbh = reinterpret_cast<DEV_BROADCAST_HDR*>(lParam);
 			if (dbh && dbh->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
 				Input::DetectControllerDisconnectionWin32();
 		}
@@ -1689,9 +1689,9 @@ HICON TRAP::INTERNAL::WindowingAPI::CreateIcon(const Image* const image, const i
 	bi.bV5BlueMask = 0x000000ff;
 	bi.bV5AlphaMask = 0xff000000;
 
-	HDC dc = GetDC(nullptr);
-	HBITMAP color = CreateDIBSection(dc, reinterpret_cast<BITMAPINFO*>(&bi), DIB_RGB_COLORS,
-		                             reinterpret_cast<void**>(&target), nullptr, static_cast<DWORD>(0));
+	const HDC dc = GetDC(nullptr);
+	const HBITMAP color = CreateDIBSection(dc, reinterpret_cast<BITMAPINFO*>(&bi), DIB_RGB_COLORS,
+		                                   reinterpret_cast<void**>(&target), nullptr, static_cast<DWORD>(0));
 	ReleaseDC(nullptr, dc);
 
 	if (!color)
@@ -1700,7 +1700,7 @@ HICON TRAP::INTERNAL::WindowingAPI::CreateIcon(const Image* const image, const i
 		return nullptr;
 	}
 
-	HBITMAP mask = CreateBitmap(image->GetWidth(), image->GetHeight(), 1, 1, nullptr);
+	const HBITMAP mask = CreateBitmap(image->GetWidth(), image->GetHeight(), 1, 1, nullptr);
 	if (!mask)
 	{
 		InputErrorWin32(Error::Platform_Error, "[WinAPI] Failed to create mask bitmap");
@@ -1725,7 +1725,7 @@ HICON TRAP::INTERNAL::WindowingAPI::CreateIcon(const Image* const image, const i
 	ii.hbmMask = mask;
 	ii.hbmColor = color;
 
-	HICON handle = CreateIconIndirect(&ii);
+	const HICON handle = CreateIconIndirect(&ii);
 
 	DeleteObject(color);
 	DeleteObject(mask);
@@ -2097,8 +2097,8 @@ bool TRAP::INTERNAL::WindowingAPI::PlatformInit()
 	if(IsWindows7OrGreaterWin32())
 	{
 		CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-		CoCreateInstance(CLSID_TaskbarList, nullptr, CLSCTX_INPROC_SERVER, IID_ITaskbarList3, reinterpret_cast<void**>(&s_Data.TaskbarList));
-		if(!s_Data.TaskbarList)
+		HRESULT result = CoCreateInstance(CLSID_TaskbarList, nullptr, CLSCTX_INPROC_SERVER, IID_ITaskbarList3, reinterpret_cast<void**>(&s_Data.TaskbarList));
+		if(result != S_OK || !s_Data.TaskbarList)
 			CoUninitialize();
 	}
 
@@ -2305,7 +2305,6 @@ bool TRAP::INTERNAL::WindowingAPI::PlatformCreateStandardCursor(InternalCursor* 
 		break;
 	}
 
-
 	cursor->Handle = static_cast<HCURSOR>(LoadImageW(nullptr, MAKEINTRESOURCEW(id), IMAGE_CURSOR, 0, 0,
 		                                             LR_DEFAULTSIZE | LR_SHARED));
 	if (!cursor->Handle)
@@ -2491,7 +2490,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowDecorated(const InternalWind
 
 void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowFloating(const InternalWindow* window, const bool enabled)
 {
-	HWND after = enabled ? HWND_TOPMOST : HWND_NOTOPMOST;
+	const HWND after = enabled ? HWND_TOPMOST : HWND_NOTOPMOST;
 	::SetWindowPos(window->Handle, after, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
 }
 
@@ -2578,7 +2577,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformGetFrameBufferSize(const InternalWind
 void TRAP::INTERNAL::WindowingAPI::PlatformGetWindowContentScale(const InternalWindow* window, float& xScale,
                                                                  float& yScale)
 {
-	HANDLE handle = MonitorFromWindow(window->Handle, MONITOR_DEFAULTTONEAREST);
+	const HANDLE handle = MonitorFromWindow(window->Handle, MONITOR_DEFAULTTONEAREST);
 	GetMonitorContentScaleWin32(static_cast<HMONITOR>(handle), xScale, yScale);
 }
 
@@ -2647,7 +2646,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformPollEvents()
 	//      by the first key release
 	//NOTE: Windows key is not reported as released by the Win+V hot-key
 	//      Other Win hot-keys are handled implicitly by InputWindowFocus because they change the input focus
-	HWND handle = GetActiveWindow();
+	const HWND handle = GetActiveWindow();
 	if (handle)
 	{
 		InternalWindow* windowPtr = static_cast<InternalWindow*>(GetPropW(handle, L"TRAP"));
@@ -2734,17 +2733,17 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetProgress(const InternalWindow* win
 	if(!s_Data.TaskbarList)
 		return;
 
-	uint32_t progress = TRAP::Math::Clamp(completed, 0u, 100u);
+	const uint32_t progress = TRAP::Math::Clamp(completed, 0u, 100u);
 
 	HRESULT res = s_Data.TaskbarList->SetProgressValue(window->Handle, progress, 100u);
-	if(!res == S_OK)
+	if(res != S_OK)
 	{
 		InputErrorWin32(Error::Platform_Error, "[WinAPI] Failed to set progress value");
 		return;
 	}
 
 	res = s_Data.TaskbarList->SetProgressState(window->Handle, static_cast<TBPFLAG>(state));
-	if(!res == S_OK)
+	if(res != S_OK)
 	{
 		InputErrorWin32(Error::Platform_Error, "[WinAPI] Failed to set progress state");
 		return;
@@ -2753,7 +2752,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetProgress(const InternalWindow* win
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-int32_t TRAP::INTERNAL::WindowingAPI::PlatformGetKeyScanCode(Input::Key key)
+int32_t TRAP::INTERNAL::WindowingAPI::PlatformGetKeyScanCode(const Input::Key key)
 {
 	return s_Data.ScanCodes[static_cast<uint32_t>(key)];
 }
@@ -2773,7 +2772,7 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetClipboardString(const std::string&
 	if (!characterCount)
 		return;
 
-	HANDLE object = GlobalAlloc(GMEM_MOVEABLE, characterCount * sizeof(WCHAR));
+	const HANDLE object = GlobalAlloc(GMEM_MOVEABLE, characterCount * sizeof(WCHAR));
 	if (!object)
 	{
 		InputErrorWin32(Error::Platform_Error, "[WinAPI] Failed to allocate global handle for clipboard");
@@ -2813,7 +2812,7 @@ std::string TRAP::INTERNAL::WindowingAPI::PlatformGetClipboardString()
 		return {};
 	}
 
-	HANDLE object = GetClipboardData(CF_UNICODETEXT);
+	const HANDLE object = GetClipboardData(CF_UNICODETEXT);
 	if (!object)
 	{
 		InputErrorWin32(Error::Format_Unavailable, "[WinAPI] Failed to convert clipboard to string");
@@ -2865,7 +2864,7 @@ VkResult TRAP::INTERNAL::WindowingAPI::PlatformCreateWindowSurface(VkInstance in
 		return VK_ERROR_EXTENSION_NOT_PRESENT;
 	}
 
-	VkWin32SurfaceCreateInfoKHR sci
+	const VkWin32SurfaceCreateInfoKHR sci
 	{
 		VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
 		nullptr,


### PR DESCRIPTION
 - Replaced some of the `reinterpret_cast`s with `Utils::BitCast` (backported `std::bit_cast` from C++20)
 - `TRAP_ASSERT` now prints absolute path instead of relative path
 - Replaced `memcpy` with `std::copy_n`
 - Replaced `memset` with `std::fill_n`
 - Replaced `TRAP::FS` namespace with `TRAP::FileSystem`
 - Replaced `std::filesystem::path.generic_u8string()` with `std::filesystem::path.u8string()`
 - Use `std::filesystem::file_size()` instead of `seekg`/`tellg`/`seekg` chain if possible
 - Replaced `const std::string&` with `const std::string_view` where possible
 - Replaced `const char*` with `const std::string_view` where possible
 - Removed `WindowingAPI::StringInExtensionString()`, was unused
 - Removed `Utils::String::FindToken()`
 - `Utils::Memory::SwapBytes()` Added compile time asserts for constant and non reference values (only non-const references are allowed)
 - Replaced `UINT_MAX`, `UINT_MIN`, `LONG_MAX`, `LONG_MIN` with appropriate `std::numeric_limits<>::max()` equivalents
 - Checked all files for `const` correctness