### PR TITLE
Independent render resolution (Render Scaling)

### DIFF
--- a/Games/Headless-Tests/engine.cfg
+++ b/Games/Headless-Tests/engine.cfg
@@ -5,3 +5,4 @@ VulkanGPU = 184f7c48-84f6-3566-2064-3d97966fb3e5
 AntiAliasing = Off
 AntiAliasingQuality = 2
 AnisotropyLevel = 16
+RenderScale = 1.000000

--- a/Games/Headless-Tests/src/Compute/ComputeTests.cpp
+++ b/Games/Headless-Tests/src/Compute/ComputeTests.cpp
@@ -85,8 +85,6 @@ void ComputeTests::OnUpdate(const TRAP::Utils::TimeStep& /*deltaTime*/)
     static uint32_t frames = 0;
     if(frames == 3)
     {
-        TRAP::Graphics::RendererAPI::GetGraphicsQueue()->WaitQueueIdle();
-        TRAP::Graphics::RendererAPI::GetComputeQueue()->WaitQueueIdle();
 
         //Screenshot
 	    TRAP::Scope<TRAP::Image> testImage = TRAP::Graphics::RenderCommand::CaptureScreenshot();

--- a/Games/Headless-Tests/src/main.cpp
+++ b/Games/Headless-Tests/src/main.cpp
@@ -14,9 +14,9 @@ public:
 	explicit HeadlessTestsApp(std::string gameName)
 		: Application(std::move(gameName))
 	{
-		// PushLayer(std::make_unique<AntiAliasingTests>());
+		PushLayer(std::make_unique<AntiAliasingTests>());
 		// PushLayer(std::make_unique<ComputeTests>());
-		PushLayer(std::make_unique<FileSystemTests>());
+		// PushLayer(std::make_unique<FileSystemTests>());
 		// PushLayer(std::make_unique<HeadlessTests>());
 		// PushLayer(std::make_unique<HashTests>());
 		// PushLayer(std::make_unique<IPAddressTests>());

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
@@ -296,6 +296,7 @@ void TRAPEditorLayer::OnAttach()
 	TRAP::Graphics::RenderCommand::SetBlendConstant(TRAP::Graphics::BlendConstant::SrcAlpha,
 	                                                TRAP::Graphics::BlendConstant::OneMinusSrcAlpha); //Blending
 
+	TRAP::Graphics::RendererAPI::GetResourceLoader()->WaitForAllResourceLoads();
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/Games/Tests/src/RenderScale/RenderScaleTests.cpp
+++ b/Games/Tests/src/RenderScale/RenderScaleTests.cpp
@@ -1,0 +1,92 @@
+#include "RenderScaleTests.h"
+#include "Application.h"
+#include <imgui.h>
+
+RenderScaleTests::RenderScaleTests()
+	: Layer("Render Scaling"),
+	m_cameraController(TRAP::Application::GetWindow()->GetAspectRatio(), true)
+{
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void RenderScaleTests::OnImGuiRender()
+{
+	ImGui::Begin("Render Scaling", nullptr, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+	                                                     ImGuiWindowFlags_AlwaysAutoResize);
+	ImGui::Text("Press ESC to close");
+    ImGui::Separator();
+
+    float renderScale = TRAP::Graphics::RenderCommand::GetRenderScale();
+    if(ImGui::SliderFloat("Render Scale", &renderScale, 0.5f, 2.0f, "%.2f", ImGuiSliderFlags_NoInput))
+        TRAP::Graphics::RenderCommand::SetRenderScale(renderScale);
+
+    const auto internalRes = TRAP::Graphics::RendererAPI::GetInternalRenderResolution(TRAP::Application::GetWindow());
+    ImGui::Text("Render Resolution: %ux%u", internalRes.x, internalRes.y);
+
+    const auto outputSize = TRAP::Application::GetWindow()->GetFrameBufferSize();
+    ImGui::Text("Output Resolution: %ux%u", outputSize.x, outputSize.y);
+
+    ImGui::End();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void RenderScaleTests::OnAttach()
+{
+	TRAP::Application::GetWindow()->SetTitle("Render Scaling");
+
+	//Load Textures
+    TRAP::Graphics::TextureManager::Load("TRAP", "./Assets/Textures/TRAPWhiteLogo2048x2048.png")->AwaitLoading();
+
+    //Wait for all pending resources (Just in case)
+    TRAP::Graphics::RendererAPI::GetResourceLoader()->WaitForAllResourceLoads();
+
+	TRAP::Graphics::RenderCommand::SetDepthTesting(true);
+	TRAP::Graphics::RenderCommand::SetBlendConstant(TRAP::Graphics::BlendConstant::SrcAlpha, TRAP::Graphics::BlendConstant::OneMinusSrcAlpha);
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void RenderScaleTests::OnUpdate([[maybe_unused]] const TRAP::Utils::TimeStep& deltaTime)
+{
+	//Update
+	m_cameraController.OnUpdate(deltaTime);
+
+	//Render
+	TRAP::Graphics::RenderCommand::Clear(TRAP::Graphics::ClearBuffer::Color_Depth);
+
+    TRAP::Graphics::Renderer2D::ResetStats();
+	TRAP::Graphics::Renderer2D::BeginScene(m_cameraController.GetCamera());
+    TRAP::Graphics::Renderer2D::DrawQuad({ {}, {0.0f, 0.0f, TRAP::Application::GetTime() * -50.0f }, {2.0f, 2.0f, 1.0f} },
+                                         { 0.2f, 0.8f, 0.3f, 1.0f }, TRAP::Graphics::TextureManager::Get2D("TRAP"));
+	TRAP::Graphics::Renderer2D::EndScene();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void RenderScaleTests::OnEvent(TRAP::Events::Event& event)
+{
+	m_cameraController.OnEvent(event);
+
+	TRAP::Events::EventDispatcher dispatcher(event);
+	dispatcher.Dispatch<TRAP::Events::KeyPressEvent>([this](TRAP::Events::KeyPressEvent& e) { return OnKeyPress(e); });
+	dispatcher.Dispatch<TRAP::Events::FrameBufferResizeEvent>([this](TRAP::Events::FrameBufferResizeEvent& e) { return OnFrameBufferResize(e); });
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+bool RenderScaleTests::OnKeyPress(TRAP::Events::KeyPressEvent& event)
+{
+	if (event.GetKey() == TRAP::Input::Key::Escape && event.GetRepeatCount() < 1)
+        TRAP::Application::Shutdown();
+
+	return true;
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+bool RenderScaleTests::OnFrameBufferResize([[maybe_unused]] TRAP::Events::FrameBufferResizeEvent& event)
+{
+    return false;
+}

--- a/Games/Tests/src/RenderScale/RenderScaleTests.h
+++ b/Games/Tests/src/RenderScale/RenderScaleTests.h
@@ -1,0 +1,23 @@
+#ifndef GAMESTRAP_RENDERSCALETESTS_H
+#define GAMESTRAP_RENDERSCALETESTS_H
+
+#include <TRAP.h>
+
+class RenderScaleTests final : public TRAP::Layer
+{
+public:
+	RenderScaleTests();
+
+	void OnImGuiRender() override;
+	void OnAttach() override;
+	void OnUpdate(const TRAP::Utils::TimeStep& deltaTime) override;
+	void OnEvent(TRAP::Events::Event& event) override;
+
+private:
+	bool OnKeyPress(TRAP::Events::KeyPressEvent& event);
+	bool OnFrameBufferResize(TRAP::Events::FrameBufferResizeEvent& event);
+
+	TRAP::Graphics::OrthographicCameraController m_cameraController;
+};
+
+#endif /*GAMESTRAP_RENDERSCALETESTS_H*/

--- a/Games/Tests/src/VariableRateShading/VRSTests.cpp
+++ b/Games/Tests/src/VariableRateShading/VRSTests.cpp
@@ -188,19 +188,33 @@ struct ShadingRateData
     uint8_t H;
 };
 
-TRAP::Ref<TRAP::Graphics::Texture> VRSTests::CreateShadingRateTexture(const uint32_t framebufferWidth,
-                                                                      const uint32_t framebufferHeight)
+TRAP::Ref<TRAP::Graphics::RenderTarget> VRSTests::CreateShadingRateTexture(const uint32_t framebufferWidth,
+                                                                           const uint32_t framebufferHeight)
 {
     //Create empty texture for shading rate
-	TRAP::Graphics::RendererAPI::TextureDesc texDesc{};
-	texDesc.Width = static_cast<uint32_t>(TRAP::Math::Ceil(static_cast<float>(framebufferWidth) / static_cast<float>(TRAP::Graphics::RendererAPI::GPUSettings.ShadingRateTexelWidth)));
-	texDesc.Height = static_cast<uint32_t>(TRAP::Math::Ceil(static_cast<float>(framebufferHeight) / static_cast<float>(TRAP::Graphics::RendererAPI::GPUSettings.ShadingRateTexelHeight)));
-	texDesc.Format = TRAP::Graphics::API::ImageFormat::R8_UINT;
-	texDesc.StartState = TRAP::Graphics::ResourceState::ShadingRateSource;
-	texDesc.Descriptors = TRAP::Graphics::RendererAPI::DescriptorType::Texture;
-	texDesc.Name = "Shading Rate Texture";
-	TRAP::Ref<TRAP::Graphics::Texture> shadingRateTex = TRAP::Graphics::Texture::CreateCustom(texDesc);
-	shadingRateTex->AwaitLoading();
+    TRAP::Graphics::RendererAPI::RenderTargetDesc rTDesc{};
+    rTDesc.Width = static_cast<uint32_t>(TRAP::Math::Ceil(static_cast<float>(framebufferWidth) / static_cast<float>(TRAP::Graphics::RendererAPI::GPUSettings.ShadingRateTexelWidth)));
+	rTDesc.Height = static_cast<uint32_t>(TRAP::Math::Ceil(static_cast<float>(framebufferHeight) / static_cast<float>(TRAP::Graphics::RendererAPI::GPUSettings.ShadingRateTexelHeight)));
+	rTDesc.Format = TRAP::Graphics::API::ImageFormat::R8_UINT;
+	rTDesc.StartState = TRAP::Graphics::ResourceState::ShadingRateSource;
+	rTDesc.Descriptors = TRAP::Graphics::RendererAPI::DescriptorType::Texture;
+    rTDesc.Depth = 1;
+    rTDesc.ArraySize = 1;
+    rTDesc.MipLevels = 1;
+    rTDesc.SampleCount = TRAP::Graphics::SampleCount::One;
+	rTDesc.Name = "Shading Rate Texture";
+
+    TRAP::Ref<TRAP::Graphics::RenderTarget> shadingRateTex = TRAP::Graphics::RenderTarget::Create(rTDesc);
+
+	// TRAP::Graphics::RendererAPI::TextureDesc texDesc{};
+	// texDesc.Width = static_cast<uint32_t>(TRAP::Math::Ceil(static_cast<float>(framebufferWidth) / static_cast<float>(TRAP::Graphics::RendererAPI::GPUSettings.ShadingRateTexelWidth)));
+	// texDesc.Height = static_cast<uint32_t>(TRAP::Math::Ceil(static_cast<float>(framebufferHeight) / static_cast<float>(TRAP::Graphics::RendererAPI::GPUSettings.ShadingRateTexelHeight)));
+	// texDesc.Format = TRAP::Graphics::API::ImageFormat::R8_UINT;
+	// texDesc.StartState = TRAP::Graphics::ResourceState::ShadingRateSource;
+	// texDesc.Descriptors = TRAP::Graphics::RendererAPI::DescriptorType::Texture;
+	// texDesc.Name = "Shading Rate Texture";
+	// TRAP::Ref<TRAP::Graphics::Texture> shadingRateTex = TRAP::Graphics::Texture::CreateCustom(texDesc);
+	// shadingRateTex->AwaitLoading();
 
     std::vector<ShadingRateData> supportedShadingRates{};
     if(static_cast<bool>(TRAP::Graphics::RendererAPI::GPUSettings.ShadingRates & TRAP::Graphics::ShadingRate::Eighth))
@@ -222,7 +236,7 @@ TRAP::Ref<TRAP::Graphics::Texture> VRSTests::CreateShadingRateTexture(const uint
 
 
     //Fill texture with lowest supported shading rate
-	std::vector<uint8_t> pixels(texDesc.Width * texDesc.Height, supportedShadingRates[0].V | supportedShadingRates[0].H);
+	std::vector<uint8_t> pixels(rTDesc.Width * rTDesc.Height, supportedShadingRates[0].V | supportedShadingRates[0].H);
 
     //Create a circular pattern from the available list of fragment shadring rates with decreasing sampling rates outwards (max. range, pattern)
     //See https://github.com/KhronosGroup/Vulkan-Samples/blob/master/samples/extensions/fragment_shading_rate/fragment_shading_rate.cpp
@@ -236,12 +250,12 @@ TRAP::Ref<TRAP::Graphics::Texture> VRSTests::CreateShadingRateTexture(const uint
     }
 
     uint8_t* pixelData = pixels.data();
-    for(uint32_t y = 0; y < texDesc.Height; ++y)
+    for(uint32_t y = 0; y < rTDesc.Height; ++y)
     {
-        for(uint32_t x = 0; x < texDesc.Width; ++x)
+        for(uint32_t x = 0; x < rTDesc.Width; ++x)
         {
-            const float deltaX = (static_cast<float>(texDesc.Width) / 2.0f - static_cast<float>(x)) / static_cast<float>(texDesc.Width) * 100.0f;
-            const float deltaY = (static_cast<float>(texDesc.Height) / 2.0f - static_cast<float>(y)) / static_cast<float>(texDesc.Height) * 100.0f;
+            const float deltaX = (static_cast<float>(rTDesc.Width) / 2.0f - static_cast<float>(x)) / static_cast<float>(rTDesc.Width) * 100.0f;
+            const float deltaY = (static_cast<float>(rTDesc.Height) / 2.0f - static_cast<float>(y)) / static_cast<float>(rTDesc.Height) * 100.0f;
             const float distance = TRAP::Math::Sqrt(deltaX * deltaX + deltaY * deltaY);
             for(auto pattern : patternLookup)
             {
@@ -256,9 +270,13 @@ TRAP::Ref<TRAP::Graphics::Texture> VRSTests::CreateShadingRateTexture(const uint
         }
     }
 
-	shadingRateTex->Update(pixels.data(), static_cast<uint32_t>(pixels.size()) * sizeof(uint8_t));
-	shadingRateTex->AwaitLoading();
-	TRAP::Graphics::RenderCommand::Transition(shadingRateTex, TRAP::Graphics::ResourceState::ShaderResource, TRAP::Graphics::ResourceState::ShadingRateSource);
+    shadingRateTex->GetTexture()->Update(pixels.data(), static_cast<uint32_t>(pixels.size()) * sizeof(uint8_t));
+    shadingRateTex->GetTexture()->AwaitLoading();
+	TRAP::Graphics::RenderCommand::Transition(shadingRateTex->GetTexture(), TRAP::Graphics::ResourceState::ShaderResource, TRAP::Graphics::ResourceState::ShadingRateSource);
+
+	// shadingRateTex->Update(pixels.data(), static_cast<uint32_t>(pixels.size()) * sizeof(uint8_t));
+	// shadingRateTex->AwaitLoading();
+	// TRAP::Graphics::RenderCommand::Transition(shadingRateTex, TRAP::Graphics::ResourceState::ShaderResource, TRAP::Graphics::ResourceState::ShadingRateSource);
 
     return shadingRateTex;
 }

--- a/Games/Tests/src/VariableRateShading/VRSTests.h
+++ b/Games/Tests/src/VariableRateShading/VRSTests.h
@@ -32,6 +32,7 @@ private:
 
     TRAP::Graphics::ShadingRate m_shadingRate;
     std::vector<RateData> m_shadingRates;
+    float m_currRenderScale;
 
 	bool m_supportsPerDrawVRS;
 	bool m_supportsPerTileVRS;

--- a/Games/Tests/src/VariableRateShading/VRSTests.h
+++ b/Games/Tests/src/VariableRateShading/VRSTests.h
@@ -24,11 +24,11 @@ private:
 	bool OnKeyPress(TRAP::Events::KeyPressEvent& event);
 	bool OnFrameBufferResize(TRAP::Events::FrameBufferResizeEvent& event);
 
-	TRAP::Ref<TRAP::Graphics::Texture> CreateShadingRateTexture(uint32_t framebufferWidth, uint32_t framebufferHeight);
+	TRAP::Ref<TRAP::Graphics::RenderTarget> CreateShadingRateTexture(uint32_t framebufferWidth, uint32_t framebufferHeight);
 
 	TRAP::Graphics::OrthographicCameraController m_cameraController;
 
-	TRAP::Ref<TRAP::Graphics::Texture> m_shadingRateTexture;
+	TRAP::Ref<TRAP::Graphics::RenderTarget> m_shadingRateTexture;
 
     TRAP::Graphics::ShadingRate m_shadingRate;
     std::vector<RateData> m_shadingRates;

--- a/Games/Tests/src/main.cpp
+++ b/Games/Tests/src/main.cpp
@@ -35,7 +35,7 @@ public:
 		: Application(std::move(gameName))
 	{
 		// PushLayer(std::make_unique<AnisotropyTests>());
-		// PushLayer(std::make_unique<AntiAliasingTests>());
+		PushLayer(std::make_unique<AntiAliasingTests>());
 		// PushLayer(std::make_unique<ClipboardTests>());
 		// PushLayer(std::make_unique<ControllerTests>());
 		// PushLayer(std::make_unique<ComputeTests>());
@@ -57,7 +57,7 @@ public:
 		// PushLayer(std::make_unique<SPIRVTests>());
 		// PushLayer(std::make_unique<SpriteSheetTests>());
 		// PushLayer(std::make_unique<TitleTests>());
-		PushLayer(std::make_unique<VRSTests>());
+		// PushLayer(std::make_unique<VRSTests>());
 		// PushLayer(std::make_unique<VulkanTextureTests>());
 		// PushLayer(std::make_unique<WindowStateTests>());
 		// PushLayer(std::make_unique<WindowFeaturesTests>());

--- a/Games/Tests/src/main.cpp
+++ b/Games/Tests/src/main.cpp
@@ -19,6 +19,7 @@
 #include "Opacity/OpacityTests.h"
 #include "RendererAPI/RendererAPIInfo.h"
 #include "RendererAPI/RendererAPITests.h"
+#include "RenderScale/RenderScaleTests.h"
 #include "Screenshot/ScreenshotTests.h"
 #include "SPIRV/SPIRVTests.h"
 #include "SpriteSheet/SpriteSheetTests.h"
@@ -53,11 +54,12 @@ public:
 		// PushLayer(std::make_unique<OpacityTests>());
 		// PushLayer(std::make_unique<RendererAPIInfo>());
 		// PushLayer(std::make_unique<RendererAPITests>());
+		PushLayer(std::make_unique<RenderScaleTests>());
 		// PushLayer(std::make_unique<ScreenshotTests>());
 		// PushLayer(std::make_unique<SPIRVTests>());
 		// PushLayer(std::make_unique<SpriteSheetTests>());
 		// PushLayer(std::make_unique<TitleTests>());
-		PushLayer(std::make_unique<VRSTests>());
+		// PushLayer(std::make_unique<VRSTests>());
 		// PushLayer(std::make_unique<VulkanTextureTests>());
 		// PushLayer(std::make_unique<WindowStateTests>());
 		// PushLayer(std::make_unique<WindowFeaturesTests>());

--- a/Games/Tests/src/main.cpp
+++ b/Games/Tests/src/main.cpp
@@ -35,7 +35,7 @@ public:
 		: Application(std::move(gameName))
 	{
 		// PushLayer(std::make_unique<AnisotropyTests>());
-		PushLayer(std::make_unique<AntiAliasingTests>());
+		// PushLayer(std::make_unique<AntiAliasingTests>());
 		// PushLayer(std::make_unique<ClipboardTests>());
 		// PushLayer(std::make_unique<ControllerTests>());
 		// PushLayer(std::make_unique<ComputeTests>());
@@ -57,7 +57,7 @@ public:
 		// PushLayer(std::make_unique<SPIRVTests>());
 		// PushLayer(std::make_unique<SpriteSheetTests>());
 		// PushLayer(std::make_unique<TitleTests>());
-		// PushLayer(std::make_unique<VRSTests>());
+		PushLayer(std::make_unique<VRSTests>());
 		// PushLayer(std::make_unique<VulkanTextureTests>());
 		// PushLayer(std::make_unique<WindowStateTests>());
 		// PushLayer(std::make_unique<WindowFeaturesTests>());

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3520,3 +3520,11 @@ SITREP 12/11/2022|22w49b2
         - Disabled VRS after render scaling pass ~<5 mins
         - VulkanRenderer StartGraphicRecording() now checks with internal resolution against VRS image attachment ~<10 mins
         - Updated VRSTests ~<5 mins
+        - RendererAPI MSAAResolvePass replaced Window* with CommandBuffer* ~<5 mins
+        - RendererAPI Removed RenderTargetsMSAA ~<10 mins
+        - VulkanRenderer Combined UpdateAntiAliasingRenderTargets() with UpdateInternalRenderTargets() ~<10 mins
+        - RendererAPI ShadingRateTextures are now cached so they dont get destroyed while being in use by command buffers ~<5 mins
+        - RendererAPI RenderScalePass() WIP MSAA support ~>20 mins
+        - RendererAPI ShadingRateTexture is now of type RenderTarget instead of Texture ~<20 mins
+        - ImGuiLayer now automatically sets appropriate MSAA sample count ~<5 mins
+        - ImGuiLayer Removed SetMSAASamples() ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3504,3 +3504,9 @@ SITREP 12/05/2022|22w49a1
     - VRSTests Added check if VRS is actually supported before trying to load the visualization shader ~<5 mins
     - VulkanShader Fixed a crash when shaders do not use any descriptors ~<5 mins
     - Fixed Windows freezing when application focus is lost ~<5 mins
+
+SITREP 12/05/2022|22w49a1
+    - Changed TRAP Engine version to 22w49a1(0.8.79)
+    - Branch decouple-resolution:
+        - RenderCommand/RendererAPI/VulkanRenderer Added SetRenderScale(), GetRenderScale() and OnPostUpdate() functions ~<10 mins
+        - Engine.cfg Added RenderScale ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3530,3 +3530,4 @@ SITREP 12/11/2022|22w49b2
         - ImGuiLayer Removed SetMSAASamples() ~<5 mins
         - VulkanRenderer Finished MSAA RenderScale support ~>30 mins
         - VulkanRenderer RenderScalePass() removed code redundancy ~<5 mins
+        - Headless-Mode Added support for RenderScale ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3531,3 +3531,4 @@ SITREP 12/11/2022|22w49b2
         - VulkanRenderer Finished MSAA RenderScale support ~>30 mins
         - VulkanRenderer RenderScalePass() removed code redundancy ~<5 mins
         - Headless-Mode Added support for RenderScale ~<10 mins
+        - Tests Added RenderScaleTests ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3510,3 +3510,4 @@ SITREP 12/05/2022|22w49a1
     - Branch decouple-resolution:
         - RenderCommand/RendererAPI/VulkanRenderer Added SetRenderScale(), GetRenderScale() and OnPostUpdate() functions ~<10 mins
         - Engine.cfg Added RenderScale ~<5 mins
+        - Moved MSAA RenderTarget from SwapChain to PerWindowData ~<20 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3516,3 +3516,7 @@ SITREP 12/11/2022|22w49b2
     - Changed TRAP Engine version to 22w49a1(0.8.81)
     - Branch decouple-resolution:
         - Added initial support for render scaling (doesnt support resizing and MSAA yet) ~>60 mins
+        - Added window resizing support for render scaling ~<10 mins
+        - Disabled VRS after render scaling pass ~<5 mins
+        - VulkanRenderer StartGraphicRecording() now checks with internal resolution against VRS image attachment ~<10 mins
+        - Updated VRSTests ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3505,9 +3505,14 @@ SITREP 12/05/2022|22w49a1
     - VulkanShader Fixed a crash when shaders do not use any descriptors ~<5 mins
     - Fixed Windows freezing when application focus is lost ~<5 mins
 
-SITREP 12/05/2022|22w49a1
-    - Changed TRAP Engine version to 22w49a1(0.8.79)
+SITREP 12/10/2022|22w49b1
+    - Changed TRAP Engine version to 22w49b1(0.8.80)
     - Branch decouple-resolution:
         - RenderCommand/RendererAPI/VulkanRenderer Added SetRenderScale(), GetRenderScale() and OnPostUpdate() functions ~<10 mins
         - Engine.cfg Added RenderScale ~<5 mins
         - Moved MSAA RenderTarget from SwapChain to PerWindowData ~<20 mins
+
+SITREP 12/11/2022|22w49b2
+    - Changed TRAP Engine version to 22w49a1(0.8.81)
+    - Branch decouple-resolution:
+        - Added initial support for render scaling (doesnt support resizing and MSAA yet) ~>60 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3528,3 +3528,4 @@ SITREP 12/11/2022|22w49b2
         - RendererAPI ShadingRateTexture is now of type RenderTarget instead of Texture ~<20 mins
         - ImGuiLayer now automatically sets appropriate MSAA sample count ~<5 mins
         - ImGuiLayer Removed SetMSAASamples() ~<5 mins
+        - VulkanRenderer Finished MSAA RenderScale support ~>30 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3529,3 +3529,4 @@ SITREP 12/11/2022|22w49b2
         - ImGuiLayer now automatically sets appropriate MSAA sample count ~<5 mins
         - ImGuiLayer Removed SetMSAASamples() ~<5 mins
         - VulkanRenderer Finished MSAA RenderScale support ~>30 mins
+        - VulkanRenderer RenderScalePass() removed code redundancy ~<5 mins

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -335,10 +335,6 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 	Graphics::RenderCommand::SetLatencyMode(latencyMode);
 	NVSTATS_INIT(0, 0);
 #endif /*NVIDIA_REFLEX_AVAILABLE*/
-
-	//Update Viewport
-	const auto frameBufferSize = m_window->GetFrameBufferSize();
-	Graphics::RenderCommand::SetViewport(0, 0, frameBufferSize.x, frameBufferSize.y);
 #endif
 
 	if(renderAPI != Graphics::RenderAPI::NONE)
@@ -560,7 +556,7 @@ void TRAP::Application::Run()
 			}
 
 			if(Graphics::RendererAPI::GetRenderAPI() != Graphics::RenderAPI::NONE)
-				Graphics::RendererAPI::GetRenderer()->OnPostUpdate();
+				Graphics::RendererAPI::OnPostUpdate();
 
 #ifndef TRAP_HEADLESS_MODE
 			ImGuiLayer::Begin();
@@ -907,7 +903,6 @@ bool TRAP::Application::OnFrameBufferResize(Events::FrameBufferResizeEvent& e)
 {
 	ZoneNamed(__tracy, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
 
-	Graphics::RenderCommand::SetViewport(0, 0, e.GetWidth(), e.GetHeight(), e.GetWindow());
 	Graphics::RendererAPI::GetRenderer()->ResizeSwapChain(e.GetWindow());
 
 	return false;

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -263,6 +263,8 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 		m_config.Get<TRAP::Graphics::SampleCount>("AntiAliasingQuality", antiAliasingSampleCount);
 		std::string anisotropyLevelStr = "16";
 		m_config.Get<std::string>("AnisotropyLevel", anisotropyLevelStr);
+		float renderScale = 1.0f;
+		m_config.Get<float>("RenderScale", renderScale);
 
 		Graphics::RendererAPI::Init(m_gameName, renderAPI);
 		Graphics::RenderCommand::SetAntiAliasing(antiAliasing, antiAliasingSampleCount);
@@ -280,6 +282,8 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 	m_config.Get<TRAP::Graphics::SampleCount>("AntiAliasingQuality", antiAliasingSampleCount);
 	std::string anisotropyLevelStr = "16";
 	m_config.Get<std::string>("AnisotropyLevel", anisotropyLevelStr);
+	float renderScale = 1.0f;
+	m_config.Get<float>("RenderScale", renderScale);
 
 	Graphics::RendererAPI::Init(m_gameName, renderAPI);
 	Graphics::RenderCommand::SetAntiAliasing(antiAliasing, antiAliasingSampleCount);
@@ -343,6 +347,8 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 
 	if(renderAPI != Graphics::RenderAPI::NONE)
 	{
+		Graphics::RenderCommand::SetRenderScale(renderScale);
+
 		//Always added as a fallback shader
 		Graphics::ShaderManager::LoadSource("FallbackGraphics", std::string(Embed::FallbackGraphicsShader))->Use();
 		Graphics::ShaderManager::LoadSource("FallbackCompute", std::string(Embed::FallbackComputeShader))->Use();
@@ -432,6 +438,7 @@ TRAP::Application::~Application()
 		m_config.Set("AntiAliasing", antiAliasing);
 		m_config.Set("AntiAliasingQuality", antiAliasingSampleCount);
 		m_config.Set("AnisotropyLevel", (anisotropyLevel == Graphics::SampleCount::One) ? "Off" : Utils::String::ConvertToString(anisotropyLevel));
+		m_config.Set("RenderScale", Graphics::RenderCommand::GetRenderScale());
 
 		//NVIDIA Reflex
 #if !defined(TRAP_HEADLESS_MODE) && defined(NVIDIA_REFLEX_AVAILABLE)
@@ -499,7 +506,7 @@ void TRAP::Application::Run()
 		else if (m_fpsLimit)
 #endif
 		{
-			std::chrono::duration<float, std::milli> limitMs{}; 
+			std::chrono::duration<float, std::milli> limitMs{};
 			if(m_fpsLimit)
 				limitMs = std::chrono::duration<float, std::milli>(1000.0f / static_cast<float>(m_fpsLimit) - limiterTimer.ElapsedMilliseconds());
 			else //If engine is not focused, set engine to 30 FPS so other applications dont lag
@@ -553,6 +560,9 @@ void TRAP::Application::Run()
 				}
 				// TP_TRACE("After: ", tickTimerSeconds, "s of tick time remaining");
 			}
+
+			if(Graphics::RendererAPI::GetRenderAPI() != Graphics::RenderAPI::NONE)
+				Graphics::RendererAPI::GetRenderer()->OnPostUpdate();
 
 #ifndef TRAP_HEADLESS_MODE
 			ImGuiLayer::Begin();

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -263,8 +263,6 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 		m_config.Get<TRAP::Graphics::SampleCount>("AntiAliasingQuality", antiAliasingSampleCount);
 		std::string anisotropyLevelStr = "16";
 		m_config.Get<std::string>("AnisotropyLevel", anisotropyLevelStr);
-		float renderScale = 1.0f;
-		m_config.Get<float>("RenderScale", renderScale);
 
 		Graphics::RendererAPI::Init(m_gameName, renderAPI);
 		Graphics::RenderCommand::SetAntiAliasing(antiAliasing, antiAliasingSampleCount);
@@ -282,8 +280,6 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 	m_config.Get<TRAP::Graphics::SampleCount>("AntiAliasingQuality", antiAliasingSampleCount);
 	std::string anisotropyLevelStr = "16";
 	m_config.Get<std::string>("AnisotropyLevel", anisotropyLevelStr);
-	float renderScale = 1.0f;
-	m_config.Get<float>("RenderScale", renderScale);
 
 	Graphics::RendererAPI::Init(m_gameName, renderAPI);
 	Graphics::RenderCommand::SetAntiAliasing(antiAliasing, antiAliasingSampleCount);
@@ -347,6 +343,8 @@ TRAP::Application::Application(std::string gameName, const uint32_t appID)
 
 	if(renderAPI != Graphics::RenderAPI::NONE)
 	{
+		float renderScale = 1.0f;
+		m_config.Get<float>("RenderScale", renderScale);
 		Graphics::RenderCommand::SetRenderScale(renderScale);
 
 		//Always added as a fallback shader

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -179,7 +179,7 @@ constexpr uint32_t TRAP_VERSION_PATCH(const uint32_t version) noexcept
 /// <summary>
 /// TRAP version number created with TRAP_MAKE_VERSION
 /// </summary>
-constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 79);
+constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 80);
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -179,7 +179,7 @@ constexpr uint32_t TRAP_VERSION_PATCH(const uint32_t version) noexcept
 /// <summary>
 /// TRAP version number created with TRAP_MAKE_VERSION
 /// </summary>
-constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 80);
+constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION(0, 8, 81);
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Graphics/API/Objects/CommandBuffer.h
+++ b/TRAP/src/Graphics/API/Objects/CommandBuffer.h
@@ -109,7 +109,7 @@ namespace TRAP::Graphics
 			                           const std::vector<uint32_t>* colorArraySlices,
 			                           const std::vector<uint32_t>* colorMipSlices,
 			                           uint32_t depthArraySlice, uint32_t depthMipSlice,
-									   const TRAP::Ref<Texture>& shadingRate = nullptr) = 0;
+									   const TRAP::Ref<RenderTarget>& shadingRate = nullptr) = 0;
 
 		/// <summary>
 		/// Add a debug marker to the command buffer.

--- a/TRAP/src/Graphics/API/Objects/SwapChain.cpp
+++ b/TRAP/src/Graphics/API/Objects/SwapChain.cpp
@@ -62,7 +62,6 @@ TRAP::Graphics::SwapChain::~SwapChain()
 	TP_DEBUG(Log::RendererSwapChainPrefix, "Destroying SwapChain");
 #endif
 
-	m_renderTargetsMSAA.clear();
 	m_renderTargets.clear();
 }
 
@@ -73,13 +72,4 @@ const std::vector<TRAP::Ref<TRAP::Graphics::RenderTarget>>& TRAP::Graphics::Swap
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
 
 	return m_renderTargets;
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-const std::vector<TRAP::Ref<TRAP::Graphics::RenderTarget>>& TRAP::Graphics::SwapChain::GetRenderTargetsMSAA() const
-{
-	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
-
-	return m_renderTargetsMSAA;
 }

--- a/TRAP/src/Graphics/API/Objects/SwapChain.h
+++ b/TRAP/src/Graphics/API/Objects/SwapChain.h
@@ -62,21 +62,11 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <returns>Render targets used by the swapchain.</returns>
 		virtual const std::vector<TRAP::Ref<RenderTarget>>& GetRenderTargets() const;
-		/// <summary>
-		/// Retrieve the render targets used by the swapchain to resolve MSAA.
-		/// </summary>
-		/// <returns>Render targets used by the swapchain to resolve MSAA.</returns>
-		virtual const std::vector<TRAP::Ref<RenderTarget>>& GetRenderTargetsMSAA() const;
 
 		/// <summary>
 		/// Toggle Vsync on and off.
 		/// </summary>
 		virtual void ToggleVSync() = 0;
-
-		/// <summary>
-		/// Set sample count used by anti aliasing.
-		/// </summary>
-		virtual void SetSampleCount(RendererAPI::SampleCount sampleCount) = 0;
 
 	protected:
 		/// <summary>
@@ -86,7 +76,6 @@ namespace TRAP::Graphics
 
 		//Render targets created from the swapchain back buffers
 		std::vector<TRAP::Ref<RenderTarget>> m_renderTargets;
-		std::vector<TRAP::Ref<RenderTarget>> m_renderTargetsMSAA;
 	};
 }
 

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -324,28 +324,18 @@ void TRAP::Graphics::RendererAPI::StartRenderPass(const Window* window)
 	TRAP::Ref<Graphics::RenderTarget> renderTarget = nullptr;
 #ifndef TRAP_HEADLESS_MODE
 	//Get correct RenderTarget
-	if(s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA) //MSAA enabled
-		renderTarget = winData->RenderTargetsMSAA[winData->CurrentSwapChainImageIndex];
-	else //No MSAA
-	{
-		if(winData->RenderScale != 1.0f && winData->State == PerWindowState::PreUpdate)
-			renderTarget = winData->InternalRenderTargets[winData->CurrentSwapChainImageIndex];
-		else
-			renderTarget = winData->SwapChain->GetRenderTargets()[winData->CurrentSwapChainImageIndex];
-	}
+	if((winData->RenderScale != 1.0f || s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA) && winData->State == PerWindowState::PreUpdate)
+		renderTarget = winData->InternalRenderTargets[winData->CurrentSwapChainImageIndex];
+	else
+		renderTarget = winData->SwapChain->GetRenderTargets()[winData->CurrentSwapChainImageIndex];
 
 	GetRenderer()->BindRenderTarget(renderTarget, nullptr, nullptr,
 									nullptr, nullptr, static_cast<uint32_t>(-1), static_cast<uint32_t>(-1), window);
 #else
-	if(s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA) //MSAA enabled
-		renderTarget = winData->RenderTargetsMSAA[winData->ImageIndex];
-	else //No MSAA
-	{
-		if(winData->RenderScale != 1.0f && winData->State == PerWindowState::PreUpdate)
-			renderTarget = winData->InternalRenderTargets[winData->ImageIndex];
-		else
-			renderTarget = winData->RenderTargets[winData->ImageIndex];
-	}
+	if((winData->RenderScale != 1.0f || s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA) && winData->State == PerWindowState::PreUpdate)
+		renderTarget = winData->InternalRenderTargets[winData->ImageIndex];
+	else
+		renderTarget = winData->RenderTargets[winData->ImageIndex];
 
 	GetRenderer()->BindRenderTarget(renderTarget, nullptr, nullptr,
 	                                nullptr, nullptr, static_cast<uint32_t>(-1), static_cast<uint32_t>(-1), window);

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -260,6 +260,38 @@ TRAP::Ref<TRAP::Graphics::RootSignature> TRAP::Graphics::RendererAPI::GetGraphic
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+TRAP::Math::Vec2ui TRAP::Graphics::RendererAPI::GetInternalRenderResolution(const Window* window)
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
+
+	if (!window)
+		window = TRAP::Application::GetWindow();
+
+	const float renderScale = s_perWindowDataMap.at(window)->RenderScale;
+	const Math::Vec2 frameBufferSize
+	{
+		static_cast<float>(window->GetFrameBufferSize().x),
+		static_cast<float>(window->GetFrameBufferSize().y)
+	};
+	const float aspectRatio = frameBufferSize.x / frameBufferSize.y;
+
+	Math::Vec2 finalRes = frameBufferSize * renderScale;
+
+	//Make sure the resolution is an integer scale of the framebuffer size.
+	//This is done to avoid scaling artifacts (like blurriness).
+	while((finalRes.x / finalRes.y) != aspectRatio)
+	{
+		if((finalRes.x / finalRes.y) <= aspectRatio)
+			++finalRes.x;
+		else
+			++finalRes.y;
+	}
+
+	return static_cast<Math::Vec2ui>(finalRes);
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
 void TRAP::Graphics::RendererAPI::StartRenderPass(const Window* window)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -284,6 +284,10 @@ TRAP::Math::Vec2ui TRAP::Graphics::RendererAPI::GetInternalRenderResolution(cons
 		window = TRAP::Application::GetWindow();
 
 	const float renderScale = s_perWindowDataMap.at(window)->RenderScale;
+
+	if(renderScale == 1.0f)
+		return window->GetFrameBufferSize();
+
 	const Math::Vec2 frameBufferSize
 	{
 		static_cast<float>(window->GetFrameBufferSize().x),

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -206,8 +206,17 @@ void TRAP::Graphics::RendererAPI::OnPostUpdate()
 		data->State = PerWindowState::PostUpdate;
 
 		if(data->RenderScale != 1.0f)
+		{
+			TRAP::Ref<RenderTarget> outputTarget = nullptr;
+#ifndef TRAP_HEADLESS_MODE
+			outputTarget = data->SwapChain->GetRenderTargets()[data->CurrentSwapChainImageIndex];
+#else
+			outputTarget = data->RenderTargets[data->CurrentSwapChainImageIndex];
+#endif
+
 			GetRenderer()->RenderScalePass(data->InternalRenderTargets[data->CurrentSwapChainImageIndex],
-			                               data->SwapChain->GetRenderTargets()[data->CurrentSwapChainImageIndex], win);
+			                               outputTarget, win);
+		}
 	}
 }
 
@@ -285,13 +294,28 @@ TRAP::Math::Vec2ui TRAP::Graphics::RendererAPI::GetInternalRenderResolution(cons
 
 	const float renderScale = s_perWindowDataMap.at(window)->RenderScale;
 
+#ifdef TRAP_HEADLESS_MODE
+	const auto& winData = s_perWindowDataMap.at(window);
+#endif
+
 	if(renderScale == 1.0f)
+	{
+#ifndef TRAP_HEADLESS_MODE
 		return window->GetFrameBufferSize();
+#else
+		return {winData->NewWidth, winData->NewHeight};
+#endif
+	}
 
 	const Math::Vec2 frameBufferSize
 	{
+#ifndef TRAP_HEADLESS_MODE
 		static_cast<float>(window->GetFrameBufferSize().x),
 		static_cast<float>(window->GetFrameBufferSize().y)
+#else
+		static_cast<float>(winData->NewWidth),
+		static_cast<float>(winData->NewHeight),
+#endif
 	};
 	const float aspectRatio = frameBufferSize.x / frameBufferSize.y;
 

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -305,7 +305,7 @@ void TRAP::Graphics::RendererAPI::StartRenderPass(const Window* window)
 #ifndef TRAP_HEADLESS_MODE
 	//Get correct RenderTarget
 	if(s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA) //MSAA enabled
-		renderTarget = winData->SwapChain->GetRenderTargetsMSAA()[winData->CurrentSwapChainImageIndex];
+		renderTarget = winData->RenderTargetsMSAA[winData->CurrentSwapChainImageIndex];
 	else //No MSAA
 		renderTarget = winData->SwapChain->GetRenderTargets()[winData->CurrentSwapChainImageIndex];
 

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -2657,9 +2657,9 @@ namespace TRAP::Graphics
 			float RenderScale = 1.0f;
 			TRAP::Ref<TRAP::Graphics::SwapChain> SwapChain;
 			bool ResizeSwapChain = false;
+			std::array<TRAP::Ref<RenderTarget>, ImageCount> RenderTargetsMSAA;
 #ifdef TRAP_HEADLESS_MODE
 			std::array<TRAP::Ref<RenderTarget>, ImageCount> RenderTargets;
-			std::array<TRAP::Ref<RenderTarget>, ImageCount> RenderTargetsMSAA;
 			bool Resize = false;
 			uint32_t NewWidth = 1920, NewHeight = 1080; //Default RenderTargets to use Full HD
 #endif

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -403,7 +403,7 @@ namespace TRAP::Graphics
 		/// Note: The texture must be in ResourceState::ShadingRateSource.
 		/// </param>
 		/// <param name="window">Window to set shading rate for.</param>
-		virtual void SetShadingRate(Ref<Texture> texture, const Window* const window) const = 0;
+		virtual void SetShadingRate(Ref<RenderTarget> texture, const Window* const window) const = 0;
 
 		/// <summary>
 		/// Clear the given window's render target.
@@ -678,9 +678,9 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <param name="source">Source MSAA render target to resolve.</param>
 		/// <param name="destination">Destination non MSAA render target to resolve into.</param>
-		/// <param name="window">Window to do the resolve pass on.</param>
+		/// <param name="cmd">CommadBuffer to resolve on.</param>
 		virtual void MSAAResolvePass(TRAP::Ref<RenderTarget> source, TRAP::Ref<RenderTarget> destination,
-		                             const Window* const window) const = 0;
+		                             CommandBuffer* const cmd) const = 0;
 
 		/// <summary>
 		/// Scale image from internal resolution to the final output resolution.
@@ -2082,7 +2082,7 @@ namespace TRAP::Graphics
 			//Shading rate combiners to use (only if supported)
 			std::array<TRAP::Graphics::RendererAPI::ShadingRateCombiner, 2> ShadingRateCombiners{};
 			//Shading rate texture to use (only if ShadingRateCaps::PerTile is supported, disables fixed ShadingRate)
-			TRAP::Ref<TRAP::Graphics::Texture> ShadingRateTexture{};
+			TRAP::Ref<TRAP::Graphics::RenderTarget> ShadingRateTexture{};
 		};
 
 		/// <summary>
@@ -2672,13 +2672,14 @@ namespace TRAP::Graphics
 			TRAP::Ref<Pipeline> CurrentGraphicsPipeline;
 			float GraphicsFrameTime;
 			bool Recording;
-			TRAP::Ref<Texture> NewShadingRateTexture;
+			TRAP::Ref<RenderTarget> NewShadingRateTexture;
+			std::array<TRAP::Ref<TRAP::Graphics::RenderTarget>, 3> CachedShadingRateTextures{};
 
 			float NewRenderScale = 1.0f;
 			float RenderScale = 1.0f;
 			TRAP::Ref<TRAP::Graphics::SwapChain> SwapChain;
 			bool ResizeSwapChain = false;
-			std::array<TRAP::Ref<RenderTarget>, ImageCount> RenderTargetsMSAA;
+			std::array<TRAP::Ref<RenderTarget>, ImageCount> TemporaryResolveRenderTargets; //Used to resolve MSAA RenderTarget before applying RenderScale
 			std::array<TRAP::Ref<RenderTarget>, ImageCount> InternalRenderTargets; //Used when RenderScale is not 1.0f
 #ifdef TRAP_HEADLESS_MODE
 			std::array<TRAP::Ref<RenderTarget>, ImageCount> RenderTargets;

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -185,6 +185,13 @@ namespace TRAP::Graphics
 		virtual void Flush(const Window* const window) const = 0;
 
 		/// <summary>
+		/// On post update function.
+		/// This function performs several tasks that need to be done after LayerStack::OnUpdate() calls.
+		/// Currently this only performs scaling of the render targets, dependening on the current render scale.
+		/// </summary>
+		virtual void OnPostUpdate() const = 0;
+
+		/// <summary>
 		/// Dispatch to the given window.
 		/// </summary>
 		/// <param name="workGroupElements">
@@ -217,6 +224,20 @@ namespace TRAP::Graphics
 		virtual void SetReflexFPSLimit(uint32_t limit) = 0;
 
 		//RenderTarget Stuff
+
+		/// <summary>
+		/// Set the render scale for the given window.
+		/// Note: This functon takes effect on the next frame.
+		/// </summary>
+		/// <param name="scale">Render scale value (valid range: 0.5f-1.0f inclusive).</param>
+		/// <param name="window">Window to set render scale for.</param>
+		virtual void SetRenderScale(float scale, const Window* const window) const = 0;
+		/// <summary>
+		/// Retrieve the used render scale value of the given window.
+		/// </summary>
+		/// <param name="window">Window to retrieve render scale from.</param>
+		/// <returns>Render scale (between 0.5f and 2.0f inclusive).</returns>
+		virtual float GetRenderScale(const Window* const window) const = 0;
 
 		/// <summary>
 		/// Set the clear color to be used by the given window.
@@ -706,6 +727,12 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to retrieve the graphics root signature from.</param>
 		/// <returns>Graphics root signature.</returns>
 		static TRAP::Ref<TRAP::Graphics::RootSignature> GetGraphicsRootSignature(const Window* const window);
+		/// <summary>
+		/// Retrieve the currently used internal render resolution of the given window.
+		/// </summary>
+		/// <param name="window">Window to get internal render resolution from.</param>
+		/// <returns>Internal render resolution.</returns>
+		static TRAP::Math::Vec2ui GetInternalRenderResolution(const Window* window);
 
 		/// <summary>
 		/// Start a render pass for the given window.
@@ -2627,6 +2654,7 @@ namespace TRAP::Graphics
 			bool Recording;
 			TRAP::Ref<Texture> NewShadingRateTexture;
 
+			float RenderScale = 1.0f;
 			TRAP::Ref<TRAP::Graphics::SwapChain> SwapChain;
 			bool ResizeSwapChain = false;
 #ifdef TRAP_HEADLESS_MODE

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.cpp
@@ -18,7 +18,6 @@
 #include "VulkanInits.h"
 #include "VulkanQueue.h"
 #include "VulkanTexture.h"
-#include <memory>
 
 TRAP::Graphics::API::VulkanCommandBuffer::~VulkanCommandBuffer()
 {
@@ -249,7 +248,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vect
 																 const std::vector<uint32_t>* const colorMipSlices,
 																 const uint32_t depthArraySlice,
 																 const uint32_t depthMipSlice,
-																 const TRAP::Ref<Texture>& shadingRate)
+																 const TRAP::Ref<RenderTarget>& shadingRate)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
 
@@ -338,9 +337,9 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vect
 	{
 		const Ref<VulkanTexture> vkTex = std::dynamic_pointer_cast<VulkanTexture>(shadingRate);
 
-		const uint32_t hashValue = static_cast<uint32_t>(shadingRate->GetImageFormat());
+		uint32_t hashValue = static_cast<uint32_t>(shadingRate->GetImageFormat());
 		renderPassHash = HashAlg<uint32_t>(&hashValue, 1, renderPassHash);
-		const uint32_t ID = static_cast<uint32_t>(RendererAPI::ResourceState::ShadingRateSource);
+		const uint32_t ID = std::dynamic_pointer_cast<VulkanRenderTarget>(shadingRate)->GetID();
 		frameBufferHash = HashAlg<uint32_t>(&ID, 1, frameBufferHash);
 	}
 
@@ -405,7 +404,7 @@ void TRAP::Graphics::API::VulkanCommandBuffer::BindRenderTargets(const std::vect
 		VulkanRenderer::FrameBufferDesc desc{};
 		desc.RenderTargets = renderTargets;
 		desc.DepthStencil = depthStencil;
-		desc.ShadingRateTexture = shadingRate;
+		desc.ShadingRate = shadingRate;
 		desc.RenderPass = renderPass;
 		if(colorArraySlices)
 			desc.ColorArraySlices = *colorArraySlices;

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanCommandBuffer.h
@@ -131,7 +131,7 @@ namespace TRAP::Graphics::API
 		                       const std::vector<uint32_t>* colorMipSlices,
 							   uint32_t depthArraySlice,
 							   uint32_t depthMipSlice,
-							   const TRAP::Ref<Texture>& shadingRate = nullptr) override;
+							   const TRAP::Ref<RenderTarget>& shadingRate = nullptr) override;
 
 		/// <summary>
 		/// Add a debug marker to the command buffer.

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanFrameBuffer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanFrameBuffer.cpp
@@ -26,7 +26,7 @@ TRAP::Graphics::API::VulkanFrameBuffer::VulkanFrameBuffer(TRAP::Ref<VulkanDevice
 
 	const uint32_t colorAttachmentCount = static_cast<uint32_t>(desc.RenderTargets.size());
 	const uint32_t depthAttachmentCount = desc.DepthStencil ? 1 : 0;
-	const uint32_t shadingRateAttachmentCount = desc.ShadingRateTexture ? 1 : 0;
+	const uint32_t shadingRateAttachmentCount = desc.ShadingRate ? 1 : 0;
 
 	if(colorAttachmentCount)
 	{
@@ -117,11 +117,11 @@ TRAP::Graphics::API::VulkanFrameBuffer::VulkanFrameBuffer(TRAP::Ref<VulkanDevice
 	}
 
 	//Shading rate
-	if(desc.ShadingRateTexture)
+	if(desc.ShadingRate)
 	{
-		const Ref<VulkanTexture> tex = std::dynamic_pointer_cast<VulkanTexture>(desc.ShadingRateTexture);
+		const Ref<VulkanRenderTarget> rTarget = std::dynamic_pointer_cast<VulkanRenderTarget>(desc.ShadingRate);
 
-		*iterAttachments = tex->GetSRVVkImageView();
+		*iterAttachments = rTarget->GetVkImageView();
 		++iterAttachments;
 	}
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPipeline.cpp
@@ -10,7 +10,7 @@
 #include "VulkanInits.h"
 #include "Graphics/API/Vulkan/VulkanCommon.h"
 #include "Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.h"
-#include "Graphics/Textures/Texture.h"
+#include "Graphics/API/Objects/RenderTarget.h"
 
 TRAP::Graphics::API::VulkanPipeline::VulkanPipeline(const RendererAPI::PipelineDesc& desc)
 	: m_vkPipeline(VK_NULL_HANDLE),

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.cpp
@@ -76,7 +76,7 @@ TRAP::Graphics::API::VulkanRenderTarget::VulkanRenderTarget(const RendererAPI::R
 		textureDesc.StartState |= RendererAPI::ResourceState::RenderTarget;
 	else
 		textureDesc.StartState |= RendererAPI::ResourceState::DepthWrite;
-	if(desc.StartState == RendererAPI::ResourceState::ShadingRateSource)
+	if(static_cast<bool>(desc.StartState & RendererAPI::ResourceState::ShadingRateSource))
 		textureDesc.StartState |= RendererAPI::ResourceState::ShadingRateSource;
 
 	//Set this by default to be able to sample the renderTarget in shader

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.cpp
@@ -76,6 +76,8 @@ TRAP::Graphics::API::VulkanRenderTarget::VulkanRenderTarget(const RendererAPI::R
 		textureDesc.StartState |= RendererAPI::ResourceState::RenderTarget;
 	else
 		textureDesc.StartState |= RendererAPI::ResourceState::DepthWrite;
+	if(desc.StartState == RendererAPI::ResourceState::ShadingRateSource)
+		textureDesc.StartState |= RendererAPI::ResourceState::ShadingRateSource;
 
 	//Set this by default to be able to sample the renderTarget in shader
 	textureDesc.Descriptors = desc.Descriptors;

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderTarget.h
@@ -70,7 +70,7 @@ namespace TRAP::Graphics::API
 			                                                                    const std::vector<uint32_t>* colorMipSlices,
 			                                                                    uint32_t depthArraySlice,
 			                                                                    uint32_t depthMipSlice,
-							   												    const TRAP::Ref<Texture>& shadingRate);
+							   												    const TRAP::Ref<RenderTarget>& shadingRate);
 
 		/// <summary>
 		/// Set the name of the render target.

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.cpp
@@ -295,15 +295,6 @@ void TRAP::Graphics::API::VulkanSwapChain::InitSwapchain(RendererAPI::SwapChainD
 		m_renderTargets.push_back(TRAP::MakeRef<VulkanRenderTarget>(descColor));
 	}
 
-	//Create MSAA resolve images if needed
-	if(desc.SampleCount != RendererAPI::SampleCount::One)
-	{
-		descColor.NativeHandle = nullptr;
-		descColor.SampleCount = desc.SampleCount;
-		for (uint32_t i = 0; i < imageCount; ++i)
-			m_renderTargetsMSAA.push_back(TRAP::MakeRef<VulkanRenderTarget>(descColor));
-	}
-
 	//////////////
 
 	m_desc = desc;
@@ -323,7 +314,6 @@ void TRAP::Graphics::API::VulkanSwapChain::DeInitSwapchain()
 
 	m_device->WaitIdle();
 
-	m_renderTargetsMSAA.clear();
 	m_renderTargets.clear();
 
 	vkDestroySwapchainKHR(m_device->GetVkDevice(), m_swapChain, nullptr);
@@ -392,19 +382,6 @@ void TRAP::Graphics::API::VulkanSwapChain::ToggleVSync()
 
 	//Toggle VSync on or off
 	//For Vulkan we need to remove the SwapChain and recreate it with correct VSync option
-	DeInitSwapchain();
-	InitSwapchain(desc);
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-void TRAP::Graphics::API::VulkanSwapChain::SetSampleCount(const RendererAPI::SampleCount sampleCount)
-{
-	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
-
-	RendererAPI::SwapChainDesc desc = m_desc;
-	desc.SampleCount = sampleCount;
-
 	DeInitSwapchain();
 	InitSwapchain(desc);
 }

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.h
@@ -56,11 +56,6 @@ namespace TRAP::Graphics::API
 		void ToggleVSync() override;
 
 		/// <summary>
-		/// Set sample count used by anti aliasing.
-		/// </summary>
-		void SetSampleCount(RendererAPI::SampleCount sampleCount) override;
-
-		/// <summary>
 		/// Retrieve the Vulkan swap chain handle.
 		/// </summary>
 		/// <returns>Vulkan swap chain handle.</returns>

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanTexture.cpp
@@ -127,7 +127,7 @@ void TRAP::Graphics::API::VulkanTexture::Init(const RendererAPI::TextureDesc &de
 		additionalFlags |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 	else if (static_cast<uint32_t>(desc.StartState & RendererAPI::ResourceState::DepthWrite))
 		additionalFlags |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-	else if (static_cast<uint32_t>(desc.StartState & RendererAPI::ResourceState::ShadingRateSource))
+	if (static_cast<uint32_t>(desc.StartState & RendererAPI::ResourceState::ShadingRateSource))
 		additionalFlags |= VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR;
 
 	VkImageType imageType = VK_IMAGE_TYPE_MAX_ENUM;

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -2302,7 +2302,7 @@ void TRAP::Graphics::API::VulkanRenderer::InitPerWindowData(Window* const window
 	                             p->RenderTargetsMSAA[0] :
 								 p->SwapChain->GetRenderTargets()[0];
 #else
-	const auto& rT = s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA ? p->RenderTargetsMSAA : p->RenderTargets;
+	const auto& rT = s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA ? p->RenderTargetsMSAA[0] : p->RenderTargets[0];
 #endif
 	p->GraphicsPipelineDesc = {};
 	p->GraphicsPipelineDesc.Type = PipelineType::Graphics;

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -1093,11 +1093,11 @@ void TRAP::Graphics::API::VulkanRenderer::Clear(const ClearBufferType clearType,
 	const PerWindowData* const data = s_perWindowDataMap.at(window).get();
 
 	TRAP::Ref<RenderTarget> renderTarget;
-#ifndef TRAP_HEADLESS_MODE
 	if(data->RenderScale != 1.0f || s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA)
 		renderTarget = data->InternalRenderTargets[data->CurrentSwapChainImageIndex];
 	else
 	{
+#ifndef TRAP_HEADLESS_MODE
 		renderTarget = data->SwapChain->GetRenderTargets()[data->CurrentSwapChainImageIndex];
 #else
 		renderTarget = data->RenderTargets[data->CurrentSwapChainImageIndex];

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -608,6 +608,22 @@ void TRAP::Graphics::API::VulkanRenderer::Flush(const Window* const window) cons
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+void TRAP::Graphics::API::VulkanRenderer::OnPostUpdate() const
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
+
+	//TODO Perform scaling for each PerWindowData dependening on set render scale
+
+	// for(const auto& [window, data] : s_perWindowDataMap)
+	// {
+	// 	const PerWindowData* const p = data.get();
+
+	// 	RenderScalePass(p);
+	// }
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
 void TRAP::Graphics::API::VulkanRenderer::Dispatch(std::array<uint32_t, 3> workGroupElements, const Window* const window) const
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
@@ -669,6 +685,33 @@ void TRAP::Graphics::API::VulkanRenderer::SetReflexFPSLimit([[maybe_unused]] con
 			SetLatencyMode(LatencyMode::Disabled, win);
 	}
 #endif /*NVIDIA_REFLEX_AVAILABLE*/
+}
+
+//------------------------------------------------------------------------------------------------------------------//
+
+void TRAP::Graphics::API::VulkanRenderer::SetRenderScale(float scale, const Window* const window) const
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
+
+	TRAP_ASSERT(window, "VulkanRenderer::GetRenderScale(): Window is nullptr!");
+	TRAP_ASSERT(scale >= 0.5f && scale <= 1.0f, "VulkanRenderer::GetRenderScale(): Scale must be between 0.5f and 2.0f inclusive!");
+
+	scale = TRAP::Math::Clamp(scale, 0.5f, 2.0f);
+
+	s_perWindowDataMap.at(window)->RenderScale = scale;
+
+	//TODO Trigger SwapChain resize?!
+}
+
+//------------------------------------------------------------------------------------------------------------------//
+
+float TRAP::Graphics::API::VulkanRenderer::GetRenderScale(const Window* const window) const
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
+
+	TRAP_ASSERT(window, "VulkanRenderer::GetRenderScale(): Window is nullptr!");
+
+	return s_perWindowDataMap.at(window)->RenderScale;
 }
 
 //------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -275,7 +275,7 @@ namespace TRAP::Graphics::API
 		/// Note: The texture must be in ResourceState::ShadingRateSource.
 		/// </param>
 		/// <param name="window">Window to set shading rate for.</param>
-		void SetShadingRate(Ref<Texture> texture, const Window* const window) const override;
+		void SetShadingRate(Ref<RenderTarget> texture, const Window* const window) const override;
 
 		/// <summary>
 		/// Clear the given window's render target.
@@ -550,15 +550,9 @@ namespace TRAP::Graphics::API
 		/// </summary>
 		/// <param name="source">Source MSAA render target to resolve.</param>
 		/// <param name="destination">Destination non MSAA render target to resolve into.</param>
-		/// <param name="window">Window to do the resolve pass on.</param>
+		/// <param name="cmd">CommadBuffer to resolve on.</param>
 		void MSAAResolvePass(TRAP::Ref<RenderTarget> source, TRAP::Ref<RenderTarget> destination,
-		                     const Window* const window) const override;
-		/// <summary>
-		/// Update the RenderTargets on anti aliasing changes.
-		/// </summary>
-		/// <param name="winData">PerWindowData to update.</param>
-		/// <returns>True if RenderTargets got updated, false otherwise.</returns>
-		bool UpdateAntiAliasingRenderTargets(PerWindowData* const winData) const;
+		                     CommandBuffer* const cmd) const override;
 
 		/// <summary>
 		/// Update the internal RenderTargets used for render scaling.
@@ -669,7 +663,7 @@ namespace TRAP::Graphics::API
 			//Depth/Stencil render target to use
 			TRAP::Ref<RenderTarget> DepthStencil;
 			//Shading rate texture to use
-			TRAP::Ref<Texture> ShadingRateTexture;
+			TRAP::Ref<RenderTarget> ShadingRate;
 			//Array layer to use from color render targets
 			std::vector<uint32_t> ColorArraySlices;
 			//Mip level to use from color render targets

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -75,6 +75,13 @@ namespace TRAP::Graphics::API
 		void Flush(const Window* const window) const override;
 
 		/// <summary>
+		/// On post update function.
+		/// This function performs several tasks that need to be done after LayerStack::OnUpdate() calls.
+		/// Currently this only performs scaling of the render targets, dependening on the current render scale.
+		/// </summary>
+		void OnPostUpdate() const override;
+
+		/// <summary>
 		/// Dispatch to the given window.
 		/// </summary>
 		/// <param name="workGroupElements">
@@ -101,6 +108,19 @@ namespace TRAP::Graphics::API
 		/// <param name="limit">FPS target to limit to.</param>
 		void SetReflexFPSLimit(uint32_t limit) override;
 
+		/// <summary>
+		/// Set the render scale for the given window.
+		/// Note: This functon takes effect on the next frame.
+		/// </summary>
+		/// <param name="scale">Render scale value (valid range: 0.5f-1.0f inclusive).</param>
+		/// <param name="window">Window to set render scale for.</param>
+		void SetRenderScale(float scale, const Window* const window) const override;
+		/// <summary>
+		/// Retrieve the used render scale value of the given window.
+		/// </summary>
+		/// <param name="window">Window to retrieve render scale from.</param>
+		/// <returns>Render scale (between 0.5f and 2.0f inclusive).</returns>
+		float GetRenderScale(const Window* const window) const override;
 		/// <summary>
 		/// Set the clear color to be used by the given window.
 		/// </summary>

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -75,13 +75,6 @@ namespace TRAP::Graphics::API
 		void Flush(const Window* const window) const override;
 
 		/// <summary>
-		/// On post update function.
-		/// This function performs several tasks that need to be done after LayerStack::OnUpdate() calls.
-		/// Currently this only performs scaling of the render targets, dependening on the current render scale.
-		/// </summary>
-		void OnPostUpdate() const override;
-
-		/// <summary>
 		/// Dispatch to the given window.
 		/// </summary>
 		/// <param name="workGroupElements">
@@ -566,6 +559,24 @@ namespace TRAP::Graphics::API
 		/// <param name="winData">PerWindowData to update.</param>
 		/// <returns>True if RenderTargets got updated, false otherwise.</returns>
 		bool UpdateAntiAliasingRenderTargets(PerWindowData* const winData) const;
+
+		/// <summary>
+		/// Update the internal RenderTargets used for render scaling.
+		/// </summary>
+		/// <param name="winData">PerWindowData to update.</param>
+		void UpdateInternalRenderTargets(PerWindowData* const winData) const;
+
+		/// <summary>
+		/// Scale image from internal resolution to the final output resolution.
+		///
+		/// Note: source and destination must be in ResourceState::RenderTarget.
+		/// </summary>
+		/// <param name="source">Source render target to resolve.</param>
+		/// <param name="destination">Destination render target to resolve into.</param>
+		/// <param name="window">Window to do the scaling pass on.</param>
+		void RenderScalePass(TRAP::Ref<RenderTarget> source,
+		                     TRAP::Ref<RenderTarget> destination,
+		                     const Window* const window) const override;
 
 		/// <summary>
 		/// Set the latency mode.

--- a/TRAP/src/Graphics/RenderCommand.cpp
+++ b/TRAP/src/Graphics/RenderCommand.cpp
@@ -170,7 +170,7 @@ void TRAP::Graphics::RenderCommand::SetShadingRate(const ShadingRate shadingRate
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::RenderCommand::SetShadingRate(TRAP::Ref<TRAP::Graphics::Texture> shadingRateTex,
+void TRAP::Graphics::RenderCommand::SetShadingRate(TRAP::Ref<TRAP::Graphics::RenderTarget> shadingRateTex,
                                                    const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetShadingRate(shadingRateTex, window);
@@ -448,7 +448,12 @@ void TRAP::Graphics::RenderCommand::Transition(Ref<Texture> texture, const Rende
 void TRAP::Graphics::RenderCommand::MSAAResolvePass(TRAP::Ref<RenderTarget> source,
                                                     TRAP::Ref<RenderTarget> destination, const Window* const window)
 {
-	RendererAPI::GetRenderer()->MSAAResolvePass(source, destination, window);
+	TRAP_ASSERT(window, "RenderCommand::MSAAResolvePass(): Window is nullptr!");
+
+	const auto& winData = TRAP::Graphics::RendererAPI::GetWindowData(window);
+	CommandBuffer* const cmd = winData.GraphicCommandBuffers[winData.ImageIndex];
+
+	RendererAPI::GetRenderer()->MSAAResolvePass(source, destination, cmd);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/RenderCommand.cpp
+++ b/TRAP/src/Graphics/RenderCommand.cpp
@@ -255,6 +255,20 @@ void TRAP::Graphics::RenderCommand::SetResolution(const uint32_t width, const ui
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+void TRAP::Graphics::RenderCommand::SetRenderScale(const float scale, const Window* const window)
+{
+	RendererAPI::GetRenderer()->SetRenderScale(scale, window);
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+float TRAP::Graphics::RenderCommand::GetRenderScale(const Window* const window)
+{
+	return RendererAPI::GetRenderer()->GetRenderScale(window);
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
 void TRAP::Graphics::RenderCommand::Draw(const uint32_t vertexCount, const uint32_t firstVertex, const Window* const window)
 {
 	RendererAPI::GetRenderer()->Draw(vertexCount, firstVertex, window);

--- a/TRAP/src/Graphics/RenderCommand.h
+++ b/TRAP/src/Graphics/RenderCommand.h
@@ -272,7 +272,7 @@ namespace TRAP::Graphics
 		/// Note: The texture must be in ResourceState::ShadingRateSource.
 		/// </param>
 		/// <param name="window">Window to set shading rate for. Default: Main Window.</param>
-		static void SetShadingRate(Ref<Texture> texture, const Window* const window = TRAP::Application::GetWindow());
+		static void SetShadingRate(Ref<RenderTarget> texture, const Window* const window = TRAP::Application::GetWindow());
 		/// <summary>
 		/// Set the anti aliasing method and the sample count.
 		/// Use AntiAliasing::Off to disable anti aliasing.

--- a/TRAP/src/Graphics/RenderCommand.h
+++ b/TRAP/src/Graphics/RenderCommand.h
@@ -263,8 +263,8 @@ namespace TRAP::Graphics
 		static void SetShadingRate(ShadingRate shadingRate,
 		                           ShadingRateCombiner postRasterizerRate,
 							       ShadingRateCombiner finalRate, const Window* const window = TRAP::Application::GetWindow());
-		//TODO EXPERIMENTAL
 		/// <summary>
+		/// TODO EXPERIMENTAL
 		/// Set the pipeline fragment shading rate via texture.
 		/// </summary>
 		/// <param name="texture">
@@ -361,6 +361,22 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to set resolution for. Default: Main Window.</param>
 		static void SetResolution(uint32_t width, uint32_t height, const Window* const window = TRAP::Application::GetWindow());
 #endif
+
+		/// <summary>
+		/// TODO EXPERIMENTAL
+		/// Set the render scale for the given window.
+		/// Note: This functon takes effect on the next frame.
+		/// </summary>
+		/// <param name="scale">Render scale value (valid range: 0.5f-1.0f inclusive).</param>
+		/// <param name="window">Window to set render scale for. Default: Main Window.</param>
+		static void SetRenderScale(float scale, const Window* const window = TRAP::Application::GetWindow());
+		/// <summary>
+		/// TODO EXPERIMENTAL
+		/// Retrieve the used render scale value of the given window.
+		/// </summary>
+		/// <param name="window">Window to retrieve render scale from. Default: Main Window.</param>
+		/// <returns>Render scale (between 0.5f and 2.0f inclusive).</returns>
+		static float GetRenderScale(const Window* const window = TRAP::Application::GetWindow());
 
 		//Drawing functions
 

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
@@ -274,7 +274,7 @@ void TRAP::ImGuiLayer::Begin()
 		TRAP::Ref<TRAP::Graphics::RenderTarget> rT = nullptr;
 
 		if(aaMethod == TRAP::Graphics::RendererAPI::AntiAliasing::MSAA) //MSAA
-			rT = winData.SwapChain->GetRenderTargetsMSAA()[winData.CurrentSwapChainImageIndex];
+			rT = winData.RenderTargetsMSAA[winData.CurrentSwapChainImageIndex];
 		else //No MSAA
 			rT = winData.SwapChain->GetRenderTargets()[winData.CurrentSwapChainImageIndex];
 

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
@@ -273,7 +273,8 @@ void TRAP::ImGuiLayer::Begin()
 																				std::numeric_limits<uint32_t>::max(),
 																				std::numeric_limits<uint32_t>::max());
 
-		if(aaMethod == TRAP::Graphics::AntiAliasing::MSAA)
+		//Only apply MSAA if no RenderScale is used (else it got already resolved to a non-MSAA texture)
+		if(aaMethod == TRAP::Graphics::AntiAliasing::MSAA && winData.RenderScale == 1.0f)
 			ImGui_ImplVulkan_SetMSAASamples(static_cast<VkSampleCountFlagBits>(aaSamples));
 		else
 			ImGui_ImplVulkan_SetMSAASamples(VK_SAMPLE_COUNT_1_BIT);

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
@@ -245,16 +245,6 @@ void TRAP::ImGuiLayer::OnEvent(Events::Event& event)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::ImGuiLayer::SetMSAASamples(const uint32_t sampleCount)
-{
-	ZoneNamedC(__tracy, tracy::Color::Brown, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Layers);
-
-	if (Graphics::RendererAPI::GetRenderAPI() == Graphics::RenderAPI::Vulkan)
-		ImGui_ImplVulkan_SetMSAASamples(static_cast<VkSampleCountFlagBits>(sampleCount));
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 void TRAP::ImGuiLayer::Begin()
 {
 	ZoneNamedC(__tracy, tracy::Color::Brown, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Layers);
@@ -273,15 +263,21 @@ void TRAP::ImGuiLayer::Begin()
 
 		TRAP::Ref<TRAP::Graphics::RenderTarget> rT = nullptr;
 
-		if(aaMethod == TRAP::Graphics::RendererAPI::AntiAliasing::MSAA) //MSAA
-			rT = winData.RenderTargetsMSAA[winData.CurrentSwapChainImageIndex];
-		else //No MSAA
+		if(aaMethod == TRAP::Graphics::RendererAPI::AntiAliasing::MSAA && winData.RenderScale == 1.0f) //MSAA and no RenderScale
+			rT = winData.InternalRenderTargets[winData.CurrentSwapChainImageIndex];
+		else
 			rT = winData.SwapChain->GetRenderTargets()[winData.CurrentSwapChainImageIndex];
 
 		//Cant use TRAP::Graphics::RenderCommand::StartRenderPass() here, because it would also bind the shading rate image
 		vkCmdBuffer->BindRenderTargets({ rT }, nullptr, nullptr, nullptr, nullptr,
 																				std::numeric_limits<uint32_t>::max(),
 																				std::numeric_limits<uint32_t>::max());
+
+		if(aaMethod == TRAP::Graphics::AntiAliasing::MSAA)
+			ImGui_ImplVulkan_SetMSAASamples(static_cast<VkSampleCountFlagBits>(aaSamples));
+		else
+			ImGui_ImplVulkan_SetMSAASamples(VK_SAMPLE_COUNT_1_BIT);
+
 		ImGui_ImplVulkan_NewFrame();
 	}
 

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.h
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.h
@@ -46,12 +46,6 @@ namespace TRAP
 		void OnEvent(Events::Event& event) override;
 
 		/// <summary>
-		/// Set the MSAA sample count.
-		/// </summary>
-		/// <param name="sampleCount">Sample count to use.</param>
-		void SetMSAASamples(uint32_t sampleCount);
-
-		/// <summary>
 		/// Begin a new ImGui frame.
 		/// </summary>
 		static void Begin();

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
@@ -1808,6 +1808,9 @@ void ImGui_ImplVulkan_SetMSAASamples(const VkSampleCountFlagBits sampleCount)
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
 
+    if(sampleCount == v->MSAASamples)
+        return;
+
     v->MSAASamples = sampleCount;
     bd->RenderPass = dynamic_cast<TRAP::Graphics::API::VulkanCommandBuffer*>
 		(

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -147,7 +147,7 @@ namespace TRAP
 		/// </summary>
 		void Clear() noexcept;
 
-		inline static constexpr auto WindowVersion =                        "[22w49a1]";
+		inline static constexpr auto WindowVersion =                        "[22w49b1]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -147,7 +147,7 @@ namespace TRAP
 		/// </summary>
 		void Clear() noexcept;
 
-		inline static constexpr auto WindowVersion =                        "[22w49b1]";
+		inline static constexpr auto WindowVersion =                        "[22w49b2]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";


### PR DESCRIPTION
This allows the RendererAPI to use a different resolution (to save performance for example) than what the Window is using.

#### Behaviour

By default the RendererAPI now uses a RenderScale of `1.0` (i.e. native resolution, same as the Window).
If the RenderScale is set to something else than `1.0` then the RendererAPI will (linearly) scale the internal RenderTarget to the output Window resolution. This happens after all `Layer::OnUpdate/OnTick()` calls and before any `Layer::OnImGuiRender()` calls.

#### Caveats

If MSAA is active and RenderScale is not set to `1.0` then the MSAA will be resolved when the internal RenderTarget gets scaled, thus disabling MSAA for everything after the scaling pass.
If a ShadingRateTexture is set and RenderScale is not set to `1.0` then the ShadingRateTexture will be disabled after the scaling pass.

To retrieve the resolution used internally use `RendererAPI::GetInternalRenderResolution()` (resolution scaled with RenderScale while keeping the same aspect ratio as the input resolution).
To retrieve the currently used RenderScale use `RendererAPI::GetRenderScale()`.
To set a new RenderScale use `RendererAPI::SetRenderScale()`.

The scaling itself is applied by the `RendererAPI::RenderScalePass()` function.
This function is automatically called inside `RendererAPI::OnPostUpdate()` when needed.

The valid range of RenderScale is between `0.5` and `2.0` (inclusive), this is ensured by the `RendererAPI::SetRenderScale()` function.

## What changed

### Changes

- `ComputeTests::OnUpdate()` now doesnt wait for Graphics and Compute Queue idle
  (already done inside `RenderCommand::CaptureScreenshot()`)
- `TRAPEditorLayer::OnAttach()` now waits for all resource loads to finish
- Applicaton: Removed unnecessary `RenderCommand::SetViewport()` calls
- SwapChain: Removed MSAA RenderTargets (now inside `RendererAPI::PerWindowData`)
- RendererAPI: `RendererAPI::MSAAResolvePass()` now takes a `CommandBuffer*` instead of a `Window*`
- VulkanRenderer: `VulkanRenderer::EndGraphicRecording()` now only injects `RendererAPI::MSAAResolvePass()` if MSAA is enabled and RenderScale is set to `1.0`
- VulkanRenderer: `VulkanRenderer::InitPerWindowData()` Fixed potential divide by 0 bug
- ImGuiLayer: `ImGuiLayer::Begin()` now controls whether to set MSAA samples for ImGui or not, removed 
  `ImGuiLayer::SetMSAASamples()`
- ShadingRateTexture now uses type `RenderTarget` instead of `Texture`
- Updated VRSTests to use the internal render resolution for the shading rate texture

### New

- Added RenderScale as option in engine.cfg
- RendererAPI: Added `RendererAPI::OnPostUpdate()`
  (called after all `Layer::OnUpdate/OnTick()` calls and before any `Layer::OnImGuiRender()` calls)
- RendererAPI: Added `RendererAPI::GetInternalRenderResolution()`
   (use to retrieve the scaled  internal resolution)
- RendererAPI: Added `RendererAPI::RenderScalePass()`
  (this function does the actual scaling)
- RendererAPI: `PerWindowData` now tracks if its before or after `Layer::OnUpdate()/OnTick()` calls
- VulkanRenderer: Replaced `VulkanRenderer::UpdateAntiAliasingRenderTargets()` with 
  `VulkanRenderer::UpdateInternalRenderTargets()`
- Tests: Added RenderScaleTests