### PR TITLE
Add NVIDIA Reflex support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,7 @@ Dependencies/Nsight-Aftermath/include/**
 Dependencies/Nsight-Aftermath/Readme.md
 Dependencies/Nsight-Aftermath/nsight-aftermath-usage-guidelines.txt
 Dependencies/SteamworksSDK/sdk/**
+Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/**
 TRAP.TODO
 compile_commands.json
 .modules/generatedocs/api/**

--- a/Dependencies/NVIDIA-Reflex/Install.md
+++ b/Dependencies/NVIDIA-Reflex/Install.md
@@ -1,0 +1,15 @@
+# NVIDIA Reflex SDK
+
+## Installation
+
+1. Create an account on the [NVIDIA Developer site](https://developer.nvidia.com/).
+2. Download the NVIDIA Reflex SDK from the [NVIDIA Reflex SDK site](https://developer.nvidia.com/performance-rendering-tools/reflex/get-started).
+3. Extract the contents of the Nvidia_Reflex_SDK_X.X.zip file into this folder.
+
+TRAP will then automatically detect if the NVIDIA Reflex SDK is installed properly on the next run of any GenerateProject script.  
+If everything went right, feel free to use the features via the TRAP::Graphics::RenderCommand::SetLatencyMode() function.  
+NOTE: NVIDIA Reflex is only available on Windows 10 and newer.
+
+### Windows
+
+The NvLowLatencyVk.dll file will be automatically copied to the .exe file's folder.

--- a/Dependencies/NVIDIA-Reflex/license.txt
+++ b/Dependencies/NVIDIA-Reflex/license.txt
@@ -1,0 +1,189 @@
+LICENSE AGREEMENT FOR NVIDIA SOFTWARE DEVELOPMENT KITS
+
+This license agreement, including exhibits attached ("Agreement”) is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs your use of a NVIDIA software development kit (“SDK”). 
+
+Each SDK has its own set of software and materials, but here is a description of the types of items that may be included in a SDK: source code, header files, APIs, data sets and assets (examples include images, textures, models, scenes, videos, native API input/output files), binary software, sample code, libraries, utility programs, programming code and documentation. 
+
+This Agreement can be accepted only by an adult of legal age of majority in the country in which the SDK is used. 
+
+If you are entering into this Agreement on behalf of a company or other legal entity, you represent that you have the legal authority to bind the entity to this Agreement, in which case “you” will mean the entity you represent. 
+
+If you don’t have the required age or authority to accept this Agreement, or if you don’t accept all the terms and conditions of this Agreement, do not download, install or use the SDK.  
+
+You agree to use the SDK only for purposes that are permitted by (a) this Agreement, and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions.
+
+1. License. 
+
+1.1 Grant
+
+Subject to the terms of this Agreement, NVIDIA hereby grants you a non-exclusive, non-transferable license, without the right to sublicense (except as expressly provided in this Agreement) to: 
+
+(i) Install and use the SDK,
+
+(ii) Modify and create derivative works of sample source code delivered in the SDK, and
+ 
+(iii) Distribute those portions of the SDK that are identified in this Agreement as distributable, as incorporated in object code format into a software application that meets the distribution requirements indicated in this Agreement.
+
+1.2 Distribution Requirements
+
+These are the distribution requirements for you to exercise the distribution grant:
+       
+(i) Your application must have material additional functionality, beyond the included portions of the SDK.
+
+(ii) The distributable portions of the SDK shall only be accessed by your application.  
+
+(iii)  The following notice shall be included in modifications and derivative works of sample source code distributed: “This software contains source code provided by NVIDIA Corporation.”
+
+(iv)  Unless a developer tool is identified in this Agreement as distributable, it is delivered for your internal use only.
+
+(v) The terms under which you distribute your application must be consistent with the terms of this Agreement, including (without limitation) terms relating to the license grant and license restrictions and protection of NVIDIA’s intellectual property rights. Additionally, you agree that you will protect the privacy, security and legal rights of your application users. 
+
+(vi) You agree to notify NVIDIA in writing of any known or suspected distribution or use of the SDK not in compliance with the requirements of this Agreement, and to enforce the terms of your agreements with respect to distributed SDK.
+
+1.3 Authorized Users
+
+You may allow employees and contractors of your entity or of your subsidiary(ies) to access and use the SDK from your secure network to perform work on your behalf. 
+
+If you are an academic institution you may allow users enrolled or employed by the academic institution to access and use the SDK from your secure network. 
+
+You are responsible for the compliance with the terms of this Agreement by your authorized users. If you become aware that your authorized users didn’t follow the terms of this Agreement, you agree to take reasonable steps to resolve the non-compliance and prevent new occurrences. 
+
+1.4 Pre-Release SDK 
+The SDK versions identified as alpha, beta, preview or otherwise as pre-release, may not be fully functional, may contain errors or design flaws, and may have reduced or different security, privacy, accessibility, availability, and reliability standards relative to commercial versions of NVIDIA software and materials. Use of a pre-release SDK may result in unexpected results, loss of data, project delays or other unpredictable damage or loss. 
+You may use a pre-release SDK at your own risk, understanding that pre-release SDKs are not intended for use in production or business-critical systems. 
+NVIDIA may choose not to make available a commercial version of any pre-release SDK. NVIDIA may also choose to abandon development and terminate the availability of a pre-release SDK at any time without liability. 
+1.5	 Updates
+
+NVIDIA may, at its option, make available patches, workarounds or other updates to this SDK. Unless the updates are provided with their separate governing terms, they are deemed part of the SDK licensed to you as provided in this Agreement.
+
+You agree that the form and content of the SDK that NVIDIA provides may change without prior notice to you. While NVIDIA generally maintains compatibility between versions, NVIDIA may in some cases make changes that introduce incompatibilities in future versions of the SDK.
+
+1.6	 Third Party Licenses
+
+The SDK may come bundled with, or otherwise include or be distributed with, third party software licensed by a NVIDIA supplier and/or open source software provided under an open source license. Use of third party software is subject to the third-party license terms, or in the absence of third party terms, the terms of this Agreement. Copyright to third party software is held by the copyright holders indicated in the third-party software or license.
+
+1.7 Reservation of Rights
+
+NVIDIA reserves all rights, title and interest in and to the SDK not expressly granted to you under this Agreement.
+
+2. Limitations. 
+
+The following license limitations apply to your use of the SDK:
+
+2.1 You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary notices from any portion of the SDK or copies of the SDK. 
+
+2.2 Except as expressly provided in this Agreement, you may not copy, sell, rent, sublicense, transfer, distribute, modify, or create derivative works of any portion of the SDK. 
+
+2.3 Unless you have an agreement with NVIDIA for this purpose, you may not indicate that an application created with the SDK is sponsored or endorsed by NVIDIA. 
+
+2.4 You may not bypass, disable, or circumvent any encryption, security, digital rights management or authentication mechanism in the SDK. 
+
+2.5 You may not use the SDK in any manner that would cause it to become subject to an open source software license. As examples, licenses that require as a condition of use, modification, and/or distribution that the SDK be (i) disclosed or distributed in source code form; (ii) licensed for the purpose of making derivative works; or (iii) redistributable at no charge.
+
+2.6  Unless you have an agreement with NVIDIA for this purpose, you may not use the SDK with any system or application where the use or failure of the system or application can reasonably be expected to threaten or result in personal injury, death, or catastrophic loss. Examples include use in avionics, navigation, military, medical, life support or other life critical applications. NVIDIA does not design, test or manufacture the SDK for these critical uses and NVIDIA shall not be liable to you or any third party, in whole or in part, for any claims or damages arising from such uses. 
+
+2.7 You agree to defend, indemnify and hold harmless NVIDIA and its affiliates, and their respective employees, contractors, agents, officers and directors, from and against any and all claims, damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses (including but not limited to attorney’s fees and costs incident to establishing the right of indemnification) arising out of or related to your use of the SDK outside of the scope of this Agreement, or not in compliance with its terms.
+
+3. Ownership. 
+
+3.1 NVIDIA or its licensors hold all rights, title and interest in and to the SDK and its modifications and derivative works, including their respective intellectual property rights, subject to your rights under Section 3.2. This SDK may include software and materials from NVIDIA’s licensors, and these licensors are intended third party beneficiaries that may enforce this Agreement with respect to their intellectual property rights. 
+
+3.2 You hold all rights, title and interest in and to your applications and your derivative works of the sample source code delivered in the SDK, including their respective intellectual property rights, subject to NVIDIA’s rights under section 3.1.
+
+3.3 You may, but don’t have to, provide to NVIDIA suggestions, feature requests or other feedback regarding the SDK, including possible enhancements or modifications to the SDK. For any feedback that you voluntarily provide, you hereby grant NVIDIA and its affiliates a perpetual, non-exclusive, worldwide, irrevocable license to use, reproduce, modify, license, sublicense (through multiple tiers of sublicensees), and distribute (through multiple tiers of distributors) it without the payment of any royalties or fees to you. NVIDIA will use feedback at its choice. 
+
+4.  No Warranties. 
+
+THE SDK IS PROVIDED BY NVIDIA “AS IS” AND “WITH ALL FAULTS.” TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND ITS AFFILIATES EXPRESSLY DISCLAIM ALL WARRANTIES OF ANY KIND OR NATURE, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, NON-INFRINGEMENT, OR THE ABSENCE OF ANY DEFECTS THEREIN, WHETHER LATENT OR PATENT. NO WARRANTY IS MADE ON THE BASIS OF TRADE USAGE, COURSE OF DEALING OR COURSE OF TRADE. 
+
+5.	Limitations of Liability. 
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND ITS AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR ANY LOST PROFITS, LOSS OF USE, LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH THIS AGREEMENT OR THE USE OR PERFORMANCE OF THE SDK, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON BREACH OF CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF ACTION OR THEORY OF LIABILITY. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL CUMULATIVE LIABILITY UNDER OR ARISING OUT OF THIS AGREEMENT EXCEED US$10.00. THE NATURE OF THE LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE OR EXTEND THIS LIMIT. 
+
+These exclusions and limitations of liability shall apply regardless if NVIDIA or its affiliates have been advised of the possibility of such damages, and regardless of whether a remedy fails its essential purpose. These exclusions and limitations of liability form an essential basis of the bargain between the parties, and, absent any of these exclusions or limitations of liability, the provisions of this Agreement, including, without limitation, the economic terms, would be substantially different. 
+
+6.   Termination. 
+
+6.1 This Agreement will continue to apply until terminated by either you or NVIDIA as described below. 
+
+6.2 If you want to terminate this Agreement, you may do so by stopping to use the SDK. 
+
+6.3 NVIDIA may, at any time, terminate this Agreement if: (i) you fail to comply with any term of this Agreement and the non-compliance is not fixed within thirty (30) days following notice from NVIDIA (or immediately if you violate NVIDIA’s intellectual property rights); (ii) you commence or participate in any legal proceeding against NVIDIA with respect to the SDK; or (iii) NVIDIA decides to no longer provide the SDK in a country or, in NVIDIA’s sole discretion, the continued use of it is no longer commercially viable. 
+
+6.4 Upon any termination of this Agreement, you agree to promptly discontinue use of the SDK and destroy all copies in your possession or control. Your prior distributions in accordance with this Agreement are not affected by the termination of this Agreement. Upon written request, you will certify in writing that you have complied with your commitments under this section. Upon any termination of this Agreement all provisions survive except for the licenses granted to you. 
+
+7.  General.  
+ 
+If you wish to assign this Agreement or your rights and obligations, including by merger, consolidation, dissolution or operation of law, contact NVIDIA to ask for permission. Any attempted assignment not approved by NVIDIA in writing shall be void and of no effect. NVIDIA may assign, delegate or transfer this Agreement and its rights and obligations, and if to a non-affiliate you will be notified. 
+
+You agree to cooperate with NVIDIA and provide reasonably requested information to verify your compliance with this Agreement.
+
+This Agreement will be governed in all respects by the laws of the United States and of the State of Delaware as those laws are applied to contracts entered into and performed entirely within Delaware by Delaware residents, without regard to the conflicts of laws principles. The United Nations Convention on Contracts for the International Sale of Goods is specifically disclaimed. You agree to all terms of this Agreement in the English language.
+
+The state or federal courts residing in Santa Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of this Agreement. Notwithstanding this, you agree that NVIDIA shall still be allowed to apply for injunctive remedies or an equivalent type of urgent legal relief in any jurisdiction. 
+
+If any court of competent jurisdiction determines that any provision of this Agreement is illegal, invalid or unenforceable, such provision will be construed as limited to the extent necessary to be consistent with and fully enforceable under the law and the remaining provisions will remain in full force and effect. Unless otherwise specified, remedies are cumulative.
+
+Each party acknowledges and agrees that the other is an independent contractor in the performance of this Agreement. 
+
+The SDK has been developed entirely at private expense and is “commercial items” consisting of “commercial computer software” and “commercial computer software documentation” provided with RESTRICTED RIGHTS. Use, duplication or disclosure by the U.S. Government or a U.S. Government subcontractor is subject to the restrictions in this Agreement pursuant to DFARS 227.7202-3(a) or as set forth in subparagraphs (b)(1) and (2) of the Commercial Computer Software - Restricted Rights clause at FAR 52.227-19, as applicable. Contractor/manufacturer is NVIDIA, 2788 San Tomas Expressway, Santa Clara, CA 95051.
+
+The SDK is subject to United States export laws and regulations. You agree that you will not ship, transfer or export the SDK into any country, or use the SDK in any manner, prohibited by the United States Bureau of Industry and Security or economic sanctions regulations administered by the U.S. Department of Treasury’s Office of Foreign Assets Control (OFAC), or any applicable export laws, restrictions or regulations. These laws include restrictions on destinations, end users and end use. By accepting this Agreement, you confirm that you are not a resident or citizen of any country currently embargoed by the U.S. and that you are not otherwise prohibited from receiving the SDK.
+
+Any notice delivered by NVIDIA to you under this Agreement will be delivered via mail, email or fax. You agree that any notices that NVIDIA sends you electronically will satisfy any legal communication requirements. Please direct your legal notices or other correspondence to NVIDIA Corporation, 2788 San Tomas Expressway, Santa Clara, California 95051, United States of America, Attention: Legal Department.
+
+This Agreement and any exhibits incorporated into this Agreement constitute the entire agreement of the parties with respect to the subject matter of this Agreement and supersede all prior negotiations or documentation exchanged between the parties relating to this SDK license. Any additional and/or conflicting terms on documents issued by you are null, void, and invalid. Any amendment or waiver under this Agreement shall be in writing and signed by representatives of both parties.
+
+(v. December 9, 2020)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+REFLEX LOW LATENCY SDK SUPPLEMENT 
+TO SOFTWARE LICENSE AGREEMENT FOR NVIDIA SOFTWARE DEVELOPMENT KITS
+
+The terms in this supplement govern your use of the pre-release version of the NVIDIA Reflex Low Latency SDK under the terms of your license agreement (“Agreement”) as modified by this supplement. Capitalized terms used but not defined below have the meaning assigned to them in the Agreement.
+
+This supplement is an exhibit to the Agreement and is incorporated as an integral part of the Agreement. In the event of conflict between the terms in this supplement and the terms in the Agreement, the terms in this supplement govern.  
+
+1. License Scope. The SDK is licensed for you to develop applications only for use in systems with NVIDIA GPUs.
+
+2. Distribution. The following portions of the SDK are distributable under the Agreement as incorporated into your application: the NVAPIs, .lib and .h files, Linux wrapper, and samples (as provided by NVIDIA or your derivative works). 
+
+3.  Marketing Requirements. Your license to the SDK under the Agreement is subject to your compliance with the following marketing terms:
+
+3.1 You must attribute the use of the SDK by including a NVIDIA Reflex reference for features in your product developed with use of the SDK, in accordance with the UI guidelines available within the Reflex SDK package. 
+3.2 You may, during the term of this Agreement, identify NVIDIA on your websites, printed collateral, tradeshow displays and other retail packaging materials as the supplier of the SDK for applications developed with use of the SDK, in accordance with the UI guidelines. 
+3.3  NVIDIA grants to you a non-exclusive, non-sublicensable, non-transferable, worldwide license, subject to the terms of this supplement and the Agreement, to use NVIDIA™ or NVIDIA Reflex solely for marketing as set forth in Sections 3.1 and 3.2 above. You will not (and will not permit others to) use any NVIDIA mark for any other goods or services, or in a way that tarnishes, degrades, disparages or reflects adversely on NVIDIA or its marks, or NVIDIA’s business or reputation. You will follow NVIDIA specifications as to style, color, and typeface, as provided from time to time. In addition to the termination rights set forth in the Agreement, NVIDIA may terminate this license at any time upon written notice to you. All goodwill associated with use of NVIDIA marks will inure to the sole benefit of NVIDIA.
+3.4  You agree that you will take such steps as are reasonably necessary to ensure that neither you, nor any person under your control, make any false or misleading representations with regard to NVIDIA or its products, or publish or employ or cooperate in the publication or employment of any misleading or deceptive advertising or promotional materials. You agree that you will not, directly or indirectly, in any country or governing body, apply to register in your own name, or otherwise attempt to acquire any legal interest in or right in or to, any NVIDIA mark.
+
+3.5 Identification by NVIDIA.  You agree that NVIDIA may identify your name on NVIDIA's websites or other materials as an individual or entity that produces products and services which incorporate the SDK.
+
+4.  Audio/Video Encoders and Decoders. You acknowledge and agree that it is your sole responsibility to obtain any additional third party licenses required to make, have made, use, have used, sell, import, and offer for sale your products or services that include or incorporate any third party software and content relating to audio and/or video encoders and decoders from, including but not limited to, Microsoft, Thomson, Fraunhofer IIS, Sisvel S.p.A., MPEG-LA, and Coding Technologies as NVIDIA does not grant to you under this Agreement any necessary patent or other rights with respect to audio and/or video encoders and decoders. 
+
+(v. December 9, 2020)
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Games/Sandbox/premake5.lua
+++ b/Games/Sandbox/premake5.lua
@@ -201,12 +201,17 @@ project "Sandbox"
 		-- NVIDIA Reflex SDK stuff
 		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
 		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
-		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Stats/reflexstats.h") then
 			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
 
 			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
 
-			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+			externalincludedirs
+			{
+				"%{IncludeDir.NVIDIAREFLEX}",
+				"%{IncludeDir.NVIDIAREFLEXSTATS}"
+			}
 
 			defines "NVIDIA_REFLEX_AVAILABLE"
 		end

--- a/Games/Sandbox/premake5.lua
+++ b/Games/Sandbox/premake5.lua
@@ -198,6 +198,19 @@ project "Sandbox"
 			defines "USE_STEAMWORKS_SDK"
 		end
 
+		-- NVIDIA Reflex SDK stuff
+		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
+
+			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
+
+			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+
+			defines "NVIDIA_REFLEX_AVAILABLE"
+		end
+
 	filter "configurations:Debug"
 		defines "TRAP_DEBUG"
 		runtime "Debug"

--- a/Games/TRAP-Editor/premake5.lua
+++ b/Games/TRAP-Editor/premake5.lua
@@ -201,12 +201,17 @@ project "TRAP-Editor"
 		-- NVIDIA Reflex SDK stuff
 		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
 		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
-		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Stats/reflexstats.h") then
 			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
 
 			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
 
-			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+			externalincludedirs
+			{
+				"%{IncludeDir.NVIDIAREFLEX}",
+				"%{IncludeDir.NVIDIAREFLEXSTATS}"
+			}
 
 			defines "NVIDIA_REFLEX_AVAILABLE"
 		end

--- a/Games/TRAP-Editor/premake5.lua
+++ b/Games/TRAP-Editor/premake5.lua
@@ -198,6 +198,19 @@ project "TRAP-Editor"
 			defines "USE_STEAMWORKS_SDK"
 		end
 
+		-- NVIDIA Reflex SDK stuff
+		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
+
+			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
+
+			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+
+			defines "NVIDIA_REFLEX_AVAILABLE"
+		end
+
 	filter "configurations:Debug"
 		defines "TRAP_DEBUG"
 		runtime "Debug"

--- a/Games/Tests/premake5.lua
+++ b/Games/Tests/premake5.lua
@@ -198,6 +198,19 @@ project "Tests"
 			defines "USE_STEAMWORKS_SDK"
 		end
 
+		-- NVIDIA Reflex SDK stuff
+		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
+
+			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
+
+			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+
+			defines "NVIDIA_REFLEX_AVAILABLE"
+		end
+
 	filter "configurations:Debug"
 		defines "TRAP_DEBUG"
 		runtime "Debug"

--- a/Games/Tests/premake5.lua
+++ b/Games/Tests/premake5.lua
@@ -201,12 +201,17 @@ project "Tests"
 		-- NVIDIA Reflex SDK stuff
 		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
 		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
-		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Stats/reflexstats.h") then
 			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
 
 			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
 
-			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+			externalincludedirs
+			{
+				"%{IncludeDir.NVIDIAREFLEX}",
+				"%{IncludeDir.NVIDIAREFLEXSTATS}"
+			}
 
 			defines "NVIDIA_REFLEX_AVAILABLE"
 		end

--- a/Games/Tests/src/NVIDIAReflex/NVIDIAReflexTests.cpp
+++ b/Games/Tests/src/NVIDIAReflex/NVIDIAReflexTests.cpp
@@ -1,0 +1,151 @@
+#include "NVIDIAReflexTests.h"
+
+NVIDIAReflexTests::NVIDIAReflexTests()
+	: Layer("NVIDIA Reflex"),
+	  m_shader(nullptr), m_latencyMode()
+{
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void NVIDIAReflexTests::OnAttach()
+{
+	TRAP::Application::GetWindow()->SetTitle("NVIDIA Reflex");
+
+	m_latencyMode = TRAP::Graphics::RenderCommand::GetLatencyMode();
+
+	//Load Icosphere vertices
+	m_vertexBuffer = TRAP::Graphics::VertexBuffer::Create(m_icoSphereVerticesIndexed.data(),
+		                                                  static_cast<uint32_t>(m_icoSphereVerticesIndexed.size()) *
+														  sizeof(float), TRAP::Graphics::UpdateFrequency::Static);
+	const TRAP::Graphics::VertexBufferLayout layout =
+	{
+		{TRAP::Graphics::ShaderDataType::Float3, "Pos"},
+		{TRAP::Graphics::ShaderDataType::Float3, "Col"}
+	};
+	m_vertexBuffer->SetLayout(layout);
+	m_vertexBuffer->AwaitLoading();
+	m_vertexBuffer->Use();
+
+	//Load Icosphere indices
+	m_indexBuffer = TRAP::Graphics::IndexBuffer::Create(m_icosphereIndices.data(),
+	                                                    static_cast<uint32_t>(m_icosphereIndices.size()) *
+														sizeof(uint16_t), TRAP::Graphics::UpdateFrequency::Static);
+	m_indexBuffer->AwaitLoading();
+	m_indexBuffer->Use();
+
+	//Load Camera UniformBuffer
+	m_cameraUBO = TRAP::Graphics::UniformBuffer::Create(sizeof(CameraUBOData),
+	                                                    TRAP::Graphics::UpdateFrequency::Dynamic);
+	m_cameraUBO->AwaitLoading();
+
+	//Load Shader
+	m_shader = TRAP::Graphics::ShaderManager::LoadFile("IcoSphereTest", "./Assets/Shaders/icosphere.shader");
+
+	//Wait for all pending resources (just in case)
+	TRAP::Graphics::RendererAPI::GetResourceLoader()->WaitForAllResourceLoads();
+
+	//Camera setup
+	m_camera.SetPerspective(TRAP::Math::Radians(45.0f), 0.01f);
+	m_camera.SetViewportSize(TRAP::Application::GetWindow()->GetWidth(),
+	                         TRAP::Application::GetWindow()->GetHeight());
+	m_cameraTransform.Position = TRAP::Math::Vec3(0.0f, 0.0f, 8.0f);
+
+	//Enable depth testing because this is 3D stuff
+	TRAP::Graphics::RenderCommand::SetDepthTesting(true);
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void NVIDIAReflexTests::OnDetach()
+{
+	m_cameraUBO.reset();
+	m_indexBuffer.reset();
+	m_vertexBuffer.reset();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void NVIDIAReflexTests::OnUpdate(const TRAP::Utils::TimeStep&)
+{
+	TRAP::Graphics::RenderCommand::SetFillMode(TRAP::Graphics::FillMode::Solid);
+	TRAP::Graphics::RenderCommand::SetCullMode(TRAP::Graphics::CullMode::Back);
+
+	//Camera UBO
+	{
+		CameraUBOData camera{};
+		camera.Projection = m_camera.GetProjectionMatrix();
+		camera.View = TRAP::Math::Inverse(m_cameraTransform.GetTransform());
+		camera.Model = TRAP::Math::Rotate(TRAP::Math::Radians(20.0f * TRAP::Application::GetTime()),
+		                                  TRAP::Math::Vec3(1.0f, 1.0f, 1.0f));
+
+		m_cameraUBO->SetData(&camera, sizeof(CameraUBOData));
+		m_shader->UseUBO(1, 0, m_cameraUBO.get());
+	}
+
+	m_vertexBuffer->Use();
+	m_indexBuffer->Use();
+	m_shader->Use();
+	TRAP::Graphics::RenderCommand::DrawIndexed(static_cast<uint32_t>(m_icosphereIndices.size()));
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void NVIDIAReflexTests::OnImGuiRender()
+{
+	ImGui::Begin("NVIDIA Reflex", nullptr, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+	                                   ImGuiWindowFlags_AlwaysAutoResize);
+	ImGui::Text("Press ESC to close");
+	ImGui::Separator();
+	ImGui::Text("Performance:");
+    ImGui::Text("CPU: %ix %s", TRAP::Utils::GetCPUInfo().LogicalCores, TRAP::Utils::GetCPUInfo().Model.c_str());
+    ImGui::Text("GPU: %s", TRAP::Graphics::RendererAPI::GetRenderer()->GetCurrentGPUName().c_str());
+    ImGui::Text("FPS: %u", TRAP::Graphics::Renderer::GetFPS());
+    ImGui::Text("CPU FrameTime: %.3fms", TRAP::Graphics::Renderer::GetCPUFrameTime());
+    ImGui::Text("GPU Graphics FrameTime: %.3fms", TRAP::Graphics::RenderCommand::GetGPUGraphicsFrameTime());
+    ImGui::Text("GPU Compute FrameTime: %.3fms", TRAP::Graphics::RenderCommand::GetGPUComputeFrameTime());
+    ImGui::Separator();
+	ImGui::Text("NVIDIA Reflex:");
+	if(!TRAP::Graphics::RendererAPI::GPUSettings.ReflexSupported)
+		ImGui::Text("NVIDIA Reflex is not supported on this GPU!");
+	else
+	{
+		ImGui::Text("Current Latency Mode: %s", TRAP::Utils::String::ConvertToString(m_latencyMode).c_str());
+
+		constexpr std::array<const char*, 3> latencyModes{"Disabled", "Enabled", "Enabled+Boost"};
+		static int32_t currentLatencyMode = static_cast<int32_t>(m_latencyMode);
+		if(ImGui::Combo("Latency Mode", &currentLatencyMode, latencyModes.data(), latencyModes.size()))
+		{
+			if(static_cast<int32_t>(m_latencyMode) != currentLatencyMode)
+			{
+				m_latencyMode = static_cast<TRAP::Graphics::LatencyMode>(currentLatencyMode);
+				TRAP::Graphics::RenderCommand::SetLatencyMode(m_latencyMode);
+				m_latencyMode = TRAP::Graphics::RenderCommand::GetLatencyMode();
+			}
+		}
+	}
+	ImGui::Separator();
+	ImGui::Text("This software contains source code provided by NVIDIA Corporation.");
+	ImGui::End();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void NVIDIAReflexTests::OnEvent(TRAP::Events::Event& event)
+{
+	TRAP::Events::EventDispatcher dispatcher(event);
+	dispatcher.Dispatch<TRAP::Events::KeyPressEvent>([this](TRAP::Events::KeyPressEvent& e)
+	{
+		return OnKeyPress(e);
+	});
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+bool NVIDIAReflexTests::OnKeyPress(TRAP::Events::KeyPressEvent& e)
+{
+	if (e.GetKey() == TRAP::Input::Key::Escape)
+		TRAP::Application::Shutdown();
+
+	return false;
+}

--- a/Games/Tests/src/NVIDIAReflex/NVIDIAReflexTests.cpp
+++ b/Games/Tests/src/NVIDIAReflex/NVIDIAReflexTests.cpp
@@ -87,6 +87,59 @@ void NVIDIAReflexTests::OnUpdate(const TRAP::Utils::TimeStep&)
 	m_indexBuffer->Use();
 	m_shader->Use();
 	TRAP::Graphics::RenderCommand::DrawIndexed(static_cast<uint32_t>(m_icosphereIndices.size()));
+
+#ifdef NVIDIA_REFLEX_AVAILABLE
+	//Update latency history
+	if (m_updateLatencyTimer.Elapsed() >= 0.025f)
+	{
+		const auto latencyData = TRAP::Graphics::RendererAPI::GetRenderer()->ReflexGetLatency();
+		const auto& curr = latencyData.frameReport[63];
+		const float totalGameToRenderLatencyMs = (curr.gpuRenderEndTime - curr.simStartTime) / 1000.0f;
+		const float simulationDeltaMs = (curr.simEndTime - curr.simStartTime) / 1000.0f;
+		const float renderDeltaMs = (curr.renderSubmitEndTime - curr.renderSubmitStartTime) / 1000.0f;
+		const float presentDeltaMs = (curr.presentEndTime - curr.presentStartTime) / 1000.0f;
+		const float driverDeltaMs = (curr.driverEndTime - curr.driverStartTime) / 1000.0f;
+		const float OSRenderQueueDeltaMs = (curr.osRenderQueueEndTime - curr.osRenderQueueStartTime) / 1000.0f;
+		const float GPURenderDeltaMs = (curr.gpuRenderEndTime - curr.gpuRenderStartTime) / 1000.0f;
+
+		static int frameTimeIndex = 0;
+		m_updateLatencyTimer.Reset();
+		if (frameTimeIndex < static_cast<int32_t>(m_totalHistory.size() - 1))
+		{
+			if(curr.gpuRenderEndTime != 0)
+			{
+				m_totalHistory[frameTimeIndex] = totalGameToRenderLatencyMs;
+				m_simulationDeltaHistory[frameTimeIndex] = simulationDeltaMs;
+				m_renderDeltaHistory[frameTimeIndex] = renderDeltaMs;
+				m_presentDeltaHistory[frameTimeIndex] = presentDeltaMs;
+				m_driverDeltaHistory[frameTimeIndex] = driverDeltaMs;
+				m_OSRenderQueueDeltaHistory[frameTimeIndex] = OSRenderQueueDeltaMs;
+				m_GPURenderDeltaHistory[frameTimeIndex] = GPURenderDeltaMs;
+			}
+			frameTimeIndex++;
+		}
+		else
+		{
+			if(curr.gpuRenderEndTime != 0)
+			{
+				std::move(m_totalHistory.begin() + 1, m_totalHistory.end(), m_totalHistory.begin());
+				m_totalHistory[m_totalHistory.size() - 1] = totalGameToRenderLatencyMs;
+				std::move(m_simulationDeltaHistory.begin() + 1, m_simulationDeltaHistory.end(), m_simulationDeltaHistory.begin());
+				m_simulationDeltaHistory[m_simulationDeltaHistory.size() - 1] = simulationDeltaMs;
+				std::move(m_renderDeltaHistory.begin() + 1, m_renderDeltaHistory.end(), m_renderDeltaHistory.begin());
+				m_renderDeltaHistory[m_renderDeltaHistory.size() - 1] = renderDeltaMs;
+				std::move(m_presentDeltaHistory.begin() + 1, m_presentDeltaHistory.end(), m_presentDeltaHistory.begin());
+				m_presentDeltaHistory[m_presentDeltaHistory.size() - 1] = presentDeltaMs;
+				std::move(m_driverDeltaHistory.begin() + 1, m_driverDeltaHistory.end(), m_driverDeltaHistory.begin());
+				m_driverDeltaHistory[m_driverDeltaHistory.size() - 1] = driverDeltaMs;
+				std::move(m_OSRenderQueueDeltaHistory.begin() + 1, m_OSRenderQueueDeltaHistory.end(), m_OSRenderQueueDeltaHistory.begin());
+				m_OSRenderQueueDeltaHistory[m_OSRenderQueueDeltaHistory.size() - 1] = OSRenderQueueDeltaMs;
+				std::move(m_GPURenderDeltaHistory.begin() + 1, m_GPURenderDeltaHistory.end(), m_GPURenderDeltaHistory.begin());
+				m_GPURenderDeltaHistory[m_GPURenderDeltaHistory.size() - 1] = GPURenderDeltaMs;
+			}
+		}
+	}
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -127,6 +180,22 @@ void NVIDIAReflexTests::OnImGuiRender()
 	ImGui::Separator();
 	ImGui::Text("This software contains source code provided by NVIDIA Corporation.");
 	ImGui::End();
+
+#ifdef NVIDIA_REFLEX_AVAILABLE
+	if(TRAP::Graphics::RendererAPI::GPUSettings.ReflexSupported)
+	{
+		ImGui::Begin("NVIDIA Reflex Latency", nullptr, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+					ImGuiWindowFlags_AlwaysAutoResize);
+		ImGui::PlotLines("Total Game to Render Latency", m_totalHistory.data(), static_cast<int>(m_totalHistory.size()), 0, nullptr, 0, 33, ImVec2(200, 50));
+		ImGui::PlotLines("Simulation Delta", m_simulationDeltaHistory.data(), static_cast<int>(m_simulationDeltaHistory.size()), 0, nullptr, 0, 33, ImVec2(200, 50));
+		ImGui::PlotLines("Render Delta", m_renderDeltaHistory.data(), static_cast<int>(m_renderDeltaHistory.size()), 0, nullptr, 0, 33, ImVec2(200, 50));
+		ImGui::PlotLines("Present Delta", m_presentDeltaHistory.data(), static_cast<int>(m_presentDeltaHistory.size()), 0, nullptr, 0, 33, ImVec2(200, 50));
+		ImGui::PlotLines("Driver Delta", m_driverDeltaHistory.data(), static_cast<int>(m_driverDeltaHistory.size()), 0, nullptr, 0, 33, ImVec2(200, 50));
+		ImGui::PlotLines("OS Render Queue Delta", m_OSRenderQueueDeltaHistory.data(), static_cast<int>(m_OSRenderQueueDeltaHistory.size()), 0, nullptr, 0, 33, ImVec2(200, 50));
+		ImGui::PlotLines("GPU Render Delta", m_GPURenderDeltaHistory.data(), static_cast<int>(m_GPURenderDeltaHistory.size()), 0, nullptr, 0, 33, ImVec2(200, 50));
+		ImGui::End();
+	}
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/Games/Tests/src/NVIDIAReflex/NVIDIAReflexTests.h
+++ b/Games/Tests/src/NVIDIAReflex/NVIDIAReflexTests.h
@@ -82,6 +82,15 @@ private:
 	TRAP::Ref<TRAP::Graphics::Shader> m_shader;
 
 	TRAP::Graphics::LatencyMode m_latencyMode;
+
+	std::array<float, 50> m_totalHistory;
+	std::array<float, 50> m_simulationDeltaHistory;
+	std::array<float, 50> m_renderDeltaHistory;
+	std::array<float, 50> m_presentDeltaHistory;
+	std::array<float, 50> m_driverDeltaHistory;
+	std::array<float, 50> m_OSRenderQueueDeltaHistory;
+	std::array<float, 50> m_GPURenderDeltaHistory;
+	TRAP::Utils::Timer m_updateLatencyTimer;
 };
 
 #endif /*GAMESTRAP_NVIDIAREFLEXTESTS_H*/

--- a/Games/Tests/src/NVIDIAReflex/NVIDIAReflexTests.h
+++ b/Games/Tests/src/NVIDIAReflex/NVIDIAReflexTests.h
@@ -1,0 +1,87 @@
+#ifndef GAMESTRAP_NVIDIAREFLEXTESTS_H
+#define GAMESTRAP_NVIDIAREFLEXTESTS_H
+
+#include <TRAP.h>
+
+class NVIDIAReflexTests final : public TRAP::Layer
+{
+public:
+	NVIDIAReflexTests();
+
+	void OnAttach() override;
+	void OnDetach() override;
+	void OnUpdate(const TRAP::Utils::TimeStep& deltaTime) override;
+	void OnImGuiRender() override;
+
+	void OnEvent(TRAP::Events::Event& event) override;
+
+private:
+	bool OnKeyPress(TRAP::Events::KeyPressEvent& e);
+
+	TRAP::Utils::Timer m_fpsTimer;
+
+	TRAP::Scope<TRAP::Graphics::VertexBuffer> m_vertexBuffer;
+	std::array<float, 12 * 6> m_icoSphereVerticesIndexed
+	{
+		//XYZ RGB
+		-1.0f,                                     (1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f,    0.0f,                                        1.0f, 0.0f, 0.0f,
+		 1.0f,                                     (1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f,    0.0f,                                        1.0f, 0.0f, 0.0f,
+		-1.0f,                                    -((1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f),  0.0f,                                        1.0f, 0.0f, 0.0f,
+		 1.0f,                                    -((1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f),  0.0f,                                        1.0f, 0.0f, 0.0f,
+
+		 0.0f,                                    -1.0f,                                      (1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f,      0.0f, 1.0f, 0.0f,
+		 0.0f,                                     1.0f,                                      (1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f,      0.0f, 1.0f, 0.0f,
+		 0.0f,                                    -1.0f,                                     -((1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f),    0.0f, 1.0f, 0.0f,
+		 0.0f,                                     1.0f,                                     -((1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f),    0.0f, 1.0f, 0.0f,
+
+		 (1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f,   0.0f,                                     -1.0f,                                        0.0f, 0.0f, 1.0f,
+		 (1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f,   0.0f,                                      1.0f,                                        0.0f, 0.0f, 1.0f,
+		-((1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f), 0.0f,                                     -1.0f,                                        0.0f, 0.0f, 1.0f,
+		-((1.0f + TRAP::Math::Sqrt(5.0f)) / 2.0f), 0.0f,                                      1.0f,                                        0.0f, 0.0f, 1.0f
+	};
+
+	TRAP::Scope<TRAP::Graphics::IndexBuffer> m_indexBuffer;
+	std::array<uint16_t, 20 * 3> m_icosphereIndices
+	{
+		0, 11, 5,
+		0, 5, 1,
+		0, 1, 7,
+		0, 7, 10,
+		0, 10, 11,
+
+		1, 5, 9,
+		5, 11, 4,
+		11, 10, 2,
+		10, 7, 6,
+		7, 1, 8,
+
+		3, 9, 4,
+		3, 4, 2,
+		3, 2, 6,
+		3, 6, 8,
+		3, 8, 9,
+
+		4, 9, 5,
+		2, 4, 11,
+		6, 2, 10,
+		8, 6, 7,
+		9, 8, 1
+	};
+
+	TRAP::Scope<TRAP::Graphics::UniformBuffer> m_cameraUBO;
+
+	struct CameraUBOData
+	{
+		TRAP::Math::Mat4 Projection;
+		TRAP::Math::Mat4 View;
+		TRAP::Math::Mat4 Model;
+	};
+	TRAP::SceneCamera m_camera;
+	TRAP::TransformComponent m_cameraTransform;
+
+	TRAP::Ref<TRAP::Graphics::Shader> m_shader;
+
+	TRAP::Graphics::LatencyMode m_latencyMode;
+};
+
+#endif /*GAMESTRAP_NVIDIAREFLEXTESTS_H*/

--- a/Games/Tests/src/main.cpp
+++ b/Games/Tests/src/main.cpp
@@ -15,6 +15,7 @@
 #include "InputLag/InputLagTests.h"
 #include "Monitors/MonitorTests.h"
 #include "MultiWindow/MultiWindowTests.h"
+#include "NVIDIAReflex/NVIDIAReflexTests.h"
 #include "Opacity/OpacityTests.h"
 #include "RendererAPI/RendererAPIInfo.h"
 #include "RendererAPI/RendererAPITests.h"
@@ -48,6 +49,7 @@ public:
 		// PushLayer(std::make_unique<InputLagTests>());
 		// PushLayer(std::make_unique<MonitorTests>());
 		// PushLayer(std::make_unique<MultiWindowTests>());
+		PushLayer(std::make_unique<NVIDIAReflexTests>());
 		// PushLayer(std::make_unique<OpacityTests>());
 		// PushLayer(std::make_unique<RendererAPIInfo>());
 		// PushLayer(std::make_unique<RendererAPITests>());
@@ -57,7 +59,7 @@ public:
 		// PushLayer(std::make_unique<TitleTests>());
 		// PushLayer(std::make_unique<VRSTests>());
 		// PushLayer(std::make_unique<VulkanTextureTests>());
-		PushLayer(std::make_unique<WindowStateTests>());
+		// PushLayer(std::make_unique<WindowStateTests>());
 		// PushLayer(std::make_unique<WindowFeaturesTests>());
 	}
 };

--- a/Games/Tests3D/premake5.lua
+++ b/Games/Tests3D/premake5.lua
@@ -201,12 +201,17 @@ project "Tests3D"
 		-- NVIDIA Reflex SDK stuff
 		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
 		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
-		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Stats/reflexstats.h") then
 			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
 
 			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
 
-			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+			externalincludedirs
+			{
+				"%{IncludeDir.NVIDIAREFLEX}",
+				"%{IncludeDir.NVIDIAREFLEXSTATS}"
+			}
 
 			defines "NVIDIA_REFLEX_AVAILABLE"
 		end

--- a/Games/Tests3D/premake5.lua
+++ b/Games/Tests3D/premake5.lua
@@ -198,6 +198,19 @@ project "Tests3D"
 			defines "USE_STEAMWORKS_SDK"
 		end
 
+		-- NVIDIA Reflex SDK stuff
+		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
+
+			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
+
+			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+
+			defines "NVIDIA_REFLEX_AVAILABLE"
+		end
+
 	filter "configurations:Debug"
 		defines "TRAP_DEBUG"
 		runtime "Debug"

--- a/Games/TestsNetwork/premake5.lua
+++ b/Games/TestsNetwork/premake5.lua
@@ -166,12 +166,17 @@ project "TestsNetwork"
 		-- NVIDIA Reflex SDK stuff
 		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
 		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
-		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Stats/reflexstats.h") then
 			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
 
 			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
 
-			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+			externalincludedirs
+			{
+				"%{IncludeDir.NVIDIAREFLEX}",
+				"%{IncludeDir.NVIDIAREFLEXSTATS}"
+			}
 
 			defines "NVIDIA_REFLEX_AVAILABLE"
 		end

--- a/Games/TestsNetwork/premake5.lua
+++ b/Games/TestsNetwork/premake5.lua
@@ -163,6 +163,19 @@ project "TestsNetwork"
 			defines "NSIGHT_AFTERMATH_AVAILABLE"
 		end
 
+		-- NVIDIA Reflex SDK stuff
+		if os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
+		   os.isfile("../../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+			links "%{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.lib"
+
+			postbuildcommands "{COPYDIR} %{IncludeDir.NVIDIAREFLEX}/../lib/NvLowLatencyVk.dll %{cfg.targetdir}"
+
+			externalincludedirs "%{IncludeDir.NVIDIAREFLEX}"
+
+			defines "NVIDIA_REFLEX_AVAILABLE"
+		end
+
 	filter "configurations:Debug"
 		defines "TRAP_DEBUG"
 		runtime "Debug"

--- a/Licenses/NVIDIA-Reflex.LICENSE
+++ b/Licenses/NVIDIA-Reflex.LICENSE
@@ -1,0 +1,189 @@
+LICENSE AGREEMENT FOR NVIDIA SOFTWARE DEVELOPMENT KITS
+
+This license agreement, including exhibits attached ("Agreement”) is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs your use of a NVIDIA software development kit (“SDK”). 
+
+Each SDK has its own set of software and materials, but here is a description of the types of items that may be included in a SDK: source code, header files, APIs, data sets and assets (examples include images, textures, models, scenes, videos, native API input/output files), binary software, sample code, libraries, utility programs, programming code and documentation. 
+
+This Agreement can be accepted only by an adult of legal age of majority in the country in which the SDK is used. 
+
+If you are entering into this Agreement on behalf of a company or other legal entity, you represent that you have the legal authority to bind the entity to this Agreement, in which case “you” will mean the entity you represent. 
+
+If you don’t have the required age or authority to accept this Agreement, or if you don’t accept all the terms and conditions of this Agreement, do not download, install or use the SDK.  
+
+You agree to use the SDK only for purposes that are permitted by (a) this Agreement, and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions.
+
+1. License. 
+
+1.1 Grant
+
+Subject to the terms of this Agreement, NVIDIA hereby grants you a non-exclusive, non-transferable license, without the right to sublicense (except as expressly provided in this Agreement) to: 
+
+(i) Install and use the SDK,
+
+(ii) Modify and create derivative works of sample source code delivered in the SDK, and
+ 
+(iii) Distribute those portions of the SDK that are identified in this Agreement as distributable, as incorporated in object code format into a software application that meets the distribution requirements indicated in this Agreement.
+
+1.2 Distribution Requirements
+
+These are the distribution requirements for you to exercise the distribution grant:
+       
+(i) Your application must have material additional functionality, beyond the included portions of the SDK.
+
+(ii) The distributable portions of the SDK shall only be accessed by your application.  
+
+(iii)  The following notice shall be included in modifications and derivative works of sample source code distributed: “This software contains source code provided by NVIDIA Corporation.”
+
+(iv)  Unless a developer tool is identified in this Agreement as distributable, it is delivered for your internal use only.
+
+(v) The terms under which you distribute your application must be consistent with the terms of this Agreement, including (without limitation) terms relating to the license grant and license restrictions and protection of NVIDIA’s intellectual property rights. Additionally, you agree that you will protect the privacy, security and legal rights of your application users. 
+
+(vi) You agree to notify NVIDIA in writing of any known or suspected distribution or use of the SDK not in compliance with the requirements of this Agreement, and to enforce the terms of your agreements with respect to distributed SDK.
+
+1.3 Authorized Users
+
+You may allow employees and contractors of your entity or of your subsidiary(ies) to access and use the SDK from your secure network to perform work on your behalf. 
+
+If you are an academic institution you may allow users enrolled or employed by the academic institution to access and use the SDK from your secure network. 
+
+You are responsible for the compliance with the terms of this Agreement by your authorized users. If you become aware that your authorized users didn’t follow the terms of this Agreement, you agree to take reasonable steps to resolve the non-compliance and prevent new occurrences. 
+
+1.4 Pre-Release SDK 
+The SDK versions identified as alpha, beta, preview or otherwise as pre-release, may not be fully functional, may contain errors or design flaws, and may have reduced or different security, privacy, accessibility, availability, and reliability standards relative to commercial versions of NVIDIA software and materials. Use of a pre-release SDK may result in unexpected results, loss of data, project delays or other unpredictable damage or loss. 
+You may use a pre-release SDK at your own risk, understanding that pre-release SDKs are not intended for use in production or business-critical systems. 
+NVIDIA may choose not to make available a commercial version of any pre-release SDK. NVIDIA may also choose to abandon development and terminate the availability of a pre-release SDK at any time without liability. 
+1.5	 Updates
+
+NVIDIA may, at its option, make available patches, workarounds or other updates to this SDK. Unless the updates are provided with their separate governing terms, they are deemed part of the SDK licensed to you as provided in this Agreement.
+
+You agree that the form and content of the SDK that NVIDIA provides may change without prior notice to you. While NVIDIA generally maintains compatibility between versions, NVIDIA may in some cases make changes that introduce incompatibilities in future versions of the SDK.
+
+1.6	 Third Party Licenses
+
+The SDK may come bundled with, or otherwise include or be distributed with, third party software licensed by a NVIDIA supplier and/or open source software provided under an open source license. Use of third party software is subject to the third-party license terms, or in the absence of third party terms, the terms of this Agreement. Copyright to third party software is held by the copyright holders indicated in the third-party software or license.
+
+1.7 Reservation of Rights
+
+NVIDIA reserves all rights, title and interest in and to the SDK not expressly granted to you under this Agreement.
+
+2. Limitations. 
+
+The following license limitations apply to your use of the SDK:
+
+2.1 You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary notices from any portion of the SDK or copies of the SDK. 
+
+2.2 Except as expressly provided in this Agreement, you may not copy, sell, rent, sublicense, transfer, distribute, modify, or create derivative works of any portion of the SDK. 
+
+2.3 Unless you have an agreement with NVIDIA for this purpose, you may not indicate that an application created with the SDK is sponsored or endorsed by NVIDIA. 
+
+2.4 You may not bypass, disable, or circumvent any encryption, security, digital rights management or authentication mechanism in the SDK. 
+
+2.5 You may not use the SDK in any manner that would cause it to become subject to an open source software license. As examples, licenses that require as a condition of use, modification, and/or distribution that the SDK be (i) disclosed or distributed in source code form; (ii) licensed for the purpose of making derivative works; or (iii) redistributable at no charge.
+
+2.6  Unless you have an agreement with NVIDIA for this purpose, you may not use the SDK with any system or application where the use or failure of the system or application can reasonably be expected to threaten or result in personal injury, death, or catastrophic loss. Examples include use in avionics, navigation, military, medical, life support or other life critical applications. NVIDIA does not design, test or manufacture the SDK for these critical uses and NVIDIA shall not be liable to you or any third party, in whole or in part, for any claims or damages arising from such uses. 
+
+2.7 You agree to defend, indemnify and hold harmless NVIDIA and its affiliates, and their respective employees, contractors, agents, officers and directors, from and against any and all claims, damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses (including but not limited to attorney’s fees and costs incident to establishing the right of indemnification) arising out of or related to your use of the SDK outside of the scope of this Agreement, or not in compliance with its terms.
+
+3. Ownership. 
+
+3.1 NVIDIA or its licensors hold all rights, title and interest in and to the SDK and its modifications and derivative works, including their respective intellectual property rights, subject to your rights under Section 3.2. This SDK may include software and materials from NVIDIA’s licensors, and these licensors are intended third party beneficiaries that may enforce this Agreement with respect to their intellectual property rights. 
+
+3.2 You hold all rights, title and interest in and to your applications and your derivative works of the sample source code delivered in the SDK, including their respective intellectual property rights, subject to NVIDIA’s rights under section 3.1.
+
+3.3 You may, but don’t have to, provide to NVIDIA suggestions, feature requests or other feedback regarding the SDK, including possible enhancements or modifications to the SDK. For any feedback that you voluntarily provide, you hereby grant NVIDIA and its affiliates a perpetual, non-exclusive, worldwide, irrevocable license to use, reproduce, modify, license, sublicense (through multiple tiers of sublicensees), and distribute (through multiple tiers of distributors) it without the payment of any royalties or fees to you. NVIDIA will use feedback at its choice. 
+
+4.  No Warranties. 
+
+THE SDK IS PROVIDED BY NVIDIA “AS IS” AND “WITH ALL FAULTS.” TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND ITS AFFILIATES EXPRESSLY DISCLAIM ALL WARRANTIES OF ANY KIND OR NATURE, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, NON-INFRINGEMENT, OR THE ABSENCE OF ANY DEFECTS THEREIN, WHETHER LATENT OR PATENT. NO WARRANTY IS MADE ON THE BASIS OF TRADE USAGE, COURSE OF DEALING OR COURSE OF TRADE. 
+
+5.	Limitations of Liability. 
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, NVIDIA AND ITS AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR ANY LOST PROFITS, LOSS OF USE, LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH THIS AGREEMENT OR THE USE OR PERFORMANCE OF THE SDK, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON BREACH OF CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF ACTION OR THEORY OF LIABILITY. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL CUMULATIVE LIABILITY UNDER OR ARISING OUT OF THIS AGREEMENT EXCEED US$10.00. THE NATURE OF THE LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE OR EXTEND THIS LIMIT. 
+
+These exclusions and limitations of liability shall apply regardless if NVIDIA or its affiliates have been advised of the possibility of such damages, and regardless of whether a remedy fails its essential purpose. These exclusions and limitations of liability form an essential basis of the bargain between the parties, and, absent any of these exclusions or limitations of liability, the provisions of this Agreement, including, without limitation, the economic terms, would be substantially different. 
+
+6.   Termination. 
+
+6.1 This Agreement will continue to apply until terminated by either you or NVIDIA as described below. 
+
+6.2 If you want to terminate this Agreement, you may do so by stopping to use the SDK. 
+
+6.3 NVIDIA may, at any time, terminate this Agreement if: (i) you fail to comply with any term of this Agreement and the non-compliance is not fixed within thirty (30) days following notice from NVIDIA (or immediately if you violate NVIDIA’s intellectual property rights); (ii) you commence or participate in any legal proceeding against NVIDIA with respect to the SDK; or (iii) NVIDIA decides to no longer provide the SDK in a country or, in NVIDIA’s sole discretion, the continued use of it is no longer commercially viable. 
+
+6.4 Upon any termination of this Agreement, you agree to promptly discontinue use of the SDK and destroy all copies in your possession or control. Your prior distributions in accordance with this Agreement are not affected by the termination of this Agreement. Upon written request, you will certify in writing that you have complied with your commitments under this section. Upon any termination of this Agreement all provisions survive except for the licenses granted to you. 
+
+7.  General.  
+ 
+If you wish to assign this Agreement or your rights and obligations, including by merger, consolidation, dissolution or operation of law, contact NVIDIA to ask for permission. Any attempted assignment not approved by NVIDIA in writing shall be void and of no effect. NVIDIA may assign, delegate or transfer this Agreement and its rights and obligations, and if to a non-affiliate you will be notified. 
+
+You agree to cooperate with NVIDIA and provide reasonably requested information to verify your compliance with this Agreement.
+
+This Agreement will be governed in all respects by the laws of the United States and of the State of Delaware as those laws are applied to contracts entered into and performed entirely within Delaware by Delaware residents, without regard to the conflicts of laws principles. The United Nations Convention on Contracts for the International Sale of Goods is specifically disclaimed. You agree to all terms of this Agreement in the English language.
+
+The state or federal courts residing in Santa Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of this Agreement. Notwithstanding this, you agree that NVIDIA shall still be allowed to apply for injunctive remedies or an equivalent type of urgent legal relief in any jurisdiction. 
+
+If any court of competent jurisdiction determines that any provision of this Agreement is illegal, invalid or unenforceable, such provision will be construed as limited to the extent necessary to be consistent with and fully enforceable under the law and the remaining provisions will remain in full force and effect. Unless otherwise specified, remedies are cumulative.
+
+Each party acknowledges and agrees that the other is an independent contractor in the performance of this Agreement. 
+
+The SDK has been developed entirely at private expense and is “commercial items” consisting of “commercial computer software” and “commercial computer software documentation” provided with RESTRICTED RIGHTS. Use, duplication or disclosure by the U.S. Government or a U.S. Government subcontractor is subject to the restrictions in this Agreement pursuant to DFARS 227.7202-3(a) or as set forth in subparagraphs (b)(1) and (2) of the Commercial Computer Software - Restricted Rights clause at FAR 52.227-19, as applicable. Contractor/manufacturer is NVIDIA, 2788 San Tomas Expressway, Santa Clara, CA 95051.
+
+The SDK is subject to United States export laws and regulations. You agree that you will not ship, transfer or export the SDK into any country, or use the SDK in any manner, prohibited by the United States Bureau of Industry and Security or economic sanctions regulations administered by the U.S. Department of Treasury’s Office of Foreign Assets Control (OFAC), or any applicable export laws, restrictions or regulations. These laws include restrictions on destinations, end users and end use. By accepting this Agreement, you confirm that you are not a resident or citizen of any country currently embargoed by the U.S. and that you are not otherwise prohibited from receiving the SDK.
+
+Any notice delivered by NVIDIA to you under this Agreement will be delivered via mail, email or fax. You agree that any notices that NVIDIA sends you electronically will satisfy any legal communication requirements. Please direct your legal notices or other correspondence to NVIDIA Corporation, 2788 San Tomas Expressway, Santa Clara, California 95051, United States of America, Attention: Legal Department.
+
+This Agreement and any exhibits incorporated into this Agreement constitute the entire agreement of the parties with respect to the subject matter of this Agreement and supersede all prior negotiations or documentation exchanged between the parties relating to this SDK license. Any additional and/or conflicting terms on documents issued by you are null, void, and invalid. Any amendment or waiver under this Agreement shall be in writing and signed by representatives of both parties.
+
+(v. December 9, 2020)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+REFLEX LOW LATENCY SDK SUPPLEMENT 
+TO SOFTWARE LICENSE AGREEMENT FOR NVIDIA SOFTWARE DEVELOPMENT KITS
+
+The terms in this supplement govern your use of the pre-release version of the NVIDIA Reflex Low Latency SDK under the terms of your license agreement (“Agreement”) as modified by this supplement. Capitalized terms used but not defined below have the meaning assigned to them in the Agreement.
+
+This supplement is an exhibit to the Agreement and is incorporated as an integral part of the Agreement. In the event of conflict between the terms in this supplement and the terms in the Agreement, the terms in this supplement govern.  
+
+1. License Scope. The SDK is licensed for you to develop applications only for use in systems with NVIDIA GPUs.
+
+2. Distribution. The following portions of the SDK are distributable under the Agreement as incorporated into your application: the NVAPIs, .lib and .h files, Linux wrapper, and samples (as provided by NVIDIA or your derivative works). 
+
+3.  Marketing Requirements. Your license to the SDK under the Agreement is subject to your compliance with the following marketing terms:
+
+3.1 You must attribute the use of the SDK by including a NVIDIA Reflex reference for features in your product developed with use of the SDK, in accordance with the UI guidelines available within the Reflex SDK package. 
+3.2 You may, during the term of this Agreement, identify NVIDIA on your websites, printed collateral, tradeshow displays and other retail packaging materials as the supplier of the SDK for applications developed with use of the SDK, in accordance with the UI guidelines. 
+3.3  NVIDIA grants to you a non-exclusive, non-sublicensable, non-transferable, worldwide license, subject to the terms of this supplement and the Agreement, to use NVIDIA™ or NVIDIA Reflex solely for marketing as set forth in Sections 3.1 and 3.2 above. You will not (and will not permit others to) use any NVIDIA mark for any other goods or services, or in a way that tarnishes, degrades, disparages or reflects adversely on NVIDIA or its marks, or NVIDIA’s business or reputation. You will follow NVIDIA specifications as to style, color, and typeface, as provided from time to time. In addition to the termination rights set forth in the Agreement, NVIDIA may terminate this license at any time upon written notice to you. All goodwill associated with use of NVIDIA marks will inure to the sole benefit of NVIDIA.
+3.4  You agree that you will take such steps as are reasonably necessary to ensure that neither you, nor any person under your control, make any false or misleading representations with regard to NVIDIA or its products, or publish or employ or cooperate in the publication or employment of any misleading or deceptive advertising or promotional materials. You agree that you will not, directly or indirectly, in any country or governing body, apply to register in your own name, or otherwise attempt to acquire any legal interest in or right in or to, any NVIDIA mark.
+
+3.5 Identification by NVIDIA.  You agree that NVIDIA may identify your name on NVIDIA's websites or other materials as an individual or entity that produces products and services which incorporate the SDK.
+
+4.  Audio/Video Encoders and Decoders. You acknowledge and agree that it is your sole responsibility to obtain any additional third party licenses required to make, have made, use, have used, sell, import, and offer for sale your products or services that include or incorporate any third party software and content relating to audio and/or video encoders and decoders from, including but not limited to, Microsoft, Thomson, Fraunhofer IIS, Sisvel S.p.A., MPEG-LA, and Coding Technologies as NVIDIA does not grant to you under this Agreement any necessary patent or other rights with respect to audio and/or video encoders and decoders. 
+
+(v. December 9, 2020)
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3191,3 +3191,4 @@ SITREP 09/08/2022|22w36a3
         - Application now uses RendererAPI::ReflexSleep() for FPS limiting when NVIDIA Reflex is supported ~<5 mins
         - RendererAPI/VulkanRenderer Added GetLatencyMode() ~<20 mins
         - VulkanDevice now only enables NVIDIA Reflex if on Windows 10 or newer ~<5 mins
+        - Utils Added ConvertToString() & ConvertToType() overloads for RendererAPI::LatencyMode ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3190,3 +3190,4 @@ SITREP 09/08/2022|22w36a3
         - RendererAPI/VulkanRenderer Added ReflexSleep() ~<20 mins
         - Application now uses RendererAPI::ReflexSleep() for FPS limiting when NVIDIA Reflex is supported ~<5 mins
         - RendererAPI/VulkanRenderer Added GetLatencyMode() ~<20 mins
+        - VulkanDevice now only enables NVIDIA Reflex if on Windows 10 or newer ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3177,4 +3177,6 @@ SITREP 09/07/2022|22w36a2
         - Dependencies Added NVIDIA-Reflex folder ~<10 mins
         - Premake scripts added optional NVIDIA-Reflex support ~<10 mins
         - VulkanRenderer Added support for VK_KHR_timeline_semaphore ~<15 mins
+        - VulkanCommon Added VkReflexCall() for NVIDIA-Reflex error checking ~<10 mins
         - VulkanDevice Added NVIDIA-Reflex initialization ~<15 mins
+        - RendererAPI/RenderCommand Added SetLatencyMode() to enable/disable NVIDIA-Reflex ~<20 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3192,3 +3192,4 @@ SITREP 09/08/2022|22w36a3
         - RendererAPI/VulkanRenderer Added GetLatencyMode() ~<20 mins
         - VulkanDevice now only enables NVIDIA Reflex if on Windows 10 or newer ~<5 mins
         - Utils Added ConvertToString() & ConvertToType() overloads for RendererAPI::LatencyMode ~<5 mins
+        - Tests Added NVIDIAReflexTests ~<20 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3195,3 +3195,4 @@ SITREP 09/08/2022|22w36a3
         - Tests Added NVIDIAReflexTests ~<20 mins
         - RendererAPI/VulkanRenderer Added ReflexMarker() ~<15 mins
         - Added ReflexMarkers according to NVIDIA Reflex integration guide ~<15 mins
+        - RendererAPI/VulkanRenderer Added ReflexGetLatency() ~<15 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3193,3 +3193,5 @@ SITREP 09/08/2022|22w36a3
         - VulkanDevice now only enables NVIDIA Reflex if on Windows 10 or newer ~<5 mins
         - Utils Added ConvertToString() & ConvertToType() overloads for RendererAPI::LatencyMode ~<5 mins
         - Tests Added NVIDIAReflexTests ~<20 mins
+        - RendererAPI/VulkanRenderer Added ReflexMarker() ~<15 mins
+        - Added ReflexMarkers according to NVIDIA Reflex integration guide ~<15 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3177,3 +3177,4 @@ SITREP 09/07/2022|22w36a2
         - Dependencies Added NVIDIA-Reflex folder ~<10 mins
         - Premake scripts added optional NVIDIA-Reflex support ~<10 mins
         - VulkanRenderer Added support for VK_KHR_timeline_semaphore ~<15 mins
+        - VulkanDevice Added NVIDIA-Reflex initialization ~<15 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3176,3 +3176,4 @@ SITREP 09/07/2022|22w36a2
     - Branch NVReflex:
         - Dependencies Added NVIDIA-Reflex folder ~<10 mins
         - Premake scripts added optional NVIDIA-Reflex support ~<10 mins
+        - VulkanRenderer Added support for VK_KHR_timeline_semaphore ~<15 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3183,7 +3183,7 @@ SITREP 09/07/2022|22w36a2
         - RendererAPI/VulkanRenderer Added SetReflexFPSLimit() ~<15 mins
 
 SITREP 09/08/2022|22w36a3
-    - Changed TRAP Engine version to 22w36a2(0.8.40)
+    - Changed TRAP Engine version to 22w36a3(0.8.40)
     - Branch NVReflex:
         - Application Moved FPSLimiter to start of Run() loop ~<5 mins
         - VulkanInits Added SemaphoreWaitInfo() ~<5 mins
@@ -3197,3 +3197,4 @@ SITREP 09/08/2022|22w36a3
         - Added ReflexMarkers according to NVIDIA Reflex integration guide ~<15 mins
         - RendererAPI/VulkanRenderer Added ReflexGetLatency() ~<15 mins
         - NVIDIAReflexTests Added latency charts ~<25 mins
+        - Premake scripts added NVIDIA Reflex Stats include header ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3198,3 +3198,4 @@ SITREP 09/08/2022|22w36a3
         - RendererAPI/VulkanRenderer Added ReflexGetLatency() ~<15 mins
         - NVIDIAReflexTests Added latency charts ~<25 mins
         - Premake scripts added NVIDIA Reflex Stats include header ~<5 mins
+        - Added NVSTATS marker ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3170,3 +3170,9 @@ SITREP 09/06/2022|22w36a1
     - RendererAPI/VulkanPhysicalDevice Added querying for GPU vendor ~<20 mins
     - Updated premake5 version ~<5 mins
     - Updated all premake scripts ~>20 mins
+
+SITREP 09/07/2022|22w36a2
+    - Changed TRAP Engine version to 22w36a2(0.8.39)
+    - Branch NVReflex:
+        - Dependencies Added NVIDIA-Reflex folder ~<10 mins
+        - Premake scripts added optional NVIDIA-Reflex support ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3180,3 +3180,4 @@ SITREP 09/07/2022|22w36a2
         - VulkanCommon Added VkReflexCall() for NVIDIA-Reflex error checking ~<10 mins
         - VulkanDevice Added NVIDIA-Reflex initialization ~<15 mins
         - RendererAPI/RenderCommand Added SetLatencyMode() to enable/disable NVIDIA-Reflex ~<20 mins
+        - RendererAPI/VulkanRenderer Added SetReflexFPSLimit() ~<15 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3181,3 +3181,11 @@ SITREP 09/07/2022|22w36a2
         - VulkanDevice Added NVIDIA-Reflex initialization ~<15 mins
         - RendererAPI/RenderCommand Added SetLatencyMode() to enable/disable NVIDIA-Reflex ~<20 mins
         - RendererAPI/VulkanRenderer Added SetReflexFPSLimit() ~<15 mins
+
+SITREP 09/08/2022|22w36a3
+    - Changed TRAP Engine version to 22w36a2(0.8.40)
+    - Branch NVReflex:
+        - Application Moved FPSLimiter to start of Run() loop ~<5 mins
+        - VulkanInits Added
+        - RendererAPI/VulkanRenderer Added ReflexSleep() ~<20 mins
+        - Application now uses RendererAPI::ReflexSleep() for FPS limiting when NVIDIA Reflex is supported ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3196,3 +3196,4 @@ SITREP 09/08/2022|22w36a3
         - RendererAPI/VulkanRenderer Added ReflexMarker() ~<15 mins
         - Added ReflexMarkers according to NVIDIA Reflex integration guide ~<15 mins
         - RendererAPI/VulkanRenderer Added ReflexGetLatency() ~<15 mins
+        - NVIDIAReflexTests Added latency charts ~<25 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3186,6 +3186,7 @@ SITREP 09/08/2022|22w36a3
     - Changed TRAP Engine version to 22w36a2(0.8.40)
     - Branch NVReflex:
         - Application Moved FPSLimiter to start of Run() loop ~<5 mins
-        - VulkanInits Added
+        - VulkanInits Added SemaphoreWaitInfo() ~<5 mins
         - RendererAPI/VulkanRenderer Added ReflexSleep() ~<20 mins
         - Application now uses RendererAPI::ReflexSleep() for FPS limiting when NVIDIA Reflex is supported ~<5 mins
+        - RendererAPI/VulkanRenderer Added GetLatencyMode() ~<20 mins

--- a/TRAP/premake5.lua
+++ b/TRAP/premake5.lua
@@ -137,6 +137,18 @@ project "TRAP"
 			defines "USE_STEAMWORKS_SDK"
 		end
 
+		-- NVIDIA Reflex SDK stuff
+		if os.isfile("../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
+		   os.isfile("../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
+		   os.isfile("../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+			externalincludedirs
+			{
+				"%{IncludeDir.NVIDIAREFLEX}"
+			}
+
+			defines "NVIDIA_REFLEX_AVAILABLE"
+		end
+
 	filter "system:linux"
 		-- Add Linux-specific files
         files

--- a/TRAP/premake5.lua
+++ b/TRAP/premake5.lua
@@ -140,10 +140,12 @@ project "TRAP"
 		-- NVIDIA Reflex SDK stuff
 		if os.isfile("../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc/NvLowLatencyVk.h") and
 		   os.isfile("../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.lib") and
-		   os.isfile("../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") then
+		   os.isfile("../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/lib/NvLowLatencyVk.dll") and
+		   os.isfile("../Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Stats/reflexstats.h") then
 			externalincludedirs
 			{
-				"%{IncludeDir.NVIDIAREFLEX}"
+				"%{IncludeDir.NVIDIAREFLEX}",
+				"%{IncludeDir.NVIDIAREFLEXSTATS}"
 			}
 
 			defines "NVIDIA_REFLEX_AVAILABLE"

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -183,7 +183,9 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 	m_config.Get("RefreshRate", refreshRate);
 	const bool vsync = m_config.Get<bool>("VSync");
 	const bool visible = true;
+#ifdef NVIDIA_REFLEX_AVAILABLE
 	const Graphics::LatencyMode latencyMode = m_config.Get<Graphics::LatencyMode>("NVIDIAReflex");
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 #else
 	const uint32_t width = 2;
 	const uint32_t height = 2;
@@ -279,6 +281,9 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 #ifndef TRAP_HEADLESS_MODE
 	//NVIDIA Reflex
 	Graphics::RenderCommand::SetLatencyMode(latencyMode);
+#ifdef NVIDIA_REFLEX_AVAILABLE
+	NVSTATS_INIT(0, 0);
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 
 	//Update Viewport
 	int32_t w = 0, h = 0;
@@ -378,7 +383,10 @@ TRAP::Application::~Application()
 		m_config.Set("AntiAliasingQuality", sampleCount);
 
 		//NVIDIA Reflex
+#if !defined(TRAP_HEADLESS_MODE) && defined(NVIDIA_REFLEX_AVAILABLE)
+		NVSTATS_SHUTDOWN();
 		m_config.Set("NVIDIAReflex", Graphics::RenderCommand::GetLatencyMode());
+#endif
 	}
 
 	std::filesystem::path cfgPath = "engine.cfg";

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -182,6 +182,7 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 	m_config.Get("RefreshRate", refreshRate);
 	const bool vsync = m_config.Get<bool>("VSync");
 	const bool visible = true;
+	const Graphics::LatencyMode latencyMode = m_config.Get<Graphics::LatencyMode>("NVIDIA Reflex");
 #else
 	const uint32_t width = 2;
 	const uint32_t height = 2;
@@ -275,6 +276,9 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 	SetFPSLimit(fpsLimit);
 
 #ifndef TRAP_HEADLESS_MODE
+	//NVIDIA Reflex
+	Graphics::RenderCommand::SetLatencyMode(latencyMode);
+
 	//Update Viewport
 	int32_t w = 0, h = 0;
 	INTERNAL::WindowingAPI::GetFrameBufferSize(static_cast<const INTERNAL::WindowingAPI::InternalWindow*>
@@ -371,6 +375,9 @@ TRAP::Application::~Application()
 		Graphics::RenderCommand::GetAntiAliasing(antiAliasing, sampleCount);
 		m_config.Set("AntiAliasing", antiAliasing);
 		m_config.Set("AntiAliasingQuality", sampleCount);
+
+		//NVIDIA Reflex
+		m_config.Set("NVIDIA Reflex", Graphics::RenderCommand::GetLatencyMode());
 	}
 
 	std::filesystem::path cfgPath = "engine.cfg";

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -280,8 +280,8 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 
 #ifndef TRAP_HEADLESS_MODE
 	//NVIDIA Reflex
-	Graphics::RenderCommand::SetLatencyMode(latencyMode);
 #ifdef NVIDIA_REFLEX_AVAILABLE
+	Graphics::RenderCommand::SetLatencyMode(latencyMode);
 	NVSTATS_INIT(0, 0);
 #endif /*NVIDIA_REFLEX_AVAILABLE*/
 

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -205,14 +205,6 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 #endif
 	Graphics::RenderAPI renderAPI = m_config.Get<Graphics::RenderAPI>("RenderAPI");
 
-	if (fpsLimit > 0)
-	{
-		if (fpsLimit >= 25 && fpsLimit <= 500)
-			m_fpsLimit = fpsLimit;
-		else
-			m_fpsLimit = 0;
-	}
-
 #ifdef TRAP_HEADLESS_MODE
 	if(enableGPU)
 	{
@@ -279,6 +271,8 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 	}
 #endif
 #endif
+
+	SetFPSLimit(fpsLimit);
 
 #ifndef TRAP_HEADLESS_MODE
 	//Update Viewport
@@ -589,6 +583,14 @@ void TRAP::Application::SetFPSLimit(const uint32_t fps)
 		s_Instance->m_fpsLimit = 0;
 	else
 		s_Instance->m_fpsLimit = TRAP::Math::Clamp(fps, 25u, 500u);
+
+#ifdef NVIDIA_REFLEX_AVAILABLE
+	if(TRAP::Graphics::RendererAPI::GetRenderAPI() != TRAP::Graphics::RenderAPI::NONE &&
+	   TRAP::Graphics::RendererAPI::GetRenderer())
+	{
+		Graphics::RendererAPI::GetRenderer()->SetReflexFPSLimit(s_Instance->m_fpsLimit);
+	}
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -427,6 +427,15 @@ void TRAP::Application::Run()
 		const Utils::TimeStep deltaTime{ (time - lastFrameTime) * m_timeScale };
 		lastFrameTime = time;
 
+		//FPSLimiter
+		if (m_fpsLimit || (!m_focused && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow)))
+		{
+			if(!Graphics::RendererAPI::GPUSettings.ReflexSupported)
+				std::this_thread::sleep_until(nextFrame);
+			else
+				Graphics::RendererAPI::GetRenderer()->ReflexSleep();
+		}
+
 		if (!m_minimized)
 		{
 			{
@@ -470,10 +479,6 @@ void TRAP::Application::Run()
 #endif
 
 		UpdateHotReloading();
-
-		//FPSLimiter
-		if (m_fpsLimit || (!m_focused && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow)))
-			std::this_thread::sleep_until(nextFrame);
 
 		if (!m_minimized)
 		{

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -509,6 +509,8 @@ void TRAP::Application::Run()
 #ifdef NVIDIA_REFLEX_AVAILABLE
 		Graphics::RendererAPI::GetRenderer()->ReflexMarker(m_globalCounter, VK_SIMULATION_END);
 #endif /*NVIDIA_REFLEX_AVAILABLE*/
+
+		++m_globalCounter;
 	}
 }
 

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -430,10 +430,10 @@ void TRAP::Application::Run()
 		//FPSLimiter
 		if (m_fpsLimit || (!m_focused && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow)))
 		{
-			if(!Graphics::RendererAPI::GPUSettings.ReflexSupported)
-				std::this_thread::sleep_until(nextFrame);
-			else
+			if(Graphics::RendererAPI::GPUSettings.ReflexSupported)
 				Graphics::RendererAPI::GetRenderer()->ReflexSleep();
+			else
+				std::this_thread::sleep_until(nextFrame);
 		}
 
 		if (!m_minimized)
@@ -591,7 +591,7 @@ void TRAP::Application::SetFPSLimit(const uint32_t fps)
 
 #ifdef NVIDIA_REFLEX_AVAILABLE
 	if(TRAP::Graphics::RendererAPI::GetRenderAPI() != TRAP::Graphics::RenderAPI::NONE &&
-	   TRAP::Graphics::RendererAPI::GetRenderer())
+	   TRAP::Graphics::RendererAPI::GPUSettings.ReflexSupported)
 	{
 		Graphics::RendererAPI::GetRenderer()->SetReflexFPSLimit(s_Instance->m_fpsLimit);
 	}

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -182,7 +182,7 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 	m_config.Get("RefreshRate", refreshRate);
 	const bool vsync = m_config.Get<bool>("VSync");
 	const bool visible = true;
-	const Graphics::LatencyMode latencyMode = m_config.Get<Graphics::LatencyMode>("NVIDIA Reflex");
+	const Graphics::LatencyMode latencyMode = m_config.Get<Graphics::LatencyMode>("NVIDIAReflex");
 #else
 	const uint32_t width = 2;
 	const uint32_t height = 2;
@@ -377,7 +377,7 @@ TRAP::Application::~Application()
 		m_config.Set("AntiAliasingQuality", sampleCount);
 
 		//NVIDIA Reflex
-		m_config.Set("NVIDIA Reflex", Graphics::RenderCommand::GetLatencyMode());
+		m_config.Set("NVIDIAReflex", Graphics::RenderCommand::GetLatencyMode());
 	}
 
 	std::filesystem::path cfgPath = "engine.cfg";
@@ -435,13 +435,10 @@ void TRAP::Application::Run()
 		lastFrameTime = time;
 
 		//FPSLimiter
-		if (m_fpsLimit || (!m_focused && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow)))
-		{
-			if(Graphics::RendererAPI::GPUSettings.ReflexSupported)
-				Graphics::RendererAPI::GetRenderer()->ReflexSleep();
-			else
-				std::this_thread::sleep_until(nextFrame);
-		}
+		if(Graphics::RendererAPI::GPUSettings.ReflexSupported)
+			Graphics::RendererAPI::GetRenderer()->ReflexSleep();
+		else if (m_fpsLimit || (!m_focused && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow)))
+			std::this_thread::sleep_until(nextFrame);
 
 		if (!m_minimized)
 		{

--- a/TRAP/src/Application.h
+++ b/TRAP/src/Application.h
@@ -184,6 +184,14 @@ namespace TRAP
 		static std::string GetGameName();
 
 		/// <summary>
+		/// Get the global counter.
+		/// The counter is incremented every frame.
+		/// Note: This is mainly used for NVIDIA-Reflex support.
+		/// </summary>
+		/// <returns>Global counter value.</returns>
+		static uint64_t GetGlobalCounter();
+
+		/// <summary>
 		/// Get the hot reloading file watcher.
 		/// </summary>
 		/// <returns>TRAP::FileSystem::FileWatcher* if file watcher is running, false otherwise.</returns>
@@ -288,6 +296,8 @@ namespace TRAP
 		uint32_t m_tickRate;
 		float m_timeScale;
 		std::string m_gameName;
+		//NVIDIA-Reflex
+		uint64_t m_globalCounter;
 
 		ThreadPool m_threadPool;
 

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -121,7 +121,7 @@ constexpr uint32_t TRAP_VERSION_PATCH(const uint32_t version)
 /// <summary>
 /// TRAP version number created with TRAP_MAKE_VERSION
 /// </summary>
-constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 38);
+constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 39);
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -121,7 +121,7 @@ constexpr uint32_t TRAP_VERSION_PATCH(const uint32_t version)
 /// <summary>
 /// TRAP version number created with TRAP_MAKE_VERSION
 /// </summary>
-constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 39);
+constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 40);
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -82,6 +82,7 @@ namespace TRAP::Graphics
 		enum class SampleCount;
 		enum class QueueType;
 		enum class GPUVendor;
+		enum class LatencyMode;
 		struct LoadActionsDesc;
 		struct BufferBarrier;
 		struct TextureBarrier;
@@ -617,6 +618,17 @@ namespace TRAP::Graphics
 		                             Window* window = nullptr) const = 0;
 
 		/// <summary>
+		/// Set the latency mode.
+		/// Note: Only LatencyMode::Disabled is supported everywhere.
+		///       Other LatencyModes are only available on Windows 10 or
+		///       newer with NVIDIA hardware.
+		/// </summary>
+		/// <param name="mode">LatencyMode to set.</param>
+		/// <param name="window">Window to set latency mode for.</param>
+		/// <returns>True on success, false otherwise.</returns>
+		virtual bool SetLatencyMode(LatencyMode mode, Window* window = nullptr) = 0;
+
+		/// <summary>
 		/// Retrieve the used descriptor pool.
 		/// </summary>
 		/// <returns>Descriptor pool.</returns>
@@ -1053,6 +1065,16 @@ namespace TRAP::Graphics
 			Color_Stencil = Color | Stencil,
 			Color_Depth_Stencil = Color | Stencil | Depth,
 			Depth_Stencil = Depth | Stencil
+		};
+
+		/// <summary>
+		/// Enum describing the different latency modes.
+		/// </summary>
+		enum class LatencyMode
+		{
+			Disabled,
+			Enabled,
+			EnabledBoost
 		};
 
 		/// <summary>
@@ -2559,6 +2581,11 @@ namespace TRAP::Graphics
 			TRAP::Ref<Pipeline> CurrentComputePipeline;
 			float ComputeFrameTime;
 			bool RecordingCompute;
+
+			//NVIDIA Reflex
+#ifdef NVIDIA_REFLEX_AVAILABLE
+			NVLL_VK_SET_SLEEP_MODE_PARAMS SleepModeParams{};
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 		};
 
 	protected:
@@ -2608,5 +2635,6 @@ MAKE_ENUM_FLAG(TRAP::Graphics::RendererAPI::ShadingRate);
 MAKE_ENUM_FLAG(TRAP::Graphics::RendererAPI::ShadingRateCaps);
 MAKE_ENUM_FLAG(TRAP::Graphics::RendererAPI::ShadingRateCombiner);
 MAKE_ENUM_FLAG(TRAP::Graphics::RendererAPI::ClearBufferType);
+MAKE_ENUM_FLAG(TRAP::Graphics::RendererAPI::LatencyMode);
 
 #endif /*TRAP_RENDERERAPI_H*/

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -9,6 +9,10 @@
 #include "Layers/ImGui/ImGuiLayer.h"
 #include "ImageFormat.h"
 
+#ifdef NVIDIA_REFLEX_AVAILABLE
+#include <NvLowLatencyVk.h>
+#endif
+
 namespace TRAP
 {
 	class Application;
@@ -2462,6 +2466,9 @@ namespace TRAP::Graphics
 			TRAP::Graphics::RendererAPI::ShadingRateCombiner ShadingRateCombiner;
 			uint32_t ShadingRateTexelWidth;
 			uint32_t ShadingRateTexelHeight;
+
+			//NVIDIA Reflex
+			bool ReflexSupported;
 		} GPUSettings{};
 
 		inline static constexpr uint32_t ImageCount = 3; //Triple Buffered

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -589,6 +589,13 @@ namespace TRAP::Graphics
 		/// <param name="frame">Frame to set marker for. Must be unique for each frame!</param>
 		/// <param name="marker">Enum value of the marker to set.</param>
 		virtual void ReflexMarker(uint32_t frame, uint32_t marker) const = 0;
+#ifdef NVIDIA_REFLEX_AVAILABLE
+		/// <summary>
+		/// Retrieve the latency report from NVIDIA-Reflex.
+		/// </summary>
+		/// <returns>Latency report.</returns>
+		virtual NVLL_VK_LATENCY_RESULT_PARAMS ReflexGetLatency() const = 0;
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 
 		/// <summary>
 		/// Retrieve the renderer title.

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -583,6 +583,12 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <param name="window">Window to sleep for.</param>
 		virtual void ReflexSleep(Window* window = nullptr) const = 0;
+		/// <summary>
+		/// NVIDIA-Reflex latency marker.
+		/// </summary>
+		/// <param name="frame">Frame to set marker for. Must be unique for each frame!</param>
+		/// <param name="marker">Enum value of the marker to set.</param>
+		virtual void ReflexMarker(uint32_t frame, uint32_t marker) const = 0;
 
 		/// <summary>
 		/// Retrieve the renderer title.

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -579,6 +579,12 @@ namespace TRAP::Graphics
 									              Window* window = nullptr) const = 0;
 
 		/// <summary>
+		/// NVIDIA-Reflex Sleep/synchronize on the given window.
+		/// </summary>
+		/// <param name="window">Window to sleep for.</param>
+		virtual void ReflexSleep(Window* window = nullptr) const = 0;
+
+		/// <summary>
 		/// Retrieve the renderer title.
 		/// Example title: "[Vulkan 1.3.0]".
 		/// </summary>
@@ -628,14 +634,15 @@ namespace TRAP::Graphics
 
 		/// <summary>
 		/// Set the latency mode.
+		/// The actual latency mode may differ from the requested one so check
+		/// the actual used mode with GetLatencyMode().
 		/// Note: Only LatencyMode::Disabled is supported everywhere.
 		///       Other LatencyModes are only available on Windows 10 or
 		///       newer with NVIDIA hardware.
 		/// </summary>
 		/// <param name="mode">LatencyMode to set.</param>
 		/// <param name="window">Window to set latency mode for.</param>
-		/// <returns>True on success, false otherwise.</returns>
-		virtual bool SetLatencyMode(LatencyMode mode, Window* window = nullptr) = 0;
+		virtual void SetLatencyMode(LatencyMode mode, Window* window = nullptr) = 0;
 
 		/// <summary>
 		/// Retrieve the used descriptor pool.

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -197,6 +197,15 @@ namespace TRAP::Graphics
 		/// <returns>True if VSync is enabled, false otherwise.</returns>
 		virtual bool GetVSync(Window* window = nullptr) const = 0;
 
+		/// <summary>
+		/// Set the FPS limit for NVIDIA-Reflex.
+		/// Note: This function affects all windows.
+		/// Note: Do not call this function in user code! Use TRAP::Application::SetFPSLimit() instead.
+		///       This function is only used internally for NVIDIA-Reflex.
+		/// </summary>
+		/// <param name="limit">FPS target to limit to.</param>
+		virtual void SetReflexFPSLimit(uint32_t limit) = 0;
+
 		//RenderTarget Stuff
 
 		/// <summary>

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -643,6 +643,13 @@ namespace TRAP::Graphics
 		/// <param name="mode">LatencyMode to set.</param>
 		/// <param name="window">Window to set latency mode for.</param>
 		virtual void SetLatencyMode(LatencyMode mode, Window* window = nullptr) = 0;
+		/// <summary>
+		/// Retrieve the currently used latency mode.
+		/// Note: This may differ from the requested mode set with SetLatencyMode().
+		/// </summary>
+		/// <param name="window">Window to retrieve latency mode for.</param>
+		/// <returns>Used latency mode.</returns>
+		virtual LatencyMode GetLatencyMode(Window* window = nullptr) const = 0;
 
 		/// <summary>
 		/// Retrieve the used descriptor pool.

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
@@ -489,7 +489,7 @@ uint8_t TRAP::Graphics::API::VulkanDevice::GetComputeQueueIndex() const
 //-------------------------------------------------------------------------------------------------------------------//
 
 #ifdef NVIDIA_REFLEX_AVAILABLE
-VkSemaphore TRAP::Graphics::API::VulkanDevice::GetReflexSemaphore() const
+VkSemaphore& TRAP::Graphics::API::VulkanDevice::GetReflexSemaphore()
 {
 	return m_reflexSemaphore;
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.cpp
@@ -95,6 +95,8 @@ TRAP::Graphics::API::VulkanDevice::VulkanDevice(TRAP::Scope<VulkanPhysicalDevice
 	rayQueryFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR;
 	VkPhysicalDeviceFragmentShadingRateFeaturesKHR shadingRateFeatures{};
 	shadingRateFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR;
+	VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timelineSemaphoreFeatures{};
+	timelineSemaphoreFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR;
 
 	if (VulkanRenderer::s_bufferDeviceAddressExtension)
 	{
@@ -121,6 +123,13 @@ TRAP::Graphics::API::VulkanDevice::VulkanDevice(TRAP::Scope<VulkanPhysicalDevice
 	if(VulkanRenderer::s_shadingRate)
 	{
 		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&shadingRateFeatures);
+		base = base->pNext;
+	}
+
+	//Timeline semaphore
+	if(VulkanRenderer::s_timelineSemaphore)
+	{
+		base->pNext = reinterpret_cast<VkBaseOutStructure*>(&timelineSemaphoreFeatures);
 		base = base->pNext;
 	}
 
@@ -186,6 +195,7 @@ TRAP::Graphics::API::VulkanDevice::VulkanDevice(TRAP::Scope<VulkanPhysicalDevice
 	VulkanRenderer::s_bufferDeviceAddressExtension = bufferDeviceAddressFeatures.bufferDeviceAddress;
 	VulkanRenderer::s_samplerYcbcrConversionExtension = ycbcrFeatures.samplerYcbcrConversion;
 	VulkanRenderer::s_shaderDrawParameters = shaderDrawParametersFeatures.shaderDrawParameters;
+	VulkanRenderer::s_timelineSemaphore = timelineSemaphoreFeatures.timelineSemaphore;
 	LoadShadingRateCaps(shadingRateFeatures);
 
 #if defined(ENABLE_GRAPHICS_DEBUG)

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.h
@@ -111,6 +111,14 @@ namespace TRAP::Graphics::API
 		/// <returns>Compute queue index.</returns>
 		uint8_t GetComputeQueueIndex() const;
 
+#ifdef NVIDIA_REFLEX_AVAILABLE
+		/// <summary>
+		/// Retrieve the NVIDIA Reflex semaphore.
+		/// </summary>
+		/// <returns>Semaphore.</returns>
+		VkSemaphore GetReflexSemaphore() const;
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
+
 	private:
 		friend VulkanQueue;
 
@@ -156,6 +164,10 @@ namespace TRAP::Graphics::API
 		uint8_t m_graphicsQueueIndex;
 		uint8_t m_transferQueueIndex;
 		uint8_t m_computeQueueIndex;
+
+#ifdef NVIDIA_REFLEX_AVAILABLE
+		VkSemaphore m_reflexSemaphore;
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 
 		VkDevice m_device;
 	};

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDevice.h
@@ -116,7 +116,7 @@ namespace TRAP::Graphics::API
 		/// Retrieve the NVIDIA Reflex semaphore.
 		/// </summary>
 		/// <returns>Semaphore.</returns>
-		VkSemaphore GetReflexSemaphore() const;
+		VkSemaphore& GetReflexSemaphore();
 #endif /*NVIDIA_REFLEX_AVAILABLE*/
 
 	private:

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanInits.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanInits.cpp
@@ -292,6 +292,22 @@ VkSemaphoreCreateInfo TRAP::Graphics::API::VulkanInits::SemaphoreCreateInfo() no
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+VkSemaphoreWaitInfoKHR TRAP::Graphics::API::VulkanInits::SemaphoreWaitInfo(VkSemaphore& semaphore, uint64_t& value) noexcept
+{
+	VkSemaphoreWaitInfoKHR info;
+
+	info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO_KHR;
+	info.pNext = nullptr;
+	info.flags = 0;
+	info.semaphoreCount = 1;
+	info.pSemaphores = &semaphore;
+	info.pValues = &value;
+
+	return info;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
 VkAttachmentDescription TRAP::Graphics::API::VulkanInits::AttachmentDescription(const VkFormat format,
 	                                                                            const VkSampleCountFlagBits sampleCount,
 	                                                                            const VkAttachmentLoadOp loadOp,

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanInits.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanInits.h
@@ -163,6 +163,14 @@ namespace TRAP::Graphics::API::VulkanInits
 	/// <returns>VkSemaphoreCreateInfo.</returns>
 	VkSemaphoreCreateInfo SemaphoreCreateInfo() noexcept;
 
+	/// <summary>
+	/// Create a Vulkan semaphore wait info.
+	/// </summary>
+	/// <param name="semaphore">Semaphore to wait on.</param>
+	/// <param name="value">Signal value to set.</param>
+	/// <returns>VkSemaphoreWaitInfoKHR</returns>
+	VkSemaphoreWaitInfoKHR SemaphoreWaitInfo(VkSemaphore& semaphore, uint64_t& value) noexcept;
+
 	//-------------------------------------------------------------------------------------------------------------------//
 
 	/// <summary>

--- a/TRAP/src/Graphics/API/Vulkan/VulkanCommon.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanCommon.h
@@ -46,6 +46,18 @@ namespace TRAP::Graphics::API
 	/// <param name="line">Line number of the error check call.</param>
 	/// <returns>True for non error codes, otherwise false.</returns>
 	constexpr bool ErrorCheck(VkResult result, std::string_view function, std::string_view file, int32_t line);
+#ifdef NVIDIA_REFLEX_AVAILABLE
+	/// <summary>
+	/// Check the if given NvLL_VK_Status contains an error.
+	/// If the given NvLL_VK_Status contains an error, the function will log information about the error.
+	/// </summary>
+	/// <param name="result">NvLL_VK_Status to check.</param>
+	/// <param name="function">Name of the function that called the error checker.</param>
+	/// <param name="file">Name of the file where the function is in that called the error checker.</param>
+	/// <param name="line">Line number of the error check call.</param>
+	/// <returns>True for non error codes, otherwise false.</returns>
+	constexpr bool ReflexErrorCheck(NvLL_VK_Status result, std::string_view function, std::string_view file, int32_t line);
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 	/// <summary>
 	/// Convert the RendererAPI::QueueType to VkQueueFlags.
 	/// </summary>
@@ -350,6 +362,9 @@ namespace TRAP::Graphics::API
 #else
 	//Utility to check VkResult for errors and log them.
 	#define VkCall(x) ::TRAP::Graphics::API::ErrorCheck(x, #x, __FILE__, __LINE__);
+#ifdef NVIDIA_REFLEX_AVAILABLE
+	#define VkReflexCall(x) ::TRAP::Graphics::API::ReflexErrorCheck(x, #x, __FILE__, __LINE__);
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 #endif
 #else
 	/// <summary>
@@ -357,6 +372,10 @@ namespace TRAP::Graphics::API
 	/// </summary>
 	constexpr void VkCall(VkResult)
 	{}
+#ifdef NVIDIA_REFLEX_AVAILABLE
+	constexpr void VkReflexCall(NvLL_VK_Status)
+	{}
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 #endif
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -435,6 +454,64 @@ constexpr bool TRAP::Graphics::API::ErrorCheck(const VkResult result, const std:
 
 	return false;
 }
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+#ifdef NVIDIA_REFLEX_AVAILABLE
+constexpr bool TRAP::Graphics::API::ReflexErrorCheck(const NvLL_VK_Status result, const std::string_view function,
+                                                     const std::string_view file, const int32_t line)
+{
+	if(result == NVLL_VK_OK)
+		return true;
+
+	switch (result)
+	{
+	case NVLL_VK_ERROR:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_ERROR: ", function, " @[", file, ':', line, ']');
+		break;
+	case NVLL_VK_LIBRARY_NOT_FOUND:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_LIBRARY_NOT_FOUND: ", function, " @[", file, ':', line,
+				']');
+		break;
+	case NVLL_VK_NO_IMPLEMENTATION:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_NO_IMPLEMENTATION: ", function, " @[", file, ':', line,
+				']');
+		break;
+	case NVLL_VK_API_NOT_INITIALIZED:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_API_NOT_INITIALIZED: ", function, " @[", file, ':', line, ']');
+		break;
+	case NVLL_VK_INVALID_ARGUMENT:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_INVALID_ARGUMENT: ", function, " @[", file, ':', line, ']');
+		break;
+	case NVLL_VK_INVALID_HANDLE:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_INVALID_HANDLE: ", function, " @[", file, ':', line, ']');
+		break;
+	case NVLL_VK_INCOMPATIBLE_STRUCT_VERSION:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_INCOMPATIBLE_STRUCT_VERSION: ", function, " @[", file, ':', line,
+				']');
+		break;
+	case NVLL_VK_INVALID_POINTER:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_INVALID_POINTER: ", function, " @[", file, ':', line, ']');
+		break;
+	case NVLL_VK_OUT_OF_MEMORY:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_OUT_OF_MEMORY: ", function, " @[", file, ':', line, ']');
+		break;
+	case NVLL_VK_API_IN_USE:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_API_IN_USE: ", function, " @[", file, ':', line, ']');
+		break;
+	case NVLL_VK_NO_VULKAN:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "NVLL_VK_NO_VULKAN: ", function, " @[", file, ':', line,
+				']');
+		break;
+
+	default:
+		TP_ERROR(Log::RendererVulkanReflexPrefix, "Unknown error: ", function, " @[", file, ':', line, ']');
+		break;
+	}
+
+	return false;
+}
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -618,6 +618,25 @@ void TRAP::Graphics::API::VulkanRenderer::SetVSync(const bool vsync, Window* win
 
 //------------------------------------------------------------------------------------------------------------------//
 
+void TRAP::Graphics::API::VulkanRenderer::SetReflexFPSLimit([[maybe_unused]] const uint32_t limit)
+{
+#ifdef NVIDIA_REFLEX_AVAILABLE
+	for(auto& [win, winData] : s_perWindowDataMap)
+	{
+		winData->SleepModeParams.minimumIntervalUs = static_cast<uint32_t>((1000.0f / static_cast<float>(limit)) * 1000.0f);
+
+		if(winData->SleepModeParams.bLowLatencyMode && winData->SleepModeParams.bLowLatencyBoost)
+			SetLatencyMode(LatencyMode::EnabledBoost, win);
+		else if(winData->SleepModeParams.bLowLatencyMode)
+			SetLatencyMode(LatencyMode::Enabled, win);
+		else
+			SetLatencyMode(LatencyMode::Disabled, win);
+	}
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
+}
+
+//------------------------------------------------------------------------------------------------------------------//
+
 void TRAP::Graphics::API::VulkanRenderer::SetClearColor(const Math::Vec4& color, Window* window) const
 {
 	if (!window)

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -623,7 +623,10 @@ void TRAP::Graphics::API::VulkanRenderer::SetReflexFPSLimit([[maybe_unused]] con
 #ifdef NVIDIA_REFLEX_AVAILABLE
 	for(auto& [win, winData] : s_perWindowDataMap)
 	{
-		winData->SleepModeParams.minimumIntervalUs = static_cast<uint32_t>((1000.0f / static_cast<float>(limit)) * 1000.0f);
+		if(limit == 0)
+			winData->SleepModeParams.minimumIntervalUs = 0;
+		else
+			winData->SleepModeParams.minimumIntervalUs = static_cast<uint32_t>((1000.0f / static_cast<float>(limit)) * 1000.0f);
 
 		if(winData->SleepModeParams.bLowLatencyMode && winData->SleepModeParams.bLowLatencyBoost)
 			SetLatencyMode(LatencyMode::EnabledBoost, win);

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -1600,6 +1600,19 @@ void TRAP::Graphics::API::VulkanRenderer::ReflexMarker([[maybe_unused]] const ui
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifdef NVIDIA_REFLEX_AVAILABLE
+NVLL_VK_LATENCY_RESULT_PARAMS TRAP::Graphics::API::VulkanRenderer::ReflexGetLatency() const
+{
+	NVLL_VK_LATENCY_RESULT_PARAMS params{};
+
+	VkReflexCall(NvLL_VK_GetLatency(m_device->GetVkDevice(), &params));
+
+	return params;
+}
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
+
+//-------------------------------------------------------------------------------------------------------------------//
+
 std::string TRAP::Graphics::API::VulkanRenderer::GetTitle() const
 {
 	return m_rendererTitle;

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -60,6 +60,7 @@ bool TRAP::Graphics::API::VulkanRenderer::s_memoryBudgetExtension = false;
 bool TRAP::Graphics::API::VulkanRenderer::s_maintenance4Extension = false;
 bool TRAP::Graphics::API::VulkanRenderer::s_externalMemory = false;
 bool TRAP::Graphics::API::VulkanRenderer::s_shadingRate = false;
+bool TRAP::Graphics::API::VulkanRenderer::s_timelineSemaphore = false;
 
 bool TRAP::Graphics::API::VulkanRenderer::s_debugMarkerSupport = false;
 
@@ -2167,6 +2168,12 @@ std::vector<std::string> TRAP::Graphics::API::VulkanRenderer::SetupDeviceExtensi
 		extensions.emplace_back(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 		extensions.emplace_back(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
 		s_shadingRate = true;
+	}
+
+	if (physicalDevice->IsExtensionSupported(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME))
+	{
+		extensions.emplace_back(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
+		s_timelineSemaphore = true;
 	}
 
 #ifdef TRAP_PLATFORM_WINDOWS

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -621,6 +621,9 @@ void TRAP::Graphics::API::VulkanRenderer::SetVSync(const bool vsync, Window* win
 void TRAP::Graphics::API::VulkanRenderer::SetReflexFPSLimit([[maybe_unused]] const uint32_t limit)
 {
 #ifdef NVIDIA_REFLEX_AVAILABLE
+	if(!GPUSettings.ReflexSupported)
+		return;
+
 	for(auto& [win, winData] : s_perWindowDataMap)
 	{
 		if(limit == 0)
@@ -1541,6 +1544,9 @@ void TRAP::Graphics::API::VulkanRenderer::ResourceRenderTargetBarriers(const std
 void TRAP::Graphics::API::VulkanRenderer::ReflexSleep([[maybe_unused]] Window *window) const
 {
 #ifdef NVIDIA_REFLEX_AVAILABLE
+	if(!GPUSettings.ReflexSupported)
+		return;
+
 	if(!window)
 		window = TRAP::Application::GetWindow();
 
@@ -1841,10 +1847,10 @@ void TRAP::Graphics::API::VulkanRenderer::MSAAResolvePass(const TRAP::Ref<Render
 void TRAP::Graphics::API::VulkanRenderer::SetLatencyMode([[maybe_unused]] const LatencyMode mode,
                                                          [[maybe_unused]] Window* window)
 {
+#ifdef NVIDIA_REFLEX_AVAILABLE
 	if(!GPUSettings.ReflexSupported)
 		return;
 
-#ifdef NVIDIA_REFLEX_AVAILABLE
 	if(!window)
 		window = TRAP::Application::GetWindow();
 

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -1585,9 +1585,12 @@ void TRAP::Graphics::API::VulkanRenderer::ReflexSleep([[maybe_unused]] Window *w
 void TRAP::Graphics::API::VulkanRenderer::ReflexMarker([[maybe_unused]] const uint32_t frame,
                                                        [[maybe_unused]] const uint32_t marker) const
 {
-	//TODO NVStats
-
 #ifdef NVIDIA_REFLEX_AVAILABLE
+	NVSTATS_MARKER(marker, frame);
+
+	if(marker == NVSTATS_PC_LATENCY_PING)
+		return;
+
 	if(marker == VK_TRIGGER_FLASH) //BUG This gives ERROR_DEVICE_LOST
 		return;
 

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -530,6 +530,13 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to set latency mode for.</param>
 		/// <returns>True on success, false otherwise.</returns>
 		void SetLatencyMode(LatencyMode mode, Window* window = nullptr) override;
+		/// <summary>
+		/// Retrieve the currently used latency mode.
+		/// Note: This may differ from the requested mode set with SetLatencyMode().
+		/// </summary>
+		/// <param name="window">Window to retrieve latency mode for.</param>
+		/// <returns>Used latency mode.</returns>
+		LatencyMode GetLatencyMode(Window* window = nullptr) const override;
 
 		/// <summary>
 		/// Initialize the internal rendering data of the given window.

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -471,6 +471,13 @@ namespace TRAP::Graphics::API
 		/// <param name="frame">Frame to set marker for. Must be unique for each frame!</param>
 		/// <param name="marker">Enum value of the marker to set.</param>
 		void ReflexMarker(uint32_t frame, uint32_t marker) const override;
+#ifdef NVIDIA_REFLEX_AVAILABLE
+		/// <summary>
+		/// Retrieve the latency report from NVIDIA-Reflex.
+		/// </summary>
+		/// <returns>Latency report.</returns>
+		NVLL_VK_LATENCY_RESULT_PARAMS ReflexGetLatency() const override;
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
 
 		/// <summary>
 		/// Retrieve the renderer title.

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -451,7 +451,7 @@ namespace TRAP::Graphics::API
 		/// <param name="renderTargetBarrier">Render target barrier.</param>
 		/// <param name="window">Window to add the barrier for. Default: Main Window.</param>
 		void ResourceRenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier,
-		                                 Window* window ) const override;
+		                                 Window* window) const override;
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
@@ -459,6 +459,12 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to add the barriers for. Default: Main Window.</param>
 		void ResourceRenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers,
 								          Window* window) const override;
+
+		/// <summary>
+		/// NVIDIA-Reflex Sleep/synchronize on the given window.
+		/// </summary>
+		/// <param name="window">Window to sleep for.</param>
+		void ReflexSleep(Window* window) const override;
 
 		/// <summary>
 		/// Retrieve the renderer title.
@@ -523,7 +529,7 @@ namespace TRAP::Graphics::API
 		/// <param name="mode">LatencyMode to set.</param>
 		/// <param name="window">Window to set latency mode for.</param>
 		/// <returns>True on success, false otherwise.</returns>
-		bool SetLatencyMode(LatencyMode mode, Window* window = nullptr) override;
+		void SetLatencyMode(LatencyMode mode, Window* window = nullptr) override;
 
 		/// <summary>
 		/// Initialize the internal rendering data of the given window.

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -506,6 +506,17 @@ namespace TRAP::Graphics::API
 		                     Window* window = nullptr) const override;
 
 		/// <summary>
+		/// Set the latency mode.
+		/// Note: Only LatencyMode::Disabled is supported everywhere.
+		///       Other LatencyModes are only available on Windows 10 or
+		///       newer with NVIDIA hardware.
+		/// </summary>
+		/// <param name="mode">LatencyMode to set.</param>
+		/// <param name="window">Window to set latency mode for.</param>
+		/// <returns>True on success, false otherwise.</returns>
+		bool SetLatencyMode(LatencyMode mode, Window* window = nullptr) override;
+
+		/// <summary>
 		/// Initialize the internal rendering data of the given window.
 		/// </summary>
 		/// <param name="window">Window to initialize the internal rendering data for.</param>

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -465,6 +465,12 @@ namespace TRAP::Graphics::API
 		/// </summary>
 		/// <param name="window">Window to sleep for.</param>
 		void ReflexSleep(Window* window) const override;
+		/// <summary>
+		/// NVIDIA-Reflex latency marker.
+		/// </summary>
+		/// <param name="frame">Frame to set marker for. Must be unique for each frame!</param>
+		/// <param name="marker">Enum value of the marker to set.</param>
+		void ReflexMarker(uint32_t frame, uint32_t marker) const override;
 
 		/// <summary>
 		/// Retrieve the renderer title.

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -91,6 +91,15 @@ namespace TRAP::Graphics::API
 		void SetVSync(bool vsync, Window* window) const override;
 
 		/// <summary>
+		/// Set the FPS limit for NVIDIA-Reflex.
+		/// Note: This function affects all windows.
+		/// Note: Do not call this function in user code! Use TRAP::Application::SetFPSLimit() instead.
+		///       This function is only used internally for NVIDIA-Reflex.
+		/// </summary>
+		/// <param name="limit">FPS target to limit to.</param>
+		void SetReflexFPSLimit(uint32_t limit) override;
+
+		/// <summary>
 		/// Set the clear color to be used by the given window.
 		/// </summary>
 		/// <param name="color">New clear color.</param>

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -536,6 +536,7 @@ namespace TRAP::Graphics::API
 		static bool s_maintenance4Extension;
 		static bool s_externalMemory;
 		static bool s_shadingRate;
+		static bool s_timelineSemaphore;
 
 		static bool s_debugMarkerSupport;
 

--- a/TRAP/src/Graphics/RenderCommand.cpp
+++ b/TRAP/src/Graphics/RenderCommand.cpp
@@ -432,7 +432,14 @@ float TRAP::Graphics::RenderCommand::GetGPUComputeFrameTime(Window* window)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-bool TRAP::Graphics::RenderCommand::SetLatencyMode(const LatencyMode mode, Window* window)
+void TRAP::Graphics::RenderCommand::SetLatencyMode(const LatencyMode mode, Window* window)
 {
-	return RendererAPI::GetRenderer()->SetLatencyMode(mode, window);
+	RendererAPI::GetRenderer()->SetLatencyMode(mode, window);
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+TRAP::Graphics::LatencyMode TRAP::Graphics::RenderCommand::GetLatencyMode(Window* window)
+{
+	return RendererAPI::GetRenderer()->GetLatencyMode(window);
 }

--- a/TRAP/src/Graphics/RenderCommand.cpp
+++ b/TRAP/src/Graphics/RenderCommand.cpp
@@ -429,3 +429,10 @@ float TRAP::Graphics::RenderCommand::GetGPUComputeFrameTime(Window* window)
 {
 	return RendererAPI::GetGPUComputeFrameTime(window);
 }
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+bool TRAP::Graphics::RenderCommand::SetLatencyMode(const LatencyMode mode, Window* window)
+{
+	return RendererAPI::GetRenderer()->SetLatencyMode(mode, window);
+}

--- a/TRAP/src/Graphics/RenderCommand.h
+++ b/TRAP/src/Graphics/RenderCommand.h
@@ -65,6 +65,10 @@ namespace TRAP::Graphics
 	/// Different sample counts for anti aliasing.
 	/// </summary>
 	using SampleCount = RendererAPI::SampleCount;
+	/// <summary>
+	/// Different different latency modes.
+	/// </summary>
+	using LatencyMode = RendererAPI::LatencyMode;
 
 	/// <summary>
 	/// Utility class for high level rendering commands.
@@ -524,6 +528,17 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to get frame time from.</param>
 		/// <returns>GPU Compute frame time in milliseconds.</returns>
 		static float GetGPUComputeFrameTime(Window* window = nullptr);
+
+		/// <summary>
+		/// Set the latency mode.
+		/// Note: Only LatencyMode::Disabled is supported everywhere.
+		///       Other LatencyModes are only available on Windows 10 or
+		///       newer with NVIDIA hardware.
+		/// </summary>
+		/// <param name="mode">LatencyMode to set.</param>
+		/// <param name="window">Window to set latency mode for.</param>
+		/// <returns>True on success, false otherwise.</returns>
+		static bool SetLatencyMode(LatencyMode mode, Window* window = nullptr);
 	};
 }
 

--- a/TRAP/src/Graphics/RenderCommand.h
+++ b/TRAP/src/Graphics/RenderCommand.h
@@ -538,7 +538,14 @@ namespace TRAP::Graphics
 		/// <param name="mode">LatencyMode to set.</param>
 		/// <param name="window">Window to set latency mode for.</param>
 		/// <returns>True on success, false otherwise.</returns>
-		static bool SetLatencyMode(LatencyMode mode, Window* window = nullptr);
+		static void SetLatencyMode(LatencyMode mode, Window* window = nullptr);
+		/// <summary>
+		/// Retrieve the currently used latency mode.
+		/// Note: This may differ from the requested mode set with SetLatencyMode().
+		/// </summary>
+		/// <param name="window">Window to retrieve latency mode for.</param>
+		/// <returns>Used latency mode.</returns>
+		static LatencyMode GetLatencyMode(Window* window = nullptr);
 	};
 }
 

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -145,7 +145,7 @@ namespace TRAP
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w36a1]";
+		inline static constexpr auto WindowVersion =                        "[22w36a2]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -145,7 +145,7 @@ namespace TRAP
 		/// </summary>
 		void Clear();
 
-		inline static constexpr auto WindowVersion =                        "[22w36a2]";
+		inline static constexpr auto WindowVersion =                        "[22w36a3]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -207,6 +207,7 @@ namespace TRAP
 		inline static constexpr auto RendererSwapChainPrefix =              "[Renderer][SwapChain] ";
 		inline static constexpr auto RendererAftermathTrackerPrefix =       "[Renderer][AftermathTracker] ";
 		inline static constexpr auto RendererVulkanPrefix =                 "[Renderer][Vulkan] ";
+		inline static constexpr auto RendererVulkanReflexPrefix =           "[Renderer][Vulkan][Reflex] ";
 		inline static constexpr auto RendererVulkanDevicePrefix =           "[Renderer][Vulkan][Device] ";
 		inline static constexpr auto RendererVulkanPhysicalDevicePrefix =   "[Renderer][Vulkan][PhysicalDevice] ";
 		inline static constexpr auto RendererVulkanDescriptorPoolPrefix =   "[Renderer][Vulkan][DescriptorPool] ";

--- a/TRAP/src/TRAPPCH.cpp
+++ b/TRAP/src/TRAPPCH.cpp
@@ -1,1 +1,5 @@
 #include "TRAPPCH.h"
+
+#ifdef NVIDIA_REFLEX_AVAILABLE
+NVSTATS_DEFINE()
+#endif

--- a/TRAP/src/TRAPPCH.h
+++ b/TRAP/src/TRAPPCH.h
@@ -101,6 +101,7 @@
 
 #ifdef NVIDIA_REFLEX_AVAILABLE
 #include <NvLowLatencyVk.h>
+#include <reflexstats.h>
 #endif
 
 #endif /*TRAP_TRAPPCH_H*/

--- a/TRAP/src/TRAPPCH.h
+++ b/TRAP/src/TRAPPCH.h
@@ -99,4 +99,8 @@
 #include <GFSDK_Aftermath_GpuCrashDump.h>
 #endif
 
+#ifdef NVIDIA_REFLEX_AVAILABLE
+#include <NvLowLatencyVk.h>
+#endif
+
 #endif /*TRAP_TRAPPCH_H*/

--- a/TRAP/src/Utils/String/String.inl
+++ b/TRAP/src/Utils/String/String.inl
@@ -184,6 +184,15 @@ T TRAP::Utils::String::ConvertToType(const std::string& input)
 
 		return Graphics::RendererAPI::GPUVendor::Unknown;
 	}
+	else if constexpr(std::is_same_v<T, TRAP::Graphics::RendererAPI::LatencyMode>) //LatencyMode
+	{
+		if(Utils::String::CompareAnyCase("Enabled", input))
+			return Graphics::RendererAPI::LatencyMode::Enabled;
+		if(Utils::String::CompareAnyCase("Enabled+Boost", input))
+			return Graphics::RendererAPI::LatencyMode::EnabledBoost;
+
+		return Graphics::RendererAPI::LatencyMode::Disabled;
+	}
 	else
 	{
 		static_assert(sizeof(T) == 0, "Unconvertable type encountered, please use a different type, "
@@ -331,6 +340,20 @@ std::string TRAP::Utils::String::ConvertToString(T value)
 
 		default:
 			return "Unknown";
+		}
+	}
+	else if constexpr(std::is_same_v<T, TRAP::Graphics::RendererAPI::LatencyMode>) //LatencyMode
+	{
+		switch(value)
+		{
+		case Graphics::RendererAPI::LatencyMode::Enabled:
+			return "Enabled";
+		case Graphics::RendererAPI::LatencyMode::EnabledBoost:
+			return "Enabled+Boost";
+
+		case Graphics::RendererAPI::LatencyMode::Disabled:
+		default:
+			return "Disabled";
 		}
 	}
 	else

--- a/TRAP/src/Utils/Win.h
+++ b/TRAP/src/Utils/Win.h
@@ -73,6 +73,7 @@
 #include <KnownFolders.h>
 #include <ShlObj_core.h>
 #include <Shobjidl.h>
+#include <initguid.h>
 //XInput
 #include <Xinput.h>
 //DirectInput

--- a/TRAP/src/Window/WindowingAPIWin32.cpp
+++ b/TRAP/src/Window/WindowingAPIWin32.cpp
@@ -209,6 +209,11 @@ void TRAP::INTERNAL::WindowingAPI::InputWindowContentScale(const InternalWindow*
 LRESULT CALLBACK TRAP::INTERNAL::WindowingAPI::WindowProc(HWND hWnd, const UINT uMsg, const WPARAM wParam,
                                                           const LPARAM lParam)
 {
+#ifdef NVIDIA_REFLEX_AVAILABLE
+	if(NVSTATS_IS_PING_MSG_ID(uMsg))
+		TRAP::Graphics::RendererAPI::GetRenderer()->ReflexMarker(TRAP::Application::GetGlobalCounter(), NVSTATS_PC_LATENCY_PING);
+#endif /*NVIDIA_REFLEX_AVAILABLE*/
+
 	InternalWindow* windowPtr = static_cast<InternalWindow*>(GetPropW(hWnd, L"TRAP"));
 
 	if (!windowPtr)

--- a/premake5.lua
+++ b/premake5.lua
@@ -36,6 +36,7 @@ IncludeDir["DISCORDGAMESDK"] = "%{wks.location}/Dependencies/DiscordGameSDK/cpp"
 IncludeDir["NSIGHTAFTERMATH"] = "%{wks.location}/Dependencies/Nsight-Aftermath/include"
 IncludeDir["VMA"] = "%{wks.location}/Dependencies/VulkanMemoryAllocator/include"
 IncludeDir["STEAMWORKSSDK"] = "%{wks.location}/Dependencies/SteamworksSDK/sdk/public/steam"
+IncludeDir["NVIDIAREFLEX"] = "%{wks.location}/Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc"
 
 include "TRAP"
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -37,6 +37,7 @@ IncludeDir["NSIGHTAFTERMATH"] = "%{wks.location}/Dependencies/Nsight-Aftermath/i
 IncludeDir["VMA"] = "%{wks.location}/Dependencies/VulkanMemoryAllocator/include"
 IncludeDir["STEAMWORKSSDK"] = "%{wks.location}/Dependencies/SteamworksSDK/sdk/public/steam"
 IncludeDir["NVIDIAREFLEX"] = "%{wks.location}/Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Vulkan/Reflex_Vulkan/inc"
+IncludeDir["NVIDIAREFLEXSTATS"] = "%{wks.location}/Dependencies/NVIDIA-Reflex/Nvidia_Reflex_SDK_1.6/1.6/Reflex_Stats"
 
 include "TRAP"
 


### PR DESCRIPTION
This pull request adds support for NVIDIA Reflex on Windows 10 and newer for NVIDIA hardware.

**Due to licensing the NVIDIA Reflex SDK must be provided by the user.**

### What changed

- Added premake integration for NVIDIA Reflex
- RendererAPI/VulkanRenderer Added integration of NVIDIA Reflex
  - RendererAPI::SetLatencyMode()
  - RendererAPI::GetLatencyMode() (Note: may differ from last SetLatencyMode() call)
  - RendererAPI::SetReflexFPSLimit() (Note: only for internal engine use)
  - RendererAPI::ReflexSleep()
  - RendererAPI::ReflexMarker()
  - RendererAPI::ReflexGetLatency()
- Application/WindowingAPIWin32 Added NVIDIA Reflex latency markers and NVIDIA Reflex Stats markers according to NVIDIA Reflex Vulkan Integration Guide.
- Tests Added NVIDIAReflexTests showing various latencies and deltas via RendererAPI::ReflexGetLatency()