### PR TITLE
Added support for Steamworks SDK 08/18/2022 | 22w33c1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ Dependencies/Nsight-Aftermath/lib/**
 Dependencies/Nsight-Aftermath/include/**
 Dependencies/Nsight-Aftermath/Readme.md
 Dependencies/Nsight-Aftermath/nsight-aftermath-usage-guidelines.txt
+Dependencies/SteamworksSDK/sdk/**
 TRAP.TODO
 compile_commands.json
 .modules/generatedocs/api/**

--- a/Dependencies/DiscordGameSDK/Install.md
+++ b/Dependencies/DiscordGameSDK/Install.md
@@ -14,4 +14,4 @@ The discord_game_sdk.dll file will be automatically copied to the .exe file's fo
 
 ### Linux
 
-The discord_game_sdk.so file will be automatically copied to /usr/local/lib during linking
+The libdiscord_game_sdk.so file will be automatically copied to the executables folder.

--- a/Dependencies/SteamworksSDK/Install.md
+++ b/Dependencies/SteamworksSDK/Install.md
@@ -1,0 +1,17 @@
+# Steamworks SDK
+
+## Installation
+
+1. Get the version 1.55 of the Steamworks SDK from https://partner.steamgames.com/.
+2. Extract the contents of the steamworks_sdk_155.zip file into this folder.
+
+TRAP will then automatically detect if the Steamworks SDK is installed properly on the next run of any GenerateProject script.  
+If everything went right, feel free to use the TRAP::Utils::Steam namespace.
+
+### Windows
+
+The steam_api64.dll file will be automatically copied to the .exe file's folder.
+
+### Linux
+
+The libsteam_api.so file will be automatically copied to the executables folder.

--- a/Games/Sandbox/premake5.lua
+++ b/Games/Sandbox/premake5.lua
@@ -104,6 +104,26 @@ project "Sandbox"
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
 		end
 
+		-- Steamworks SDK stuff
+		if os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/linux64/libsteam_api.so") and
+		   os.isdir("../../Dependencies/SteamworksSDK/sdk/public/steam") then
+
+			links "steam_api"
+			libdirs "%{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/linux64"
+
+			postbuildcommands
+			{
+				"{COPYFILE} %{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/linux64/libsteam_api.so %{cfg.targetdir}"
+			}
+
+			files
+			{
+				"%{IncludeDir.STEAMWORKSSDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
+		end
+
 	filter "system:windows"
 		links
 		{
@@ -154,6 +174,26 @@ project "Sandbox"
 			}
 
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
+		end
+
+		-- Steamworks SDK stuff
+		if os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.dll") and
+		   os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.lib") and
+		   os.isdir("../../Dependencies/SteamworksSDK/sdk/public/steam") then
+
+			links "%{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/win64/steam_api64.lib"
+
+			postbuildcommands
+			{
+				"{COPYDIR} %{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/win64/steam_api64.dll %{cfg.targetdir}"
+			}
+
+			files
+			{
+				"%{IncludeDir.STEAMWORKSSDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
 		end
 
 	filter "configurations:Debug"

--- a/Games/TRAP-Editor/premake5.lua
+++ b/Games/TRAP-Editor/premake5.lua
@@ -104,6 +104,26 @@ project "TRAP-Editor"
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
 		end
 
+		-- Steamworks SDK stuff
+		if os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/linux64/libsteam_api.so") and
+		   os.isdir("../../Dependencies/SteamworksSDK/sdk/public/steam") then
+
+			links "steam_api"
+			libdirs "%{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/linux64"
+
+			postbuildcommands
+			{
+				"{COPYFILE} %{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/linux64/libsteam_api.so %{cfg.targetdir}"
+			}
+
+			files
+			{
+				"%{IncludeDir.STEAMWORKSSDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
+		end
+
 	filter "system:windows"
 		links
 		{
@@ -154,6 +174,26 @@ project "TRAP-Editor"
 			}
 
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
+		end
+
+		-- Steamworks SDK stuff
+		if os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.dll") and
+		   os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.lib") and
+		   os.isdir("../../Dependencies/SteamworksSDK/sdk/public/steam") then
+
+			links "%{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/win64/steam_api64.lib"
+
+			postbuildcommands
+			{
+				"{COPYDIR} %{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/win64/steam_api64.dll %{cfg.targetdir}"
+			}
+
+			files
+			{
+				"%{IncludeDir.STEAMWORKSSDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
 		end
 
 	filter "configurations:Debug"

--- a/Games/Tests/premake5.lua
+++ b/Games/Tests/premake5.lua
@@ -104,6 +104,26 @@ project "Tests"
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
 		end
 
+		-- Steamworks SDK stuff
+		if os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/linux64/libsteam_api.so") and
+		   os.isdir("../../Dependencies/SteamworksSDK/sdk/public/steam") then
+
+			links "steam_api"
+			libdirs "%{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/linux64"
+
+			postbuildcommands
+			{
+				"{COPYFILE} %{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/linux64/libsteam_api.so %{cfg.targetdir}"
+			}
+
+			files
+			{
+				"%{IncludeDir.STEAMWORKSSDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
+		end
+
 	filter "system:windows"
 		links
 		{
@@ -154,6 +174,26 @@ project "Tests"
 			}
 
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
+		end
+
+		-- Steamworks SDK stuff
+		if os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.dll") and
+		   os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.lib") and
+		   os.isdir("../../Dependencies/SteamworksSDK/sdk/public/steam") then
+
+			links "%{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/win64/steam_api64.lib"
+
+			postbuildcommands
+			{
+				"{COPYDIR} %{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/win64/steam_api64.dll %{cfg.targetdir}"
+			}
+
+			files
+			{
+				"%{IncludeDir.STEAMWORKSSDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
 		end
 
 	filter "configurations:Debug"

--- a/Games/Tests3D/premake5.lua
+++ b/Games/Tests3D/premake5.lua
@@ -104,6 +104,26 @@ project "Tests3D"
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
 		end
 
+		-- Steamworks SDK stuff
+		if os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/linux64/libsteam_api.so") and
+		   os.isdir("../../Dependencies/SteamworksSDK/sdk/public/steam") then
+
+			links "steam_api"
+			libdirs "%{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/linux64"
+
+			postbuildcommands
+			{
+				"{COPYFILE} %{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/linux64/libsteam_api.so %{cfg.targetdir}"
+			}
+
+			files
+			{
+				"%{IncludeDir.STEAMWORKSSDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
+		end
+
 	filter "system:windows"
 		links
 		{
@@ -154,6 +174,26 @@ project "Tests3D"
 			}
 
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
+		end
+
+		-- Steamworks SDK stuff
+		if os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.dll") and
+		   os.isfile("../../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.lib") and
+		   os.isdir("../../Dependencies/SteamworksSDK/sdk/public/steam") then
+
+			links "%{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/win64/steam_api64.lib"
+
+			postbuildcommands
+			{
+				"{COPYDIR} %{IncludeDir.STEAMWORKSSDK}/../../redistributable_bin/win64/steam_api64.dll %{cfg.targetdir}"
+			}
+
+			files
+			{
+				"%{IncludeDir.STEAMWORKSSDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
 		end
 
 	filter "configurations:Debug"

--- a/Licenses/SteamworksSDK.LICENSE
+++ b/Licenses/SteamworksSDK.LICENSE
@@ -1,0 +1,67 @@
+================ STEAMWORKS SDK license ===================
+VALVE, Corp.
+SDK LICENSE
+
+This SDK License (the "Agreement") is made by and between you (the "Licensee") and Valve Corporation, a Washington corporation,(“Valve”) with offices located at 10400 NE 4th Street, Suite 1400, Bellevue, WA 98004, USA.
+
+THIS DOCUMENT DESCRIBES A CONTRACT BETWEEN YOU AND VALVE. PLEASE READ IT BEFORE DOWNLOADING OR USING THE STEAMWORKS SOFTWARE DEVELOPMENT KIT (THE “SDK”). BY DOWNLOADING AND/OR USING THE SDK YOU INDICATE YOUR ACCEPTANCE OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT DOWNLOAD AND/OR USE THE SDK.
+
+Whereas, Valve is the developer of an online platform titled "Steam" that provides online distribution services as well as a number of additional online services designed to be embedded in computer games and application software, including, but not limited to, user authentication, in-app purchasing and trading, leaderboards, matchmaking, stats and achievements (the “Steamworks Services”) and the SDK;
+
+Whereas, Licensee wishes to develop a game or application software designed to take advantage of the Steamworks Services (the "Licensee Software"); and
+
+Whereas, Licensee wishes to receive, and Valve wishes to disclose to Licensee, the SDK, and other information as deemed appropriate by Valve, all on the terms set forth herein;
+
+Now, therefore, in consideration of the mutual promises made herein, the parties agree as follows:
+
+1. License.
+
+1.1 License Grant. Valve hereby grants Licensee a nonexclusive, royalty-free, terminable, worldwide, nontransferable license to:
+
+(a) use and locally reproduce the SDK in source code form, solely to develop the Licensee Software; and
+
+(b) reproduce and distribute the part of the SDK provided inside the folder named redistributable_bin (the "SDK Redistributables") along with the Licensee Software in object code form.
+
+1.2 Updates. Valve may from time to time, in its sole discretion, provide updates, error corrections, and future versions of the SDK to Licensee. Upon delivery, such updates, error corrections and future versions shall be deemed part of the SDK, as applicable, under this Agreement.
+
+1.3 Reservation of Rights. Valve reserves all rights not explicitly granted herein.
+
+2. Ancillary Obligations.
+
+2.1 No obligation to provide services. Nothing herein shall be construed as establishing an obligation to Valve to provide Steamworks Services or accept Licensee Software for distribution via Steam.
+
+2.2 Indemnity. Licensee hereby agrees that it is solely responsible for any and all Licensee Software and Licensee's creation, distribution, and promotion thereof. Licensee shall defend, indemnify, and hold harmless Valve, its officers, directors, employees and agents against any and all claims, damages (including reasonable attorneys’ fees and costs), losses, or liabilities whatsoever arising out of Licensee's creation, distribution, or promotion of the Licensee Software.
+
+2.3 Trademarks. Licensee acknowledges and agrees that this Agreement does not grant Licensee any right to use any trademarks or trade names of Valve or its licensors. All such marks shall remain the property of the respective owner. Licensee will refrain from any action or communication that can be incorrectly interpreted as a cooperation or partnership between Valve and Licensee.
+
+2.4 No reverse engineering. Licensee will not take any steps to reverse engineer the functionality of the SDK or develop software to replace the SDK's functionality. If Licensee develops software to interact with the Steamworks Services, such software shall not communicate with the Steamworks Services directly but always through the application programming interface (API) provided by the SDK Redistributables.
+
+3. Term.
+
+3.1 Term. This Agreement shall become effective as of the date Licensee downloads or installs the SDK. It will continue to apply until terminated by either Valve or Licensee as set out below.
+
+3.2 Termination. Valve may terminate this Agreement immediately upon written (including email) notice to Licensee. Licensee may terminate this Agreement at any time by ceasing Licensees use of the SDK and ending Licensee's distribution of Licensee Software created using the SDK. Furthermore, the Agreement will terminate automatically upon Licensee's breach of any term of this Agreement.
+
+3.3 Survival. Sections 1.3, 2, 3.2, 3.3, and 4-6 shall survive any expiration or termination of this Agreement.
+
+4. Disclaimer of Warranties; Limitation of Liability
+
+4.1 NO WARRANTIES. THE SDK AND ANY OTHER MATERIAL DOWNLOADED BY LICENSEE IS PROVIDED “AS IS”. VALVE AND ITS SUPPLIERS DISCLAIM ALL WARRANTIES WITH RESPECT TO THE SDK, EITHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT, TITLE AND FITNESS FOR A PARTICULAR PURPOSE.
+
+4.2 LIMITATION OF LIABILITY. IN NO EVENT SHALL VALVE OR ITS SUPPLIERS BE LIABLE FOR ANY SPECIAL, INCIDENTAL, INDIRECT, OR CONSEQUENTIAL DAMAGES WHATSOEVER (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, OR ANY OTHER PECUNIARY LOSS) ARISING OUT OF THE USE OF OR INABILITY TO USE THE ENGINE AND/OR THE SDK, EVEN IF VALVE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+5. No Exclusivity.
+
+Neither this Agreement nor the disclosure or receipt of Information shall constitute or imply any promise to or intention to make any purchase of products or services by either party or its affiliated companies or any commitment by either party or its affiliated companies with respect to the present or future marketing of any product or service or any commitment to enter into any other business relationship. Except for the license and use restrictions expressly set forth herein, each party will be free (1) to pursue, negotiate, and enter into similar relationships with third parties and (2) to develop, market, and make available similar products and services. Neither party will be obligated to enter into any other agreement with the other party by virtue of this Agreement.
+
+6. General.
+
+6.1 Modification. No amendment or modification of this Agreement shall be valid or binding on the parties unless made in writing and signed on behalf of both of the parties by their respective duly authorized officers or representatives.
+
+6.2 Assignment. Licensee may not assign this agreement without the prior written consent of Valve. Subject to the limitations set forth in this Agreement, this Agreement will inure to the benefit of and be binding upon the parties, their successors and assigns.
+
+6.3 Severability. If any provision of this Agreement shall be held by a court of competent jurisdiction to be illegal, invalid or unenforceable, the remaining provisions shall remain in full force and effect.
+
+6.4 Governing Law, Jurisdiction and Venue. This Agreement shall be governed by the laws of the State of Washington. For any claims of any kind arising out of this Agreement or use of the SDK, each of the parties hereto submits to exclusive jurisdiction and venue in the state and federal courts sitting in King County, Washington.
+
+6.5 Entire Agreement. This Agreement constitutes the entire understanding between the parties hereto and supersedes all previous communications, representations and understandings, oral or written, between the parties, with respect to the subject matter of this Agreement.

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3084,3 +3084,11 @@ SITREP 08/17/2022|22w33b1
     - Tests Added sprite sheets ~<5 mins
     - Tests Added SpriteSheetTests ~<30 mins
     - Renderer2D Fixed a crash while using nullptr SubTexture2D ~<5 mins
+
+SITREP 08/18/2022|22w33c1
+    - Changed TRAP Engine version to 22w33c1(0.8.28)
+    - Branch steamworks:
+        - Update premake scripts to support Steamworks SDK ~<20 mins
+        - Application Added optional AppID parameter to constructor ~<5 mins
+        - SteamworksSDK Initialization, Shutdown and callbacks are now handled in Application ~<10 mins
+        - SteamworksSDK exposed SDK interfaces via TRAP::Utils::Steam ~<15 mins

--- a/TRAP/premake5.lua
+++ b/TRAP/premake5.lua
@@ -118,6 +118,23 @@ project "TRAP"
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
 		end
 
+		-- Steamworks SDK stuff
+		if os.isfile("../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.dll") and
+		   os.isfile("../Dependencies/SteamworksSDK/sdk/redistributable_bin/win64/steam_api64.lib") and
+		   os.isdir("../Dependencies/SteamworksSDK/sdk/public/steam") then
+			sysincludedirs
+			{
+				"%{IncludeDir.STEAMWORKSSDK}"
+			}
+
+			files
+			{
+				"%{IncludeDir.DISCORDGAMESDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
+		end
+
 	filter "system:linux"
 		-- Add Linux-specific files
         files
@@ -163,6 +180,22 @@ project "TRAP"
 			}
 
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
+		end
+
+		-- Steamworks SDK stuff
+		if os.isfile("../Dependencies/SteamworksSDK/sdk/redistributable_bin/linux64/libsteam_api.so") and
+		   os.isdir("../Dependencies/SteamworksSDK/sdk/public/steam") then
+			sysincludedirs
+			{
+				"%{IncludeDir.STEAMWORKSSDK}"
+			}
+
+			files
+			{
+				"%{IncludeDir.DISCORDGAMESDK}/**.h"
+			}
+
+			defines "USE_STEAMWORKS_SDK"
 		end
 
 	filter "configurations:Debug"

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -23,6 +23,7 @@
 #include "Utils/Utils.h"
 #include "Window/Monitor.h"
 #include "Utils/Discord/DiscordGameSDK.h"
+#include "Utils/Steam/SteamworksSDK.h"
 #include "Utils/Memory.h"
 
 TRAP::Application* TRAP::Application::s_Instance = nullptr;
@@ -102,7 +103,7 @@ static bool CheckSingleProcessWindows()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-TRAP::Application::Application(std::string gameName)
+TRAP::Application::Application(std::string gameName, const uint32_t appID)
 	: m_hotReloadingEnabled(false),
 	  m_timer(),
 	  m_FramesPerSecond(0),
@@ -160,6 +161,8 @@ TRAP::Application::Application(std::string gameName)
 		TRAP::TRAPLog.SetFilePath(*logFolder / "trap.log");
 	else //Fallback to current directory
 		TRAP::TRAPLog.SetFilePath("trap.log");
+
+	TRAP::Utils::Steam::Initalize(appID);
 
 	std::filesystem::path cfgPath = "engine.cfg";
 #ifndef TRAP_HEADLESS_MODE
@@ -338,6 +341,7 @@ TRAP::Application::~Application()
 
 	m_layerStack.Shutdown();
 
+	TRAP::Utils::Steam::Shutdown();
 	TRAP::Utils::Discord::Destroy();
 	if(TRAP::Utils::GetLinuxWindowManager() != TRAP::Utils::LinuxWindowManager::Unknown)
 		Input::Shutdown();
@@ -485,6 +489,8 @@ void TRAP::Application::Run()
 
 		//Needed by Discord Game SDK
 		TRAP::Utils::Discord::RunCallbacks();
+		//Needed by Steamworks SDK
+		TRAP::Utils::Steam::RunCallbacks();
 	}
 }
 

--- a/TRAP/src/Application.h
+++ b/TRAP/src/Application.h
@@ -40,7 +40,8 @@ namespace TRAP
 		/// Constructor.
 		/// </summary>
 		/// <param name="gameName">Name of the game.</param>
-		explicit Application(std::string gameName);
+		/// <param name="appID">Optional: Steam AppID for this application. Default: Invalid AppID.</param>
+		explicit Application(std::string gameName, uint32_t appID = 0);
 		/// <summary>
 		/// Destructor.
 		/// </summary>

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -121,7 +121,7 @@ constexpr uint32_t TRAP_VERSION_PATCH(const uint32_t version)
 /// <summary>
 /// TRAP version number created with TRAP_MAKE_VERSION
 /// </summary>
-constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 27);
+constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 28);
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -133,7 +133,7 @@ namespace TRAP
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w33b1]";
+		inline static constexpr auto WindowVersion =                        "[22w33c1]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";
@@ -230,6 +230,7 @@ namespace TRAP
 		inline static constexpr auto NetworkSocketUnixPrefix =              "[Network][Socket][Unix] ";
 		inline static constexpr auto SceneSerializerPrefix =                "[SceneSerializer] ";
 		inline static constexpr auto DiscordGameSDKPrefix =                 "[Discord] ";
+		inline static constexpr auto SteamworksSDKPrefix =                  "[Steam] ";
 		inline static constexpr auto HotReloadingPrefix =                   "[HotReloading] ";
 		inline static constexpr auto UtilsStringPrefix =                    "[Utils][String] ";
 

--- a/TRAP/src/Utils/Steam/SteamworksSDK.cpp
+++ b/TRAP/src/Utils/Steam/SteamworksSDK.cpp
@@ -1,0 +1,241 @@
+#include "TRAPPCH.h"
+#include "SteamworksSDK.h"
+
+#include "Log/Log.h"
+
+#include "Core/Base.h"
+
+#ifdef USE_STEAMWORKS_SDK
+bool steamInitialized = false;
+#endif
+
+//-------------------------------------------------------------------------------------------------------------------//
+#ifdef USE_STEAMWORKS_SDK
+void SteamLogCallback(const int32_t severity, const char* msg)
+{
+    if(severity == 0)
+        TP_INFO(TRAP::Log::SteamworksSDKPrefix, msg);
+    else if(severity == 1)
+        TP_WARN(TRAP::Log::SteamworksSDKPrefix, msg);
+}
+#endif
+//-------------------------------------------------------------------------------------------------------------------//
+
+void TRAP::Utils::Steam::Initalize([[maybe_unused]] const uint32_t appID)
+{
+#ifdef USE_STEAMWORKS_SDK
+    if(steamInitialized)
+        return;
+
+    TP_INFO(TRAP::Log::SteamworksSDKPrefix, "Initializing Steam");
+
+    if(SteamAPI_RestartAppIfNecessary(appID))
+    {
+        TP_ERROR(TRAP::Log::SteamworksSDKPrefix, "Please launch the game through Steam!");
+        std::exit(-1);
+    }
+
+    if(!SteamAPI_Init())
+	{
+        TP_ERROR(TRAP::Log::SteamworksSDKPrefix, "Steam must be running to play this game!");
+        std::exit(-1);
+	}
+
+    SteamUtils()->SetWarningMessageHook(&SteamLogCallback);
+
+    // SteamScreenshots()->HookScreenshots(false);
+#endif
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void TRAP::Utils::Steam::Shutdown()
+{
+#ifdef USE_STEAMWORKS_SDK
+    if(!steamInitialized)
+        return;
+
+    TP_INFO(TRAP::Log::SteamworksSDKPrefix, "Destroying Steam");
+
+    SteamAPI_Shutdown();
+#endif
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void TRAP::Utils::Steam::RunCallbacks()
+{
+#ifdef USE_STEAMWORKS_SDK
+    if(steamInitialized)
+        SteamAPI_RunCallbacks();
+#endif
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+bool TRAP::Utils::Steam::IsInitialized()
+{
+#ifdef USE_STEAMWORKS_SDK
+    return steamInitialized;
+#else
+    return false;
+#endif
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+#ifdef USE_STEAMWORKS_SDK
+
+ISteamApps* TRAP::Utils::Steam::GetSteamApps()
+{
+    return SteamApps();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamFriends* TRAP::Utils::Steam::GetSteamFriends()
+{
+    return SteamFriends();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamHTMLSurface* TRAP::Utils::Steam::GetSteamHTMLSurface()
+{
+    return SteamHTMLSurface();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamHTTP* TRAP::Utils::Steam::GetSteamHTTP()
+{
+    return SteamHTTP();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamInput* TRAP::Utils::Steam::GetSteamInput()
+{
+    return SteamInput();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamInventory* TRAP::Utils::Steam::GetSteamInventory()
+{
+    return SteamInventory();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamMatchmaking* TRAP::Utils::Steam::GetSteamMatchmaking()
+{
+    return SteamMatchmaking();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamMatchmakingServers* TRAP::Utils::Steam::GetSteamMatchmakingServers()
+{
+    return SteamMatchmakingServers();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamMusic* TRAP::Utils::Steam::GetSteamMusic()
+{
+    return SteamMusic();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamMusicRemote* TRAP::Utils::Steam::GetSteamMusicRemote()
+{
+    return SteamMusicRemote();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamNetworkingMessages* TRAP::Utils::Steam::GetSteamNetworkingMessages()
+{
+    return SteamNetworkingMessages();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamNetworkingSockets* TRAP::Utils::Steam::GetSteamNetworkingSockets()
+{
+    return SteamNetworkingSockets();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamNetworkingUtils* TRAP::Utils::Steam::GetSteamNetworkingUtils()
+{
+    return SteamNetworkingUtils();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamParties* TRAP::Utils::Steam::GetSteamParties()
+{
+    return SteamParties();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamRemotePlay* TRAP::Utils::Steam::GetSteamRemotePlay()
+{
+    return SteamRemotePlay();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamRemoteStorage* TRAP::Utils::Steam::GetSteamRemoteStorage()
+{
+    return SteamRemoteStorage();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamScreenshots* TRAP::Utils::Steam::GetSteamScreenshots()
+{
+    return SteamScreenshots();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamUGC* TRAP::Utils::Steam::GetSteamUGC()
+{
+    return SteamUGC();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamUser* TRAP::Utils::Steam::GetSteamUser()
+{
+    return SteamUser();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamUserStats* TRAP::Utils::Steam::GetSteamUserStats()
+{
+    return SteamUserStats();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamUtils* TRAP::Utils::Steam::GetSteamUtils()
+{
+    return SteamUtils();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+ISteamVideo* TRAP::Utils::Steam::GetSteamVideo()
+{
+    return SteamVideo();
+}
+
+#endif

--- a/TRAP/src/Utils/Steam/SteamworksSDK.h
+++ b/TRAP/src/Utils/Steam/SteamworksSDK.h
@@ -1,0 +1,183 @@
+#ifndef TRAP_STEAMWORKSSDK_H
+#define TRAP_STEAMWORKSSDK_H
+
+#include <cstdint>
+#include <string>
+#include <optional>
+
+#ifdef USE_STEAMWORKS_SDK
+
+#ifdef _MSC_VER
+	#pragma warning(push, 0)
+#endif
+#include <steam_api.h>
+#ifdef _MSC_VER
+	#pragma warning(pop)
+#endif
+
+#endif
+
+namespace TRAP::Utils::Steam
+{
+    /// <summary>
+    /// Initialize the Steamworks SDK.
+    /// If the application was launched without Steam, it will be relaunched through Steam.
+    /// A callback for messages will be registered.
+    ///
+    /// Note: This function stops the engine if it fails to initialize.
+    /// </summary>
+    /// <param name="appID">Steam AppID for this application.</param>
+    void Initalize(uint32_t appID);
+
+    /// <summary>
+    /// Shutdown the Steamworks SDK.
+    /// </summary>
+    void Shutdown();
+
+    /// <summary>
+    /// Dispatches callbacks and call results to all of the registered listeners.
+    /// </summary>
+    void RunCallbacks();
+
+    /// <summary>
+    /// Check whether the Steamworks SDK is initialized or not.
+    /// </summary>
+    /// <returns>True if Steamworks SDK is initialized, false otherwise.</returns>
+    bool IsInitialized();
+
+#ifdef USE_STEAMWORKS_SDK
+    /// <summary>
+    /// Retrieve the SteamApps interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamApps interface.</returns>
+    ISteamApps* GetSteamApps();
+
+    /// <summary>
+    /// Retrieve the SteamFriends interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamFriends interface.</returns>
+    ISteamFriends* GetSteamFriends();
+
+    /// <summary>
+    /// Retrieve the SteamHTMLSurface interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamHTMLSurface interface.</returns>
+    ISteamHTMLSurface* GetSteamHTMLSurface();
+
+    /// <summary>
+    /// Retrieve the SteamHTTP interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamHTTP interface.</returns>
+    ISteamHTTP* GetSteamHTTP();
+
+    /// <summary>
+    /// Retrieve the SteamInput interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamInput interface.</returns>
+    ISteamInput* GetSteamInput();
+
+    /// <summary>
+    /// Retrieve the SteamInventory interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamInventory interface.</returns>
+    ISteamInventory* GetSteamInventory();
+
+    /// <summary>
+    /// Retrieve the SteamMatchmaking interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamMatchmaking interface.</returns>
+    ISteamMatchmaking* GetSteamMatchmaking();
+
+    /// <summary>
+    /// Retrieve the SteamMatchmakingServers interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamMatchmakingServers interface.</returns>
+    ISteamMatchmakingServers* GetSteamMatchmakingServers();
+
+    /// <summary>
+    /// Retrieve the SteamMusic interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamMusic interface.</returns>
+    ISteamMusic* GetSteamMusic();
+
+    /// <summary>
+    /// Retrieve the SteamMusicRemote interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamMusicRemote interface.</returns>
+    ISteamMusicRemote* GetSteamMusicRemote();
+
+    /// <summary>
+    /// Retrieve the SteamNetworkingMessages interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamNetworkingMessages interface.</returns>
+    ISteamNetworkingMessages* GetSteamNetworkingMessages();
+
+    /// <summary>
+    /// Retrieve the SteamNetworkingSockets interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamNetworkingSockets interface.</returns>
+    ISteamNetworkingSockets* GetSteamNetworkingSockets();
+
+    /// <summary>
+    /// Retrieve the SteamNetworkingUtils interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamNetworkingUtils interface.</returns>
+    ISteamNetworkingUtils* GetSteamNetworkingUtils();
+
+    /// <summary>
+    /// Retrieve the SteamParties interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamParties interface.</returns>
+    ISteamParties* GetSteamParties();
+
+    /// <summary>
+    /// Retrieve the SteamRemotePlay interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamRemotePlay interface.</returns>
+    ISteamRemotePlay* GetSteamRemotePlay();
+
+    /// <summary>
+    /// Retrieve the SteamRemoteStorage interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamRemoteStorage interface.</returns>
+    ISteamRemoteStorage* GetSteamRemoteStorage();
+
+    /// <summary>
+    /// Retrieve the SteamScreenshots interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamScreenshots interface.</returns>
+    ISteamScreenshots* GetSteamScreenshots();
+
+    /// <summary>
+    /// Retrieve the SteamUGC interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamUGC interface.</returns>
+    ISteamUGC* GetSteamUGC();
+
+    /// <summary>
+    /// Retrieve the SteamUser interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamUser interface.</returns>
+    ISteamUser* GetSteamUser();
+
+    /// <summary>
+    /// Retrieve the SteamUserStats interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamUserStats interface.</returns>
+    ISteamUserStats* GetSteamUserStats();
+
+    /// <summary>
+    /// Retrieve the SteamUtils interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamUtils interface.</returns>
+    ISteamUtils* GetSteamUtils();
+
+    /// <summary>
+    /// Retrieve the SteamVideo interface.
+    /// </summary>
+    /// <returns>Pointer to the SteamVideo interface.</returns>
+    ISteamVideo* GetSteamVideo();
+#endif
+}
+
+#endif /*TRAP_STEAMWORKSSDK_H*/

--- a/premake5.lua
+++ b/premake5.lua
@@ -34,6 +34,7 @@ IncludeDir["MODERNDIALOGS"] = "%{wks.location}/Dependencies/ModernDialogs/Modern
 IncludeDir["DISCORDGAMESDK"] = "%{wks.location}/Dependencies/DiscordGameSDK/cpp"
 IncludeDir["NSIGHTAFTERMATH"] = "%{wks.location}/Dependencies/Nsight-Aftermath/include"
 IncludeDir["VMA"] = "%{wks.location}/Dependencies/VulkanMemoryAllocator/include"
+IncludeDir["STEAMWORKSSDK"] = "%{wks.location}/Dependencies/SteamworksSDK/sdk/public/steam"
 
 include "TRAP"
 


### PR DESCRIPTION
This adds basic support for the Steamworks SDK.

Added support in premake scripts for Steamworks SDK.
Initialization, Shutdown and callbacks are handled by TRAP::Application.
Steamworks SDK functions are exposed through the TRAP::Utils::Steam namespace.