### PR TITLE
Decouple Headless mode

### DIFF
--- a/Games/Headless-Tests/engine.cfg
+++ b/Games/Headless-Tests/engine.cfg
@@ -6,3 +6,5 @@ AntiAliasing = Off
 AntiAliasingQuality = 2
 AnisotropyLevel = 16
 RenderScale = 1.000000
+Width = 1920
+Height = 1080

--- a/Games/Headless-Tests/src/Compute/ComputeTests.cpp
+++ b/Games/Headless-Tests/src/Compute/ComputeTests.cpp
@@ -136,7 +136,7 @@ void ComputeTests::OnUpdate([[maybe_unused]] const TRAP::Utils::TimeStep& deltaT
 
     //Use shader
     const auto texShader = TRAP::Graphics::ShaderManager::Get("Texture");
-    texShader->UseTexture(1, 0, m_compTex, TRAP::Application::GetWindow());
+    texShader->UseTexture(1, 0, m_compTex);
     texShader->Use();
 
     //Render Quad

--- a/Games/Headless-Tests/src/main.cpp
+++ b/Games/Headless-Tests/src/main.cpp
@@ -15,12 +15,12 @@ public:
 		: Application(std::move(gameName))
 	{
 		// PushLayer(std::make_unique<AntiAliasingTests>());
-		// PushLayer(std::make_unique<ComputeTests>());
+		PushLayer(std::make_unique<ComputeTests>());
 		// PushLayer(std::make_unique<FileSystemTests>());
 		// PushLayer(std::make_unique<HeadlessTests>());
 		// PushLayer(std::make_unique<HashTests>());
 		// PushLayer(std::make_unique<IPAddressTests>());
-		PushLayer(std::make_unique<MathTests>());
+		// PushLayer(std::make_unique<MathTests>());
 	}
 };
 

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
@@ -248,10 +248,8 @@ void TRAPEditorLayer::OnAttach()
 		}
 	}
 
-#ifndef TRAP_HEADLESS_MODE
 	//Set Discord stuff
 	TRAP::Utils::Discord::SetActivity({"trapwhitelogo2048x2048", "TRAP™ Editor", "TRAP™ Editor", "Developed by TrappedGames"});
-#endif /*TRAP_HEADLESS_MODE*/
 
 	//Enable Developer features
 	TRAP::Application::SetHotReloading(true);

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3848,3 +3848,4 @@ SITREP 04/09/2023|23w14b1
     - Headless mode Removed support for VSync ~<15 mins
     - Branch headless-rendererapi-rework:
         - Headless mode Removed usage of TRAP::Window ~>60 mins
+        - Headless mode Removed support for Window, Monitor, SwapChain, VulkanSwapChain, VulkanSurface, Input, WindowingAPI ~>60 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3849,3 +3849,4 @@ SITREP 04/09/2023|23w14b1
     - Branch headless-rendererapi-rework:
         - Headless mode Removed usage of TRAP::Window ~>60 mins
         - Headless mode Removed support for Window, Monitor, SwapChain, VulkanSwapChain, VulkanSurface, Input, WindowingAPI ~>60 mins
+        - Headless mode Removed unnecessary TRAP_HEADLESS_MODE checks ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3846,3 +3846,5 @@ SITREP 04/09/2023|23w14b1
     - Docs Updated differences between normal and headless mode ~<10 mins
     - Renamed PerWindowData to PerViewportData ~<5 mins
     - Headless mode Removed support for VSync ~<15 mins
+    - Branch headless-rendererapi-rework:
+        - Headless mode Removed usage of TRAP::Window ~>60 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3850,3 +3850,4 @@ SITREP 04/09/2023|23w14b1
         - Headless mode Removed usage of TRAP::Window ~>60 mins
         - Headless mode Removed support for Window, Monitor, SwapChain, VulkanSwapChain, VulkanSurface, Input, WindowingAPI ~>60 mins
         - Headless mode Removed unnecessary TRAP_HEADLESS_MODE checks ~<10 mins
+        - Headless mode Removed unnecessary GetLinuxWindowManager() checks ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3851,3 +3851,4 @@ SITREP 04/09/2023|23w14b1
         - Headless mode Removed support for Window, Monitor, SwapChain, VulkanSwapChain, VulkanSurface, Input, WindowingAPI ~>60 mins
         - Headless mode Removed unnecessary TRAP_HEADLESS_MODE checks ~<10 mins
         - Headless mode Removed unnecessary GetLinuxWindowManager() checks ~<10 mins
+        - Headless mode Added saving and loading of viewport width and height through engine.cfg ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -3852,3 +3852,4 @@ SITREP 04/09/2023|23w14b1
         - Headless mode Removed unnecessary TRAP_HEADLESS_MODE checks ~<10 mins
         - Headless mode Removed unnecessary GetLinuxWindowManager() checks ~<10 mins
         - Headless mode Added saving and loading of viewport width and height through engine.cfg ~<10 mins
+        - Headless mode Added RendererAPI::GetResolution() function to query viewport size ~<10 mins

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -253,7 +253,11 @@ void TRAP::Application::RunWork(const Utils::TimeStep& deltaTime, float& tickTim
 
 	if(Graphics::RendererAPI::GetRenderAPI() != Graphics::RenderAPI::NONE)
 	{
+#ifndef TRAP_HEADLESS_MODE
 		Graphics::RenderCommand::Flush(m_window.get());
+#else
+		Graphics::RenderCommand::Flush();
+#endif /*TRAP_HEADLESS_MODE*/
 		Graphics::Renderer2D::Reset();
 	}
 }
@@ -1011,7 +1015,7 @@ std::unique_ptr<TRAP::Window> TRAP::Application::CreateMainWindow(const TRAP::Wi
 	}
 #ifdef TRAP_HEADLESS_MODE
 	if(!window && TRAP::Graphics::RendererAPI::GetRenderAPI() != TRAP::Graphics::RenderAPI::NONE)
-		TRAP::Graphics::RendererAPI::GetRenderer()->InitPerViewportData(nullptr);
+		TRAP::Graphics::RendererAPI::GetRenderer()->InitPerViewportData();
 #endif /*TRAP_HEADLESS_MODE*/
 
 	return window;

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -76,8 +76,7 @@ TRAP::Application::Application(std::string gameName, [[maybe_unused]] const std:
 #ifndef TRAP_HEADLESS_MODE
 	m_window = CreateMainWindow(LoadWindowProps(m_config));
 #else
-	if(TRAP::Graphics::RendererAPI::GetRenderAPI() != TRAP::Graphics::RenderAPI::NONE)
-		TRAP::Graphics::RendererAPI::GetRenderer()->InitPerViewportData();
+	CreateMainViewport(m_config);
 #endif /*TRAP_HEADLESS_MODE*/
 
 	if(Graphics::RendererAPI::GetRenderAPI() != Graphics::RenderAPI::NONE)
@@ -875,6 +874,11 @@ void TRAP::Application::UpdateTRAPConfig(Utils::Config& config, const uint32_t f
 
 	if (Graphics::RendererAPI::GetRenderAPI() != Graphics::RenderAPI::NONE)
 	{
+#ifdef TRAP_HEADLESS_MODE
+		config.Set("Width", Graphics::RendererAPI::GetViewportData().NewWidth);
+		config.Set("Height", Graphics::RendererAPI::GetViewportData().NewHeight);
+#endif /*TRAP_HEADLESS_MODE*/
+
 		//GPU UUID
 		std::array<uint8_t, 16> GPUUUID{};
 		if(Graphics::RendererAPI::GetNewGPU() != std::array<uint8_t, 16>{}) //Only if UUID is not empty
@@ -1020,6 +1024,22 @@ std::unique_ptr<TRAP::Window> TRAP::Application::CreateMainWindow(const TRAP::Wi
 	}
 
 	return window;
+}
+#endif /*TRAP_HEADLESS_MODE*/
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+#ifdef TRAP_HEADLESS_MODE
+void TRAP::Application::CreateMainViewport(const TRAP::Utils::Config& config)
+{
+	uint32_t width = 1920;
+	uint32_t height = 1080;
+
+	config.Get<uint32_t>("Width", width);
+	config.Get<uint32_t>("Height", height);
+
+	if(TRAP::Graphics::RendererAPI::GetRenderAPI() != TRAP::Graphics::RenderAPI::NONE)
+		TRAP::Graphics::RendererAPI::GetRenderer()->InitPerViewportData(width, height);
 }
 #endif /*TRAP_HEADLESS_MODE*/
 

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -875,8 +875,12 @@ void TRAP::Application::UpdateTRAPConfig(Utils::Config& config, const uint32_t f
 	if (Graphics::RendererAPI::GetRenderAPI() != Graphics::RenderAPI::NONE)
 	{
 #ifdef TRAP_HEADLESS_MODE
-		config.Set("Width", Graphics::RendererAPI::GetViewportData().NewWidth);
-		config.Set("Height", Graphics::RendererAPI::GetViewportData().NewHeight);
+		uint32_t width = 1920;
+		uint32_t height = 1080;
+		Graphics::RendererAPI::GetRenderer()->GetResolution(width, height);
+
+		config.Set("Width", width);
+		config.Set("Height", height);
 #endif /*TRAP_HEADLESS_MODE*/
 
 		//GPU UUID

--- a/TRAP/src/Application.cpp
+++ b/TRAP/src/Application.cpp
@@ -40,7 +40,9 @@ TRAP::Application::Application(std::string gameName, [[maybe_unused]] const std:
 {
 	ZoneScoped;
 
+#ifdef TRAP_HEADLESS_MODE
 	TRAP::Utils::RegisterSIGINTCallback();
+#endif /*TRAP_HEADLESS_MODE*/
 
 #ifdef TRACY_ENABLE
 	//Set Main Thread name for profiler
@@ -91,9 +93,7 @@ TRAP::Application::Application(std::string gameName, [[maybe_unused]] const std:
 #ifndef TRAP_HEADLESS_MODE
 	InitializeInput();
 	m_ImGuiLayer = InitializeImGui(m_layerStack);
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 	TRAP::Utils::Discord::Create();
 #endif /*TRAP_HEADLESS_MODE*/
 }
@@ -114,18 +114,14 @@ TRAP::Application::~Application()
 	TRAP::Utils::Steam::Shutdown();
 #ifndef TRAP_HEADLESS_MODE
 	TRAP::Utils::Discord::Destroy();
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 #ifdef TRAP_PLATFORM_LINUX
 	if(TRAP::Utils::GetLinuxWindowManager() != TRAP::Utils::LinuxWindowManager::Unknown)
 #endif /*TRAP_PLATFORM_LINUX*/
 	{
 		Input::Shutdown();
 	}
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 	UpdateTRAPConfig(m_config, m_window.get(), m_fpsLimit, m_newRenderAPI);
 #else
 	UpdateTRAPConfig(m_config, m_fpsLimit, m_newRenderAPI);

--- a/TRAP/src/Application.h
+++ b/TRAP/src/Application.h
@@ -384,11 +384,17 @@ namespace TRAP
 		/// Create the main window.
 		///
 		/// Linux: If no known window manager can be found this function will close the engine.
-		/// Headless-Mode: This function may not create a window, this is not an error.
 		/// </summary>
 		/// <param name="winProps">Properties for the window.</param>
 		/// <returns>Created main window or nullptr.</returns>
 		static std::unique_ptr<TRAP::Window> CreateMainWindow(const TRAP::WindowProps& winProps);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifdef TRAP_HEADLESS_MODE
+		/// <summary>
+		/// Create the main viewport.
+		/// </summary>
+		/// <param name="config">Config to load data from.</param>
+		static void CreateMainViewport(const TRAP::Utils::Config& config);
 #endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>

--- a/TRAP/src/Application.h
+++ b/TRAP/src/Application.h
@@ -2,6 +2,7 @@
 #define TRAP_APPLICATION_H
 
 #include <thread>
+#include <optional>
 
 #include "Utils/Config/Config.h"
 #include "Layers/LayerStack.h"
@@ -158,11 +159,13 @@ namespace TRAP
 		/// </summary>
 		static void Shutdown();
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Get the Main Render window.
 		/// </summary>
 		/// <returns>Pointer to the main render window.</returns>
 		[[nodiscard]] static Window* GetWindow();
+#endif /*TRAP_HEADLESS_MODE*/
 		/// <summary>
 		/// Get the Time since the Engine was started.
 		/// </summary>
@@ -174,6 +177,7 @@ namespace TRAP
 		/// <returns>Reference to the thread pool.</returns>
 		[[nodiscard]] static ThreadPool& GetThreadPool();
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clipboard.
 		/// </summary>
@@ -184,6 +188,7 @@ namespace TRAP
 		/// </summary>
 		/// <returns>String containing the clipboards content.</returns>
 		[[nodiscard]] static std::string GetClipboardString();
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Get the id of the main engine thread.
@@ -315,6 +320,7 @@ namespace TRAP
 		/// <returns>Loaded config.</returns>
 		static Utils::Config LoadTRAPConfig();
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Update the engine.cfg file.
 		/// </summary>
@@ -323,6 +329,15 @@ namespace TRAP
 		/// <param name="fpsLimit">FPS limit to save.</param>
 		/// <param name="renderAPI">RenderAPI to save.</param>
 		static void UpdateTRAPConfig(Utils::Config& config, const Window* window, uint32_t fpsLimit, Graphics::RenderAPI renderAPI);
+#else
+		/// <summary>
+		/// Update the engine.cfg file.
+		/// </summary>
+		/// <param name="config">Config to update.</param>
+		/// <param name="fpsLimit">FPS limit to save.</param>
+		/// <param name="renderAPI">RenderAPI to save.</param>
+		static void UpdateTRAPConfig(Utils::Config& config, uint32_t fpsLimit, Graphics::RenderAPI renderAPI);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Save the engine.cfg file.
@@ -330,19 +345,23 @@ namespace TRAP
 		/// <param name="config">Config to save.</param>
 		static void SaveTRAPConfig(Utils::Config& config);
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Load the advanced window properties from the given config.
 		/// </summary>
 		/// <param name="config">Config to load data from.</param>
 		/// <returns>Advanced Window properties.</returns>
 		static WindowProps::AdvancedProps LoadAdvancedWindowProps(const TRAP::Utils::Config& config);
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Load the window properties from the given config.
 		/// </summary>
 		/// <param name="config">Config to load data from.</param>
 		/// <returns>Window properties.</returns>
 		static WindowProps LoadWindowProps(const TRAP::Utils::Config& config);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Select the RenderAPI to be used for rendering.
@@ -359,6 +378,7 @@ namespace TRAP
 		/// <param name="config">Config to load data from.</param>
 		static void InitializeRendererAPI(std::string_view gameName, const TRAP::Graphics::RenderAPI& renderAPI, const TRAP::Utils::Config& config);
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Create the main window.
 		///
@@ -368,6 +388,7 @@ namespace TRAP
 		/// <param name="winProps">Properties for the window.</param>
 		/// <returns>Created main window or nullptr.</returns>
 		static std::unique_ptr<TRAP::Window> CreateMainWindow(const TRAP::WindowProps& winProps);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Load fallback shaders.
@@ -390,11 +411,11 @@ namespace TRAP
 		/// <param name="config">Config to load data from.</param>
 		static void ApplyRendererAPISettings(const TRAP::Utils::Config& config);
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Initialize TRAP::Input.
 		/// </summary>
 		static void InitializeInput();
-#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Initialize ImGui Layer.
 		/// </summary>
@@ -411,15 +432,21 @@ namespace TRAP
 
 		//Layers
 		LayerStack m_layerStack{};
+#ifndef TRAP_HEADLESS_MODE
 		ImGuiLayer* m_ImGuiLayer = nullptr;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Main window
+#ifndef TRAP_HEADLESS_MODE
 		std::unique_ptr<Window> m_window = nullptr;
 		bool m_minimized = false;
 		bool m_focused = true;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		//NVIDIA-Reflex
 		uint64_t m_globalCounter = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Multithreading
 		ThreadPool m_threadPool;

--- a/TRAP/src/Application.h
+++ b/TRAP/src/Application.h
@@ -183,6 +183,8 @@ namespace TRAP
 		/// </summary>
 		/// <param name="string">String to be set.</param>
 		static void SetClipboardString(const std::string& string);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Get current content of the clipboard.
 		/// </summary>
@@ -353,7 +355,6 @@ namespace TRAP
 		/// <returns>Advanced Window properties.</returns>
 		static WindowProps::AdvancedProps LoadAdvancedWindowProps(const TRAP::Utils::Config& config);
 #endif /*TRAP_HEADLESS_MODE*/
-
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Load the window properties from the given config.
@@ -416,6 +417,8 @@ namespace TRAP
 		/// Initialize TRAP::Input.
 		/// </summary>
 		static void InitializeInput();
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Initialize ImGui Layer.
 		/// </summary>
@@ -436,17 +439,17 @@ namespace TRAP
 		ImGuiLayer* m_ImGuiLayer = nullptr;
 #endif /*TRAP_HEADLESS_MODE*/
 
-		//Main window
 #ifndef TRAP_HEADLESS_MODE
+		//Main window
 		std::unique_ptr<Window> m_window = nullptr;
 		bool m_minimized = false;
 		bool m_focused = true;
 #endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
+#if defined(NVIDIA_REFLEX_AVAILABLE) && !defined(TRAP_HEADLESS_MODE)
 		//NVIDIA-Reflex
 		uint64_t m_globalCounter = 0;
-#endif /*TRAP_HEADLESS_MODE*/
+#endif /*NVIDIA_REFLEX_AVAILABLE && !TRAP_HEADLESS_MODE*/
 
 		//Multithreading
 		ThreadPool m_threadPool;

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -53,10 +53,8 @@
 //-------------------------------------------------------------------------------------------------------------------//
 
 //Headless mode.
-//This macro changes Window and RendererAPI behaviour.
-//By default the Main Window will be hidden.
-//The RendererAPI uses relaxed requirements to allow for offline rendering or compute
-//if the hardware supports an RenderAPI.
+//This macro enables the headless mode
+//See https://gamestrap.github.io/TRAP/pages/gettingstarted.html#differences-between-normal-mode-and-headless-mode
 //#define TRAP_HEADLESS_MODE
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/FileSystem/FileSystem.cpp
+++ b/TRAP/src/FileSystem/FileSystem.cpp
@@ -38,7 +38,7 @@ void TRAP::FileSystem::Init()
         if(!CreateFolder(*gameDocsFolder))
             TP_ERROR(Log::FileSystemPrefix, "Failed to create game documents folder: \"", gameDocsFolder->u8string(), "\"!");
     }
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 
     //Create game log folder
     const auto gameLogFolder = GetGameLogFolderPath();
@@ -662,7 +662,7 @@ bool TRAP::FileSystem::Rename(const std::filesystem::path& oldPath, const std::s
     return (*docsFolder / "logs");
 #else
     return "logs";
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
+++ b/TRAP/src/Graphics/API/Objects/AftermathTracker.cpp
@@ -83,9 +83,9 @@ bool LoadFunctions()
     );
 
     return (AftermathEnableGPUCrashDumps != nullptr) && (AftermathDisableGPUCrashDumps != nullptr) && (AftermathGetGPUCrashDumpStatus != nullptr);
-#endif
-
+#else
     return false;
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Graphics/API/Objects/Fence.h
+++ b/TRAP/src/Graphics/API/Objects/Fence.h
@@ -74,7 +74,10 @@ namespace TRAP::Graphics
 
 	private:
 		friend void TRAP::Graphics::API::VulkanQueue::Submit(const RendererAPI::QueueSubmitDesc& desc) const;
+
+#ifndef TRAP_HEADLESS_MODE
 		friend TRAP::Graphics::RendererAPI::PresentStatus TRAP::Graphics::API::VulkanQueue::Present(const RendererAPI::QueuePresentDesc& desc) const;
+#endif /*TRAP_HEADLESS_MODE*/
 	};
 }
 

--- a/TRAP/src/Graphics/API/Objects/Queue.h
+++ b/TRAP/src/Graphics/API/Objects/Queue.h
@@ -48,12 +48,14 @@ namespace TRAP::Graphics
 		/// <param name="desc">Queue submit description.</param>
 		virtual void Submit(const RendererAPI::QueueSubmitDesc& desc) const = 0;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Queue an image for presentation.
 		/// </summary>
 		/// <param name="desc">Queue presentation description.</param>
 		/// <returns>Presentation status.</returns>
 		[[nodiscard]] virtual RendererAPI::PresentStatus Present(const RendererAPI::QueuePresentDesc& desc) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 	protected:
 		/// <summary>

--- a/TRAP/src/Graphics/API/Objects/Semaphore.h
+++ b/TRAP/src/Graphics/API/Objects/Semaphore.h
@@ -53,7 +53,10 @@ namespace TRAP::Graphics
 
 	private:
 		friend void TRAP::Graphics::API::VulkanQueue::Submit(const RendererAPI::QueueSubmitDesc& desc) const;
+
+#ifndef TRAP_HEADLESS_MODE
 		friend TRAP::Graphics::RendererAPI::PresentStatus TRAP::Graphics::API::VulkanQueue::Present(const RendererAPI::QueuePresentDesc& desc) const;
+#endif /*TRAP_HEADLESS_MODE*/
 	};
 }
 

--- a/TRAP/src/Graphics/API/Objects/SwapChain.cpp
+++ b/TRAP/src/Graphics/API/Objects/SwapChain.cpp
@@ -1,9 +1,13 @@
 #include "TRAPPCH.h"
 #include "SwapChain.h"
 
+#ifndef TRAP_HEADLESS_MODE
 #include "Graphics/API/Vulkan/Objects/VulkanSwapChain.h"
+#endif /*TRAP_HEADLESS_MODE*/
+
 #include "Graphics/API/Vulkan/VulkanCommon.h"
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] TRAP::Ref<TRAP::Graphics::SwapChain> TRAP::Graphics::SwapChain::Create(RendererAPI::SwapChainDesc& desc)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
@@ -21,6 +25,7 @@
 		return nullptr;
 	}
 }
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -43,6 +48,7 @@
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 TRAP::Graphics::SwapChain::SwapChain()
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
@@ -73,3 +79,5 @@ TRAP::Graphics::SwapChain::~SwapChain()
 
 	return m_renderTargets;
 }
+
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Graphics/API/Objects/SwapChain.h
+++ b/TRAP/src/Graphics/API/Objects/SwapChain.h
@@ -13,12 +13,14 @@ namespace TRAP::Graphics
 	class SwapChain
 	{
 	public:
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Create a new swap chain from the given description.
 		/// </summary>
 		/// <param name="desc">Swap chain description.</param>
 		/// <returns>Created swap chain.</returns>
 		[[nodiscard]] static TRAP::Ref<SwapChain> Create(RendererAPI::SwapChainDesc& desc);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Retrieve the recommended swap chain image format.
@@ -33,6 +35,7 @@ namespace TRAP::Graphics
 		/// </summary>
 		virtual ~SwapChain();
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Copy constructor.
 		/// </summary>
@@ -83,6 +86,7 @@ namespace TRAP::Graphics
 
 		//Render targets created from the swapchain back buffers
 		std::vector<TRAP::Ref<RenderTarget>> m_renderTargets;
+#endif /*TRAP_HEADLESS_MODE*/
 	};
 }
 

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -630,16 +630,13 @@ void TRAP::Graphics::RendererAPI::ResizeSwapChain(const Window* window)
 	s_isVulkanCapableFirstTest = false;
 
 #ifndef TRAP_HEADLESS_MODE
-	if(TRAP::Utils::GetLinuxWindowManager() != TRAP::Utils::LinuxWindowManager::Unknown)
+	if (!INTERNAL::WindowingAPI::Init())
 	{
-		if (!INTERNAL::WindowingAPI::Init())
-		{
-			Utils::Dialogs::ShowMsgBox("Failed to initialize WindowingAPI", "The WindowingAPI couldn't be initialized!\n"
-								       "Error code: 0x0011", Utils::Dialogs::Style::Error,
-								       Utils::Dialogs::Buttons::Quit);
-			TP_CRITICAL(Log::RendererVulkanPrefix, "Failed to initialize WindowingAPI! (0x0011)");
-			exit(0x0011);
-		}
+		Utils::Dialogs::ShowMsgBox("Failed to initialize WindowingAPI", "The WindowingAPI couldn't be initialized!\n"
+									"Error code: 0x0011", Utils::Dialogs::Style::Error,
+									Utils::Dialogs::Buttons::Quit);
+		TP_CRITICAL(Log::RendererVulkanPrefix, "Failed to initialize WindowingAPI! (0x0011)");
+		exit(0x0011);
 	}
 #endif /*TRAP_HEADLESS_MODE*/
 

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -14,6 +14,7 @@
 #include "Objects/Queue.h"
 #include "Objects/Sampler.h"
 #include "Objects/SwapChain.h"
+#include "ImageLoader/Image.h"
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -20,12 +20,12 @@
 TRAP::Scope<TRAP::Graphics::RendererAPI> TRAP::Graphics::RendererAPI::s_Renderer = nullptr;
 TRAP::Graphics::RenderAPI TRAP::Graphics::RendererAPI::s_RenderAPI = TRAP::Graphics::RenderAPI::NONE;
 TRAP::Scope<TRAP::Graphics::API::ResourceLoader> TRAP::Graphics::RendererAPI::s_ResourceLoader = nullptr;
-// #ifndef TRAP_HEADLESS_MODE
+#ifndef TRAP_HEADLESS_MODE
 std::unordered_map<const TRAP::Window*,
                    TRAP::Scope<TRAP::Graphics::RendererAPI::PerViewportData>> TRAP::Graphics::RendererAPI::s_perViewportDataMap = {};
-// #else
-// TRAP::Scope<TRAP::Graphics::RendererAPI::PerViewportData> TRAP::Graphics::RendererAPI::s_perViewportData = nullptr;
-// #endif /*TRAP_HEADLESS_MODE*/
+#else
+TRAP::Scope<TRAP::Graphics::RendererAPI::PerViewportData> TRAP::Graphics::RendererAPI::s_perViewportData = nullptr;
+#endif /*TRAP_HEADLESS_MODE*/
 bool TRAP::Graphics::RendererAPI::s_isVulkanCapable = true;
 bool TRAP::Graphics::RendererAPI::s_isVulkanCapableFirstTest = true;
 TRAP::Ref<TRAP::Graphics::DescriptorPool> TRAP::Graphics::RendererAPI::s_descriptorPool = nullptr;
@@ -97,7 +97,11 @@ void TRAP::Graphics::RendererAPI::Shutdown()
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
 
+#ifndef TRAP_HEADLESS_MODE
 	s_perViewportDataMap.clear();
+#else
+	s_perViewportData.reset();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	TRAP::Graphics::Sampler::ClearCache();
 
@@ -204,23 +208,30 @@ void TRAP::Graphics::RendererAPI::OnPostUpdate()
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
 
+#ifndef TRAP_HEADLESS_MODE
 	for(const auto& [win, data] : s_perViewportDataMap)
 	{
 		data->State = PerWindowState::PostUpdate;
 
 		if(data->RenderScale != 1.0f)
 		{
-			TRAP::Ref<RenderTarget> outputTarget = nullptr;
-#ifndef TRAP_HEADLESS_MODE
-			outputTarget = data->SwapChain->GetRenderTargets()[data->CurrentSwapChainImageIndex];
-#else
-			outputTarget = data->RenderTargets[data->CurrentSwapChainImageIndex];
-#endif
+			TRAP::Ref<RenderTarget> outputTarget = data->SwapChain->GetRenderTargets()[data->CurrentSwapChainImageIndex];
 
 			GetRenderer()->RenderScalePass(data->InternalRenderTargets[data->CurrentSwapChainImageIndex],
 			                               outputTarget, win);
 		}
 	}
+#else
+	s_perViewportData->State = PerWindowState::PostUpdate;
+
+	if(s_perViewportData->RenderScale != 1.0f)
+	{
+		TRAP::Ref<RenderTarget> outputTarget = s_perViewportData->RenderTargets[s_perViewportData->CurrentSwapChainImageIndex];
+
+		GetRenderer()->RenderScalePass(s_perViewportData->InternalRenderTargets[s_perViewportData->CurrentSwapChainImageIndex],
+										outputTarget);
+	}
+#endif /*TRAP_HEADLESS_MODE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -261,7 +272,8 @@ void TRAP::Graphics::RendererAPI::OnPostUpdate()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-[[nodiscard]] TRAP::Graphics::RendererAPI::PerViewportData& TRAP::Graphics::RendererAPI::GetWindowData(const Window* window)
+#ifndef TRAP_HEADLESS_MODE
+[[nodiscard]] TRAP::Graphics::RendererAPI::PerViewportData& TRAP::Graphics::RendererAPI::GetViewportData(const Window* window)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
 
@@ -270,9 +282,18 @@ void TRAP::Graphics::RendererAPI::OnPostUpdate()
 
 	return *s_perViewportDataMap.at(window);
 }
+#else
+[[nodiscard]] TRAP::Graphics::RendererAPI::PerViewportData& TRAP::Graphics::RendererAPI::GetViewportData()
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
+
+	return *s_perViewportData;
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] TRAP::Ref<TRAP::Graphics::RootSignature> TRAP::Graphics::RendererAPI::GetGraphicsRootSignature(const Window* window)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
@@ -285,9 +306,21 @@ void TRAP::Graphics::RendererAPI::OnPostUpdate()
 		s_perViewportDataMap.at(window)->GraphicsPipelineDesc.Pipeline
 	).RootSignature;
 }
+#else
+[[nodiscard]] TRAP::Ref<TRAP::Graphics::RootSignature> TRAP::Graphics::RendererAPI::GetGraphicsRootSignature()
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
+
+	return std::get<TRAP::Graphics::RendererAPI::GraphicsPipelineDesc>
+	(
+		s_perViewportData->GraphicsPipelineDesc.Pipeline
+	).RootSignature;
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] TRAP::Math::Vec2ui TRAP::Graphics::RendererAPI::GetInternalRenderResolution(const Window* window)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
@@ -297,28 +330,13 @@ void TRAP::Graphics::RendererAPI::OnPostUpdate()
 
 	const float renderScale = s_perViewportDataMap.at(window)->RenderScale;
 
-#ifdef TRAP_HEADLESS_MODE
-	const auto& winData = s_perViewportDataMap.at(window);
-#endif
-
 	if(renderScale == 1.0f)
-	{
-#ifndef TRAP_HEADLESS_MODE
 		return window->GetFrameBufferSize();
-#else
-		return {winData->NewWidth, winData->NewHeight};
-#endif
-	}
 
 	const Math::Vec2 frameBufferSize
 	{
-#ifndef TRAP_HEADLESS_MODE
 		static_cast<float>(window->GetFrameBufferSize().x),
 		static_cast<float>(window->GetFrameBufferSize().y)
-#else
-		static_cast<float>(winData->NewWidth),
-		static_cast<float>(winData->NewHeight),
-#endif
 	};
 	const float aspectRatio = frameBufferSize.x / frameBufferSize.y;
 
@@ -336,9 +354,42 @@ void TRAP::Graphics::RendererAPI::OnPostUpdate()
 
 	return static_cast<Math::Vec2ui>(finalRes);
 }
+#else
+[[nodiscard]] TRAP::Math::Vec2ui TRAP::Graphics::RendererAPI::GetInternalRenderResolution()
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
+
+	const float renderScale = s_perViewportData->RenderScale;
+
+	if(renderScale == 1.0f)
+		return {s_perViewportData->NewWidth, s_perViewportData->NewHeight};
+
+	const Math::Vec2 frameBufferSize
+	{
+		static_cast<float>(s_perViewportData->NewWidth),
+		static_cast<float>(s_perViewportData->NewHeight),
+	};
+	const float aspectRatio = frameBufferSize.x / frameBufferSize.y;
+
+	Math::Vec2 finalRes = frameBufferSize * renderScale;
+
+	//Make sure the resolution is an integer scale of the framebuffer size.
+	//This is done to avoid scaling artifacts (like blurriness).
+	while((finalRes.x / finalRes.y) != aspectRatio)
+	{
+		if((finalRes.x / finalRes.y) <= aspectRatio)
+			++finalRes.x;
+		else
+			++finalRes.y;
+	}
+
+	return static_cast<Math::Vec2ui>(finalRes);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RendererAPI::StartRenderPass(const Window* window)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
@@ -346,31 +397,40 @@ void TRAP::Graphics::RendererAPI::StartRenderPass(const Window* window)
 	if(window == nullptr)
 		window = TRAP::Application::GetWindow();
 
-	const auto* const winData = s_perViewportDataMap.at(window).get();
+	const auto* const viewportData = s_perViewportDataMap.at(window).get();
 
 	TRAP::Ref<Graphics::RenderTarget> renderTarget = nullptr;
-#ifndef TRAP_HEADLESS_MODE
+
 	//Get correct RenderTarget
-	if((winData->RenderScale != 1.0f || s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA) && winData->State == PerWindowState::PreUpdate)
-		renderTarget = winData->InternalRenderTargets[winData->CurrentSwapChainImageIndex];
+	if((viewportData->RenderScale != 1.0f || s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA) && viewportData->State == PerWindowState::PreUpdate)
+		renderTarget = viewportData->InternalRenderTargets[viewportData->CurrentSwapChainImageIndex];
 	else
-		renderTarget = winData->SwapChain->GetRenderTargets()[winData->CurrentSwapChainImageIndex];
+		renderTarget = viewportData->SwapChain->GetRenderTargets()[viewportData->CurrentSwapChainImageIndex];
 
 	GetRenderer()->BindRenderTarget(renderTarget, nullptr, nullptr,
 									nullptr, nullptr, static_cast<uint32_t>(-1), static_cast<uint32_t>(-1), window);
+}
 #else
-	if((winData->RenderScale != 1.0f || s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA) && winData->State == PerWindowState::PreUpdate)
-		renderTarget = winData->InternalRenderTargets[winData->ImageIndex];
+void TRAP::Graphics::RendererAPI::StartRenderPass()
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
+
+	TRAP::Ref<Graphics::RenderTarget> renderTarget = nullptr;
+
+	//Get correct RenderTarget
+	if((s_perViewportData->RenderScale != 1.0f || s_currentAntiAliasing == RendererAPI::AntiAliasing::MSAA) && s_perViewportData->State == PerWindowState::PreUpdate)
+		renderTarget = s_perViewportData->InternalRenderTargets[s_perViewportData->ImageIndex];
 	else
-		renderTarget = winData->RenderTargets[winData->ImageIndex];
+		renderTarget = s_perViewportData->RenderTargets[s_perViewportData->ImageIndex];
 
 	GetRenderer()->BindRenderTarget(renderTarget, nullptr, nullptr,
-	                                nullptr, nullptr, static_cast<uint32_t>(-1), static_cast<uint32_t>(-1), window);
-#endif
+	                                nullptr, nullptr, static_cast<uint32_t>(-1), static_cast<uint32_t>(-1));
 }
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RendererAPI::StopRenderPass(const Window* window)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
@@ -381,6 +441,15 @@ void TRAP::Graphics::RendererAPI::StopRenderPass(const Window* window)
 	GetRenderer()->BindRenderTarget(nullptr, nullptr, nullptr, nullptr, nullptr, static_cast<uint32_t>(-1),
 	                                static_cast<uint32_t>(-1), window);
 }
+#else
+void TRAP::Graphics::RendererAPI::StopRenderPass()
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
+
+	GetRenderer()->BindRenderTarget(nullptr, nullptr, nullptr, nullptr, nullptr, static_cast<uint32_t>(-1),
+	                                static_cast<uint32_t>(-1));
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -505,6 +574,7 @@ void TRAP::Graphics::RendererAPI::ResizeSwapChain(const Window* window)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] float TRAP::Graphics::RendererAPI::GetGPUGraphicsFrameTime(const Window* window)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
@@ -514,9 +584,18 @@ void TRAP::Graphics::RendererAPI::ResizeSwapChain(const Window* window)
 
 	return s_perViewportDataMap.at(window)->GraphicsFrameTime;
 }
+#else
+[[nodiscard]] float TRAP::Graphics::RendererAPI::GetGPUGraphicsFrameTime()
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
+
+	return s_perViewportData->GraphicsFrameTime;
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] float TRAP::Graphics::RendererAPI::GetGPUComputeFrameTime(const Window* window)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
@@ -526,6 +605,14 @@ void TRAP::Graphics::RendererAPI::ResizeSwapChain(const Window* window)
 
 	return s_perViewportDataMap.at(window)->ComputeFrameTime;
 }
+#else
+[[nodiscard]] float TRAP::Graphics::RendererAPI::GetGPUComputeFrameTime()
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
+
+	return s_perViewportData->ComputeFrameTime;
+}
+#endif /**/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -541,6 +628,7 @@ void TRAP::Graphics::RendererAPI::ResizeSwapChain(const Window* window)
 
 	s_isVulkanCapableFirstTest = false;
 
+#ifndef TRAP_HEADLESS_MODE
 	if(TRAP::Utils::GetLinuxWindowManager() != TRAP::Utils::LinuxWindowManager::Unknown)
 	{
 		if (!INTERNAL::WindowingAPI::Init())
@@ -552,8 +640,14 @@ void TRAP::Graphics::RendererAPI::ResizeSwapChain(const Window* window)
 			exit(0x0011);
 		}
 	}
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 	if (INTERNAL::WindowingAPI::VulkanSupported())
+#else
+	static VkResult initRes = VkInitialize();
+	if(initRes == VK_SUCCESS)
+#endif /*TRAP_HEADLESS_MODE*/
 	{
 		if(VkGetInstanceVersion() < VK_API_VERSION_1_1)
 		{
@@ -564,9 +658,10 @@ void TRAP::Graphics::RendererAPI::ResizeSwapChain(const Window* window)
 			return s_isVulkanCapable;
 		}
 
+		std::vector<std::string> instanceExtensions{};
+#ifndef TRAP_HEADLESS_MODE
 		//Required: Instance Extensions
 		//Surface extensions are optional in Headless mode.
-		std::vector<std::string> instanceExtensions{};
 		const auto reqExt = INTERNAL::WindowingAPI::GetRequiredInstanceExtensions();
 
 		if (std::get<0>(reqExt).empty() ||
@@ -585,6 +680,7 @@ void TRAP::Graphics::RendererAPI::ResizeSwapChain(const Window* window)
 		GPUSettings.SurfaceSupported = true;
 		instanceExtensions.push_back(std::get<0>(reqExt));
 		instanceExtensions.push_back(std::get<1>(reqExt));
+#endif /*TRAP_HEADLESS_MODE*/
 
 		if(!API::VulkanInstance::IsExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME))
 		{
@@ -683,6 +779,7 @@ TRAP::Graphics::RendererAPI::PerViewportData::~PerViewportData()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] uint32_t TRAP::Graphics::RendererAPI::GetCurrentImageIndex(const TRAP::Window* const window)
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
@@ -691,3 +788,11 @@ TRAP::Graphics::RendererAPI::PerViewportData::~PerViewportData()
 
 	return s_perViewportDataMap.at(window)->ImageIndex;
 }
+#else
+[[nodiscard]] uint32_t TRAP::Graphics::RendererAPI::GetCurrentImageIndex()
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
+
+	return s_perViewportData->ImageIndex;
+}
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Graphics/API/RendererAPI.cpp
+++ b/TRAP/src/Graphics/API/RendererAPI.cpp
@@ -123,9 +123,7 @@ void TRAP::Graphics::RendererAPI::Shutdown()
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
 
-#ifdef TRAP_HEADLESS_MODE
 	TRAP_ASSERT(s_RenderAPI != RenderAPI::NONE , "RendererAPI::GetRenderer(): RendererAPI is not available because RenderAPI::NONE is set (or EnableGPU=False)!");
-#endif
 
 	return s_Renderer.get();
 }
@@ -135,6 +133,8 @@ void TRAP::Graphics::RendererAPI::Shutdown()
 [[nodiscard]] TRAP::Graphics::API::ResourceLoader* TRAP::Graphics::RendererAPI::GetResourceLoader() noexcept
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
+
+	TRAP_ASSERT(s_RenderAPI != RenderAPI::NONE , "RendererAPI::GetResourceLoader(): ResourceLoader is not available because RenderAPI::NONE is set (or EnableGPU=False)!");
 
 	return s_ResourceLoader.get();
 }

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -2,9 +2,12 @@
 #define TRAP_RENDERERAPI_H
 
 #include <variant>
+#include <unordered_map>
 
 #include "Window/Window.h"
 #include "ImageFormat.h"
+#include "Maths/Math.h"
+#include "Graphics/API/Vulkan/Utils/VulkanLoader.h"
 
 #if defined(NVIDIA_REFLEX_AVAILABLE) && !defined(TRAP_HEADLESS_MODE)
 #include <NvLowLatencyVk.h>
@@ -14,6 +17,7 @@ namespace TRAP
 {
 	class Application;
 	class Window;
+	class Image;
 }
 
 namespace TRAP::Graphics

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -181,6 +181,7 @@ namespace TRAP::Graphics
 		/// <param name="gameName">Name of the game.</param>
 		virtual void InitInternal(std::string_view gameName) = 0;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Flush renderer for the given window.
 		///
@@ -191,7 +192,18 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <param name="window">Window to flush.</param>
 		virtual void Flush(const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Flush renderer.
+		///
+		/// 1. Stops graphics and compute recording.
+		/// 2. Submits the graphics and compute commands.
+		/// 3. Starts graphics and compute recording for the next frame.
+		/// </summary>
+		virtual void Flush() const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Dispatch to the given window.
 		/// </summary>
@@ -201,6 +213,16 @@ namespace TRAP::Graphics
 		/// </param>
 		/// <param name="window">Window to Dispatch.</param>
 		virtual void Dispatch(std::array<uint32_t, 3> workGroupElements, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Dispatch.
+		/// </summary>
+		/// <param name="workGroupElements">
+		/// Number of elements to dispatch for each dimension.
+		/// The elements are automatically divided by the number of threads in the work group and rounded up.
+		/// </param>
+		virtual void Dispatch(std::array<uint32_t, 3> workGroupElements) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>
@@ -230,6 +252,7 @@ namespace TRAP::Graphics
 
 		//RenderTarget Stuff
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the render scale for the given window.
 		/// Note: This functon takes effect on the next frame.
@@ -237,13 +260,30 @@ namespace TRAP::Graphics
 		/// <param name="scale">Render scale value (valid range: 0.5f-1.0f inclusive).</param>
 		/// <param name="window">Window to set render scale for.</param>
 		virtual void SetRenderScale(float scale, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the render scale.
+		/// Note: This functon takes effect on the next frame.
+		/// </summary>
+		/// <param name="scale">Render scale value (valid range: 0.5f-1.0f inclusive).</param>
+		virtual void SetRenderScale(float scale) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the used render scale value of the given window.
 		/// </summary>
 		/// <param name="window">Window to retrieve render scale from.</param>
 		/// <returns>Render scale (between 0.5f and 2.0f inclusive).</returns>
 		[[nodiscard]] virtual float GetRenderScale(const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Retrieve the used render scale value.
+		/// </summary>
+		/// <returns>Render scale (between 0.5f and 2.0f inclusive).</returns>
+		[[nodiscard]] virtual float GetRenderScale() const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clear color to be used by the given window.
 		/// </summary>
@@ -251,50 +291,95 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to set clear color for.</param>
 		virtual void SetClearColor(const Color& color /*= { 0.1f, 0.1f, 0.1f, 1.0f }*/,
 		                           const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the clear color.
+		/// </summary>
+		/// <param name="color">New clear color.</param>
+		virtual void SetClearColor(const Color& color /*= { 0.1f, 0.1f, 0.1f, 1.0f }*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clear depth value to be used by the given window.
 		/// </summary>
 		/// <param name="depth">New clear depth value. Must be between 0.0f and 1.0f</param>
 		/// <param name="window">Window to set clear depth value for.</param>
 		virtual void SetClearDepth(float depth /*= 0.0f*/, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the clear depth value.
+		/// </summary>
+		/// <param name="depth">New clear depth value. Must be between 0.0f and 1.0f</param>
+		virtual void SetClearDepth(float depth /*= 0.0f*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clear stencil value to be used by the given window.
 		/// </summary>
 		/// <param name="stencil">New clear stencil value.</param>
 		/// <param name="window">Window to set clear stencil value for.</param>
 		virtual void SetClearStencil(uint32_t stencil /*= 0*/, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the clear stencil value.
+		/// </summary>
+		/// <param name="stencil">New clear stencil value.</param>
+		virtual void SetClearStencil(uint32_t stencil /*= 0*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 #ifdef TRAP_HEADLESS_MODE
 		/// <summary>
-		/// Set the resolution of the render targets used by the given window.
-		///
-		/// Note: This function is only available in Headless mode.
+		/// Set the resolution of the render targets.
 		/// </summary>
 		/// <param name="width">New width.</param>
 		/// <param name="height">New height.</param>
-		/// <param name="window">Window to set resolution for.</param>
-		virtual void SetResolution(uint32_t width, uint32_t height, const Window* const window) const = 0;
-#endif
+		virtual void SetResolution(uint32_t width, uint32_t height) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Pipeline Stuff
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable depth testing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth testing.</param>
 		/// <param name="window">Window to set depth testing for.</param>
 		virtual void SetDepthTesting(bool enabled, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Enable or disable depth testing.
+		/// </summary>
+		/// <param name="enabled">Enable or disable depth testing.</param>
+		virtual void SetDepthTesting(bool enabled) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable depth writing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth writing.</param>
 		/// <param name="window">Window to set depth writing for.</param>
 		virtual void SetDepthWriting(bool enabled, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Enable or disable depth writing.
+		/// </summary>
+		/// <param name="enabled">Enable or disable depth writing.</param>
+		virtual void SetDepthWriting(bool enabled) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the depth function for the given window.
 		/// </summary>
 		/// <param name="function">Function to use for depth testing.</param>
 		/// <param name="window">Window to set depth function for.</param>
 		virtual void SetDepthFunction(CompareMode function, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the depth function.
+		/// </summary>
+		/// <param name="function">Function to use for depth testing.</param>
+		virtual void SetDepthFunction(CompareMode function) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the depth action to perform when depth testing fails for the given window.
 		/// </summary>
@@ -302,24 +387,57 @@ namespace TRAP::Graphics
 		/// <param name="back">Depth action to perform when depth testing fails.</param>
 		/// <param name="window">Window to set the depth fail action for.</param>
 		virtual void SetDepthFail(StencilOp front, StencilOp back, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the depth action to perform when depth testing fails.
+		/// </summary>
+		/// <param name="front">Depth action to perform when depth testing fails.</param>
+		/// <param name="back">Depth action to perform when depth testing fails.</param>
+		virtual void SetDepthFail(StencilOp front, StencilOp back) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the depth bias (scalar factor to add to each fragments depth value) for the given window.
 		/// </summary>
 		/// <param name="depthBias">Depth bias.</param>
 		/// <param name="window">Window to set the depth bias for.</param>
 		virtual void SetDepthBias(int32_t depthBias, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the depth bias (scalar factor to add to each fragments depth value).
+		/// </summary>
+		/// <param name="depthBias">Depth bias.</param>
+		virtual void SetDepthBias(int32_t depthBias) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the depth bias slope factor (scalar factor applied to fragment's slope in depth bias calculation) for the given window.
 		/// </summary>
 		/// <param name="factor">Depth bias slope factor.</param>
 		/// <param name="window">Window to set the depth bias slope factor for.</param>
 		virtual void SetDepthBiasSlopeFactor(float factor, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the depth bias slope factor (scalar factor applied to fragment's slope in depth bias calculation).
+		/// </summary>
+		/// <param name="factor">Depth bias slope factor.</param>
+		virtual void SetDepthBiasSlopeFactor(float factor) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable stencil testing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable stencil testing.</param>
 		/// <param name="window">Window to set stencil testing for.</param>
 		virtual void SetStencilTesting(bool enabled, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Enable or disable stencil testing.
+		/// </summary>
+		/// <param name="enabled">Enable or disable stencil testing.</param>
+		virtual void SetStencilTesting(bool enabled) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the stencil action to perform when stencil testing fails for the given window.
 		/// </summary>
@@ -327,13 +445,31 @@ namespace TRAP::Graphics
 		/// <param name="back">Stencil action to perform when stencil testing fails.</param>
 		/// <param name="window">Window to set the stencil fail action for.</param>
 		virtual void SetStencilFail(StencilOp front, StencilOp back, const Window* window) const = 0;
+#else
 		/// <summary>
-		/// Set the stencil action to perform when stencil testing and depth testing passes for the given window.
+		/// Set the stencil action to perform when stencil testing fails.
+		/// </summary>
+		/// <param name="front">Stencil action to perform when stencil testing fails.</param>
+		/// <param name="back">Stencil action to perform when stencil testing fails.</param>
+		virtual void SetStencilFail(StencilOp front, StencilOp back) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
+		/// <summary>
+		/// Set the stencil action to perform when stencil testing passes for the given window.
 		/// </summary>
 		/// <param name="front">Stencil action to perform when passed.</param>
 		/// <param name="back">Stencil action to perform when passed.</param>
 		/// <param name="window">Window to set the stencil pass action for.</param>
 		virtual void SetStencilPass(StencilOp front, StencilOp back, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the stencil action to perform when stencil testing passes.
+		/// </summary>
+		/// <param name="front">Stencil action to perform when passed.</param>
+		/// <param name="back">Stencil action to perform when passed.</param>
+		virtual void SetStencilPass(StencilOp front, StencilOp back) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the stencil functions for the given window.
 		/// </summary>
@@ -341,6 +477,15 @@ namespace TRAP::Graphics
 		/// <param name="back">Function to use on the back for stencil testing.</param>
 		/// <param name="window">Window to set stencil functions for.</param>
 		virtual void SetStencilFunction(CompareMode front, CompareMode back, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the stencil functions.
+		/// </summary>
+		/// <param name="front">Function to use on the front for stencil testing.</param>
+		/// <param name="back">Function to use on the back for stencil testing.</param>
+		virtual void SetStencilFunction(CompareMode front, CompareMode back) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the stencil mask for the given window.
 		/// </summary>
@@ -348,30 +493,71 @@ namespace TRAP::Graphics
 		/// <param name="write">Select the bits of the stencil values updated by the stencil test.</param>
 		/// <param name="window">Window to set stencil mask for.</param>
 		virtual void SetStencilMask(uint8_t read, uint8_t write, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the stencil mask.
+		/// </summary>
+		/// <param name="read">Select the bits of the stencil values to test.</param>
+		/// <param name="write">Select the bits of the stencil values updated by the stencil test.</param>
+		virtual void SetStencilMask(uint8_t read, uint8_t write) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the cull mode for the given window.
 		/// </summary>
 		/// <param name="mode">Cull mode to use.</param>
 		/// <param name="window">Window to set cull mode for.</param>
 		virtual void SetCullMode(CullMode mode, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the cull mode.
+		/// </summary>
+		/// <param name="mode">Cull mode to use.</param>
+		virtual void SetCullMode(CullMode mode) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the fill mode for the given window.
 		/// </summary>
 		/// <param name="mode">Fill mode to use.</param>
 		/// <param name="window">Window to set fill mode for.</param>
 		virtual void SetFillMode(FillMode mode, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the fill mode.
+		/// </summary>
+		/// <param name="mode">Fill mode to use.</param>
+		virtual void SetFillMode(FillMode mode) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the primitive topology for the given window.
 		/// </summary>
 		/// <param name="topology">Primitive topology to use.</param>
 		/// <param name="window">Window to set primitive topology for.</param>
 		virtual void SetPrimitiveTopology(PrimitiveTopology topology, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the primitive topology.
+		/// </summary>
+		/// <param name="topology">Primitive topology to use.</param>
+		virtual void SetPrimitiveTopology(PrimitiveTopology topology) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the front face winding order for the given window.
 		/// </summary>
 		/// <param name="face">Front face winding order to use.</param>
 		/// <param name="window">Window to set front face winding order for.</param>
 		virtual void SetFrontFace(FrontFace face, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the front face winding order.
+		/// </summary>
+		/// <param name="face">Front face winding order to use.</param>
+		virtual void SetFrontFace(FrontFace face) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the blend mode for the given window.
 		/// </summary>
@@ -379,6 +565,15 @@ namespace TRAP::Graphics
 		/// <param name="modeAlpha">Blend mode to use for the alpha channel.</param>
 		/// <param name="window">Window to set the blend mode for.</param>
 		virtual void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the blend mode.
+		/// </summary>
+		/// <param name="modeRGB">Blend mode to use for the RGB channels.</param>
+		/// <param name="modeAlpha">Blend mode to use for the alpha channel.</param>
+		virtual void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the blend constants/factors for the given window.
 		/// </summary>
@@ -390,6 +585,18 @@ namespace TRAP::Graphics
 		virtual void SetBlendConstant(BlendConstant sourceRGB, BlendConstant sourceAlpha,
 			                          BlendConstant destinationRGB, BlendConstant destinationAlpha,
 									  const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the blend constants/factors.
+		/// </summary>
+		/// <param name="sourceRGB">Specifies how the red, green, and blue blending factors are computed.</param>
+		/// <param name="sourceAlpha">Specifies how the alpha source blending factor is computed.</param>
+		/// <param name="destinationRGB">Specifies how the red, green, and blue destination blending factors are computed.</param>
+		/// <param name="destinationAlpha">Specified how the alpha destination blending factor is computed.</param>
+		virtual void SetBlendConstant(BlendConstant sourceRGB, BlendConstant sourceAlpha,
+			                          BlendConstant destinationRGB, BlendConstant destinationAlpha) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the pipeline fragment shading rate and combiner operation for the command buffer.
 		/// </summary>
@@ -400,6 +607,18 @@ namespace TRAP::Graphics
 		virtual void SetShadingRate(ShadingRate shadingRate,
 		                            ShadingRateCombiner postRasterizerRate,
 							        ShadingRateCombiner finalRate, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the pipeline fragment shading rate and combiner operation for the command buffer.
+		/// </summary>
+		/// <param name="shadingRate">Shading rate to use.</param>
+		/// <param name="postRasterizerRate">Shading rate combiner to use.</param>
+		/// <param name="finalRate">Shading rate combiner to use.</param>
+		virtual void SetShadingRate(ShadingRate shadingRate,
+		                            ShadingRateCombiner postRasterizerRate,
+							        ShadingRateCombiner finalRate) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the pipeline fragment shading rate via texture.
 		/// </summary>
@@ -409,16 +628,35 @@ namespace TRAP::Graphics
 		/// </param>
 		/// <param name="window">Window to set shading rate for.</param>
 		virtual void SetShadingRate(Ref<RenderTarget> texture, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set the pipeline fragment shading rate via texture.
+		/// </summary>
+		/// <param name="texture">
+		/// Shading rate texture to use.
+		/// Note: The texture must be in ResourceState::ShadingRateSource.
+		/// </param>
+		virtual void SetShadingRate(Ref<RenderTarget> texture) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Clear the given window's render target.
 		/// </summary>
 		/// <param name="clearType">Type of buffer to clear.</param>
 		/// <param name="window">Window to clear.</param>
 		virtual void Clear(ClearBufferType clearType, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Clear the given render target.
+		/// </summary>
+		/// <param name="clearType">Type of buffer to clear.</param>
+		virtual void Clear(ClearBufferType clearType) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//CommandBuffer Stuff
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set viewport size for the given window.
 		/// </summary>
@@ -431,6 +669,20 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to set viewport for.</param>
 		virtual void SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height, float minDepth /*= 0.0f*/,
 		                         float maxDepth /*= 1.0f*/, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set viewport size.
+		/// </summary>
+		/// <param name="x">X coordinate of the top left corner of the viewport.</param>
+		/// <param name="y">Y coordinate of the top left corner of the viewport.</param>
+		/// <param name="width">New viewport width.</param>
+		/// <param name="height">New viewport height.</param>
+		/// <param name="minDepth">New min depth value. Default: 0.0f.</param>
+		/// <param name="maxDepth">New max depth value. Default: 1.0f.</param>
+		virtual void SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height, float minDepth /*= 0.0f*/,
+		                         float maxDepth /*= 1.0f*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set scissor size for the given window.
 		/// </summary>
@@ -441,7 +693,18 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to set scissor size for.</param>
 		virtual void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height,
 		                        const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Set scissor size.
+		/// </summary>
+		/// <param name="x">Upper left corner.</param>
+		/// <param name="y">Upper left corner.</param>
+		/// <param name="width">New scissor width.</param>
+		/// <param name="height">New scissor height.</param>
+		virtual void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw non-indexed, non-instanced geometry for the given window.
 		/// </summary>
@@ -449,6 +712,15 @@ namespace TRAP::Graphics
 		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for.</param>
 		virtual void Draw(uint32_t vertexCount, uint32_t firstVertex /*= 0*/, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Draw non-indexed, non-instanced geometry.
+		/// </summary>
+		/// <param name="vertexCount">Number of vertices to draw.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		virtual void Draw(uint32_t vertexCount, uint32_t firstVertex /*= 0*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw indexed, non-instanced geometry for the given window.
 		/// </summary>
@@ -458,6 +730,16 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to draw for.</param>
 		virtual void DrawIndexed(uint32_t indexCount, uint32_t firstIndex /*= 0*/, uint32_t firstVertex /*= 0*/,
 		                         const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Draw indexed, non-instanced geometry.
+		/// </summary>
+		/// <param name="indexCount">Number of indices to draw.</param>
+		/// <param name="firstIndex">Index of the first indice to draw. Default: 0.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		virtual void DrawIndexed(uint32_t indexCount, uint32_t firstIndex /*= 0*/, uint32_t firstVertex /*= 0*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw non-indexed, instanced geometry for the given window.
 		/// </summary>
@@ -468,6 +750,18 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to draw for.</param>
 		virtual void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex /*= 0*/,
 		                           uint32_t firstInstance /*= 0*/, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Draw non-indexed, instanced geometry.
+		/// </summary>
+		/// <param name="vertexCount">Number of vertices to draw.</param>
+		/// <param name="instanceCount">Number of instances to draw.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
+		virtual void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex /*= 0*/,
+		                           uint32_t firstInstance /*= 0*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw indexed, instanced geometry for the given window.
 		/// </summary>
@@ -480,7 +774,21 @@ namespace TRAP::Graphics
 		virtual void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
 		                                  uint32_t firstIndex /*= 0*/, uint32_t firstInstance /*= 0*/,
 										  uint32_t firstVertex /*= 0*/, const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Draw indexed, instanced geometry.
+		/// </summary>
+		/// <param name="indexCount">Number of indices to draw.</param>
+		/// <param name="instanceCount">Number of instances to draw.</param>
+		/// <param name="firstIndex">Index of the first indice to draw. Default: 0.</param>
+		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		virtual void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+		                                  uint32_t firstIndex /*= 0*/, uint32_t firstInstance /*= 0*/,
+										  uint32_t firstVertex /*= 0*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind vertex buffer on the given window.
 		/// </summary>
@@ -489,6 +797,15 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to bind the vertex buffer for.</param>
 		virtual void BindVertexBuffer(const TRAP::Ref<Buffer>& vBuffer, const VertexBufferLayout& layout,
 		                              const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Bind vertex buffer.
+		/// </summary>
+		/// <param name="vBuffer">Vertex buffer to bind.</param>
+		/// <param name="layout">Layout of the vertex buffer.</param>
+		virtual void BindVertexBuffer(const TRAP::Ref<Buffer>& vBuffer, const VertexBufferLayout& layout) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind an index buffer on the given window.
 		/// </summary>
@@ -497,6 +814,15 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to bind the vertex buffer for.</param>
 		virtual void BindIndexBuffer(const TRAP::Ref<Buffer>& iBuffer, IndexType indexType,
 		                             const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Bind an index buffer.
+		/// </summary>
+		/// <param name="iBuffer">Index buffer to bind.</param>
+		/// <param name="indexType">Data type used by the index buffer.</param>
+		virtual void BindIndexBuffer(const TRAP::Ref<Buffer>& iBuffer, IndexType indexType) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind a descriptor set on the given window.
 		/// </summary>
@@ -507,6 +833,17 @@ namespace TRAP::Graphics
 		virtual void BindDescriptorSet(DescriptorSet& dSet, uint32_t index,
 		                               QueueType queueType /*= QueueType::Graphics*/,
 									   const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Bind a descriptor set.
+		/// </summary>
+		/// <param name="dSet">Descriptor set to bind.</param>
+		/// <param name="index">Index for which descriptor set to bind.</param>
+		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
+		virtual void BindDescriptorSet(DescriptorSet& dSet, uint32_t index,
+		                               QueueType queueType /*= QueueType::Graphics*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind push constant buffer data on the given window.
 		/// Note: There is an optimized function which uses the index into the RootSignature
@@ -519,6 +856,19 @@ namespace TRAP::Graphics
 		virtual void BindPushConstants(const char* name, const void* constantsData,
 		                               QueueType queueType /*= QueueType::Graphics*/,
 									   const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Bind push constant buffer data.
+		/// Note: There is an optimized function which uses the index into the RootSignature
+		///       instead of the name of the push constant block.
+		/// </summary>
+		/// <param name="name">Name of the push constant block.</param>
+		/// <param name="constantsData">Pointer to the constant buffer data.</param>
+		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
+		virtual void BindPushConstants(const char* name, const void* constantsData,
+		                               QueueType queueType /*= QueueType::Graphics*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind push constant buffer data on the given window.
 		/// </summary>
@@ -529,6 +879,17 @@ namespace TRAP::Graphics
 		virtual void BindPushConstantsByIndex(uint32_t paramIndex, const void* constantsData,
 											  QueueType queueType /*= QueueType::Graphics*/,
 											  const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Bind push constant buffer data.
+		/// </summary>
+		/// <param name="paramIndex">Index of the push constant block in the RootSignatures descriptors array.</param>
+		/// <param name="constantsData">Pointer to the constant buffer data.</param>
+		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
+		virtual void BindPushConstantsByIndex(uint32_t paramIndex, const void* constantsData,
+											  QueueType queueType /*= QueueType::Graphics*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind render target(s) on the given window.
 		///
@@ -549,6 +910,27 @@ namespace TRAP::Graphics
 									  std::vector<uint32_t>* colorMipSlices /*= nullptr*/,
 									  uint32_t depthArraySlice /*= -1*/, uint32_t depthMipSlice /*= -1*/,
 									  const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Bind render target(s).
+		///
+		/// Note: This functions ends the currently running render pass and starts a new one.
+		/// </summary>
+		/// <param name="colorTarget">Color render target to bind.</param>
+		/// <param name="depthStencil">Optional depth stencil target to bind. Default: nullptr.</param>
+		/// <param name="loadActions">Optional load actions for each render target. Default: nullptr.</param>
+		/// <param name="colorArraySlices">Optional color array slices for each render target. Default: nullptr.</param>
+		/// <param name="colorMipSlices">Optional color mip slices for each render target. Default: nullptr.</param>
+		/// <param name="depthArraySlice">Optional depth array slice for the depth stencil target. Default: -1.</param>
+		/// <param name="depthMipSlice">Optional depth mip slice for the depth stencil target. Default: -1.</param>
+		virtual void BindRenderTarget(const TRAP::Ref<Graphics::RenderTarget>& colorTarget,
+		                              const TRAP::Ref<Graphics::RenderTarget>& depthStencil /*= nullptr*/,
+									  const RendererAPI::LoadActionsDesc* loadActions /*= nullptr*/,
+									  std::vector<uint32_t>* colorArraySlices /*= nullptr*/,
+									  std::vector<uint32_t>* colorMipSlices /*= nullptr*/,
+									  uint32_t depthArraySlice /*= -1*/, uint32_t depthMipSlice /*= -1*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind render target(s) on the given window.
 		///
@@ -569,7 +951,28 @@ namespace TRAP::Graphics
 									   std::vector<uint32_t>* colorMipSlices /*= nullptr*/,
 									   uint32_t depthArraySlice /*= -1*/, uint32_t depthMipSlice /*= -1*/,
 									   const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Bind render target(s).
+		///
+		/// Note: This functions ends the currently running render pass and starts a new one.
+		/// </summary>
+		/// <param name="colorTargets">Color render target(s) to bind.</param>
+		/// <param name="depthStencil">Optional depth stencil target to bind. Default: nullptr.</param>
+		/// <param name="loadActions">Optional load actions for each render target. Default: nullptr.</param>
+		/// <param name="colorArraySlices">Optional color array slices for each render target. Default: nullptr.</param>
+		/// <param name="colorMipSlices">Optional color mip slices for each render target. Default: nullptr.</param>
+		/// <param name="depthArraySlice">Optional depth array slice for the depth stencil target. Default: -1.</param>
+		/// <param name="depthMipSlice">Optional depth mip slice for the depth stencil target. Default: -1.</param>
+		virtual void BindRenderTargets(const std::vector<TRAP::Ref<Graphics::RenderTarget>>& colorTargets,
+		                               const TRAP::Ref<Graphics::RenderTarget>& depthStencil /*= nullptr*/,
+									   const RendererAPI::LoadActionsDesc* loadActions /*= nullptr*/,
+									   std::vector<uint32_t>* colorArraySlices /*= nullptr*/,
+									   std::vector<uint32_t>* colorMipSlices /*= nullptr*/,
+									   uint32_t depthArraySlice /*= -1*/, uint32_t depthMipSlice /*= -1*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
@@ -579,6 +982,16 @@ namespace TRAP::Graphics
 		virtual void ResourceBufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
 										   QueueType queueType /*= QueueType::Graphics*/,
 								           const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Add a resource barrier (memory dependency).
+		/// </summary>
+		/// <param name="bufferBarrier">Buffer barrier.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		virtual void ResourceBufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
+										   QueueType queueType /*= QueueType::Graphics*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
@@ -588,6 +1001,16 @@ namespace TRAP::Graphics
 		virtual void ResourceBufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
 											QueueType queueType /*= QueueType::Graphics*/,
 									        const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Add resource barriers (memory dependencies).
+		/// </summary>
+		/// <param name="bufferBarriers">Buffer barriers.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		virtual void ResourceBufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
+											QueueType queueType /*= QueueType::Graphics*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
@@ -597,6 +1020,16 @@ namespace TRAP::Graphics
 		virtual void ResourceTextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
 											QueueType queueType /*= QueueType::Graphics*/,
 									        const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Add a resource barrier (memory dependency).
+		/// </summary>
+		/// <param name="textureBarrier">Texture barrier.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		virtual void ResourceTextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
+											QueueType queueType /*= QueueType::Graphics*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
@@ -606,6 +1039,16 @@ namespace TRAP::Graphics
 		virtual void ResourceTextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
 											 QueueType queueType /*= QueueType::Graphics*/,
 									         const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Add resource barriers (memory dependencies).
+		/// </summary>
+		/// <param name="textureBarriers">Texture barriers.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		virtual void ResourceTextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
+											 QueueType queueType /*= QueueType::Graphics*/) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
@@ -613,6 +1056,14 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to add the barrier for.</param>
 		virtual void ResourceRenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier,
 									             const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Add a resource barrier (memory dependency).
+		/// </summary>
+		/// <param name="renderTargetBarrier">Render target barrier.</param>
+		virtual void ResourceRenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
@@ -620,6 +1071,13 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to add the barriers for.</param>
 		virtual void ResourceRenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers,
 									              const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Add resource barriers (memory dependencies).
+		/// </summary>
+		/// <param name="renderTargetBarriers">Render target barriers.</param>
+		virtual void ResourceRenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>
@@ -670,12 +1128,20 @@ namespace TRAP::Graphics
 		/// <returns>List of all supported GPUs.</returns>
 		[[nodiscard]] virtual std::vector<std::pair<std::string, std::array<uint8_t, 16>>> GetAllGPUs() const = 0;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Capture a screenshot of the last presented frame.
 		/// </summary>
 		/// <param name="window">Window to capture screenshot on.</param>
 		/// <returns>Captured screenshot as TRAP::Image on success, Black 1x1 TRAP::Image otherwise.</returns>
 		[[nodiscard]] virtual TRAP::Scope<TRAP::Image> CaptureScreenshot(const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Capture a screenshot of the last presented frame.
+		/// </summary>
+		/// <returns>Captured screenshot as TRAP::Image on success, Black 1x1 TRAP::Image otherwise.</returns>
+		[[nodiscard]] virtual TRAP::Scope<TRAP::Image> CaptureScreenshot() const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Resolve a MSAA render target to a non MSAA render target.
@@ -689,6 +1155,7 @@ namespace TRAP::Graphics
 		virtual void MSAAResolvePass(TRAP::Ref<RenderTarget> source, TRAP::Ref<RenderTarget> destination,
 		                             CommandBuffer* cmd) const = 0;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Scale image from internal resolution to the final output resolution.
 		///
@@ -700,6 +1167,17 @@ namespace TRAP::Graphics
 		virtual void RenderScalePass(TRAP::Ref<RenderTarget> source,
 									 TRAP::Ref<RenderTarget> destination,
 		                             const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Scale image from internal resolution to the final output resolution.
+		///
+		/// Note: source and destination must be in ResourceState::RenderTarget.
+		/// </summary>
+		/// <param name="source">Source render target to resolve.</param>
+		/// <param name="destination">Destination render target to resolve into.</param>
+		virtual void RenderScalePass(TRAP::Ref<RenderTarget> source,
+									 TRAP::Ref<RenderTarget> destination) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>
@@ -742,19 +1220,36 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <returns>Transfer queue.</returns>
 		[[nodiscard]] static TRAP::Ref<TRAP::Graphics::Queue> GetTransferQueue() noexcept;
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the currently used graphics root signature of the given window.
 		/// </summary>
 		/// <param name="window">Window to retrieve the graphics root signature from.</param>
 		/// <returns>Graphics root signature.</returns>
 		[[nodiscard]] static TRAP::Ref<TRAP::Graphics::RootSignature> GetGraphicsRootSignature(const Window* window);
+#else
+		/// <summary>
+		/// Retrieve the currently used graphics root signature.
+		/// </summary>
+		/// <returns>Graphics root signature.</returns>
+		[[nodiscard]] static TRAP::Ref<TRAP::Graphics::RootSignature> GetGraphicsRootSignature();
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the currently used internal render resolution of the given window.
 		/// </summary>
 		/// <param name="window">Window to get internal render resolution from.</param>
 		/// <returns>Internal render resolution.</returns>
 		[[nodiscard]] static TRAP::Math::Vec2ui GetInternalRenderResolution(const Window* window);
+#else
+		/// <summary>
+		/// Retrieve the currently used internal render resolution.
+		/// </summary>
+		/// <returns>Internal render resolution.</returns>
+		[[nodiscard]] static TRAP::Math::Vec2ui GetInternalRenderResolution();
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Start a render pass for the given window.
 		///
@@ -762,11 +1257,26 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <param name="window">Window to start render pass for.</param>
 		static void StartRenderPass(const Window* window);
+#else
+		/// <summary>
+		/// Start a render pass.
+		///
+		/// Note: This will bind the render target for the current frame again.
+		/// </summary>
+		static void StartRenderPass();
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Stop running render pass of the given window.
 		/// </summary>
 		/// <param name="window">Window to stop render pass on.</param>
 		static void StopRenderPass(const Window* window);
+#else
+		/// <summary>
+		/// Stop running render pass.
+		/// </summary>
+		static void StopRenderPass();
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Transition a texture from old layout to the new layout.
@@ -823,37 +1333,75 @@ namespace TRAP::Graphics
 		static void ResizeSwapChain(const Window* window);
 #endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the GPU side frame time for the graphics queue.
 		/// </summary>
 		/// <param name="window">Window to get frame time from.</param>
 		/// <returns>GPU Graphics frame time in milliseconds.</returns>
 		[[nodiscard]] static float GetGPUGraphicsFrameTime(const Window* window);
+#else
+		/// <summary>
+		/// Retrieve the GPU side frame time for the graphics queue.
+		/// </summary>
+		/// <returns>GPU Graphics frame time in milliseconds.</returns>
+		[[nodiscard]] static float GetGPUGraphicsFrameTime();
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the GPU side frame time for the compute queue.
 		/// </summary>
 		/// <param name="window">Window to get frame time from.</param>
 		/// <returns>GPU Compute frame time in milliseconds.</returns>
 		[[nodiscard]] static float GetGPUComputeFrameTime(const Window* window);
+#else
+		/// <summary>
+		/// Retrieve the GPU side frame time for the compute queue.
+		/// </summary>
+		/// <returns>GPU Compute frame time in milliseconds.</returns>
+		[[nodiscard]] static float GetGPUComputeFrameTime();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	//protected:
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
-		/// Retrieve windows internal rendering data.
+		/// Retrieve internal rendering data.
 		/// </summary>
 		/// <returns>Windows internal rendering data.</returns>
-		[[nodiscard]] static PerViewportData& GetWindowData(const Window* window);
+		[[nodiscard]] static PerViewportData& GetViewportData(const Window* window);
+#else
+		/// <summary>
+		/// Retrieve internal rendering data.
+		/// </summary>
+		/// <returns>Internal rendering data.</returns>
+		[[nodiscard]] static PerViewportData& GetViewportData();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	public:
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Initialize the internal rendering data of the given window.
 		/// </summary>
 		/// <param name="window">Window to initialize the internal rendering data for.</param>
 		virtual void InitPerViewportData(Window* window) const = 0;
+#else
+		/// <summary>
+		/// Initialize the internal rendering data.
+		/// </summary>
+		virtual void InitPerViewportData() const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Remove the internal rendering data of the given window.
 		/// </summary>
 		/// <param name="window">Window to remove the internal rendering data from.</param>
 		virtual void RemovePerViewportData(const Window* window) const = 0;
+#else
+		/// <summary>
+		/// Remove the internal rendering data.
+		/// </summary>
+		virtual void RemovePerViewportData() const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Wait for the GPU to idle.
@@ -2632,12 +3180,20 @@ namespace TRAP::Graphics
 
 		inline static constexpr uint32_t ImageCount = 3; //Triple Buffered
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the image index currently used for rendering from the given window.
 		/// </summary>
 		/// <param name="window">Window to retrieve image index from.</param>
 		/// <returns>Image index.</returns>
 		[[nodiscard]] static uint32_t GetCurrentImageIndex(const TRAP::Window* window);
+#else
+		/// <summary>
+		/// Retrieve the image index currently used for rendering.
+		/// </summary>
+		/// <returns>Image index.</returns>
+		[[nodiscard]] static uint32_t GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 #ifdef ENABLE_NSIGHT_AFTERMATH
 		//GPU crash dump tracker using Nsight Aftermath instrumentation
@@ -2759,11 +3315,11 @@ namespace TRAP::Graphics
 		};
 
 	protected:
-// #ifndef TRAP_HEADLESS_MODE
+#ifndef TRAP_HEADLESS_MODE
 		static std::unordered_map<const Window*, TRAP::Scope<PerViewportData>> s_perViewportDataMap;
-// #else
-// 		static TRAP::Scope<PerViewportData> s_perViewportData;
-// #endif /*TRAP_HEADLESS_MODE*/
+#else
+		static TRAP::Scope<PerViewportData> s_perViewportData;
+#endif /*TRAP_HEADLESS_MODE*/
 
 	private:
 		static bool s_isVulkanCapable;

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -1392,7 +1392,9 @@ namespace TRAP::Graphics
 		/// <summary>
 		/// Initialize the internal rendering data.
 		/// </summary>
-		virtual void InitPerViewportData() const = 0;
+		/// <param name="width">Width for the viewport.</param>
+		/// <param name="height">Height for the viewport.</param>
+		virtual void InitPerViewportData(uint32_t width, uint32_t height) const = 0;
 #endif /*TRAP_HEADLESS_MODE*/
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -3251,9 +3251,9 @@ namespace TRAP::Graphics
 			PerViewportData& operator=(const PerViewportData &) = delete;
 			PerViewportData& operator=(PerViewportData &&) = default;
 
-// #ifndef TRAP_HEADLESS_MODE
+#ifndef TRAP_HEADLESS_MODE
 			TRAP::Window* Window{};
-// #endif /*TRAP_HEADLESS_MODE*/
+#endif /*TRAP_HEADLESS_MODE*/
 
 			PerWindowState State{};
 

--- a/TRAP/src/Graphics/API/RendererAPI.h
+++ b/TRAP/src/Graphics/API/RendererAPI.h
@@ -1252,6 +1252,14 @@ namespace TRAP::Graphics
 		/// <returns>Internal render resolution.</returns>
 		[[nodiscard]] static TRAP::Math::Vec2ui GetInternalRenderResolution();
 #endif /*TRAP_HEADLESS_MODE*/
+#ifdef TRAP_HEADLESS_MODE
+		/// <summary>
+		/// Get the resolution of the render targets.
+		/// </summary>
+		/// <param name="width">Output: Width.</param>
+		/// <param name="height">Output: Height.</param>
+		virtual void GetResolution(uint32_t& width, uint32_t& height) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>

--- a/TRAP/src/Graphics/API/ResourceLoader.h
+++ b/TRAP/src/Graphics/API/ResourceLoader.h
@@ -6,6 +6,7 @@
 #include <thread>
 
 #include "RendererAPI.h"
+#include "ImageLoader/Image.h"
 
 namespace TRAP::Graphics
 {

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDescriptorPool.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanDescriptorPool.cpp
@@ -7,7 +7,7 @@
 #include "VulkanInits.h"
 #include "Graphics/API/Vulkan/VulkanCommon.h"
 #include "Graphics/API/Vulkan/VulkanRenderer.h"
-#include <vulkan/vulkan_core.h>
+#include "Graphics/API/Vulkan/Utils/VulkanLoader.h"
 
 std::array<VkDescriptorPoolSize, TRAP::Graphics::API::VulkanDescriptorPool::DESCRIPTOR_TYPE_RANGE_SIZE>
 TRAP::Graphics::API::VulkanDescriptorPool::s_descriptorPoolSizes =

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanFence.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanFence.h
@@ -61,8 +61,10 @@ namespace TRAP::Graphics::API
 		void Wait() override;
 
 	private:
+#ifndef TRAP_HEADLESS_MODE
 		friend std::optional<uint32_t> TRAP::Graphics::API::VulkanSwapChain::AcquireNextImage(const TRAP::Ref<Semaphore>& signalSemaphore,
 		                                                                                      const TRAP::Ref<Fence>& fence) const;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		VkFence m_fence;
 		TRAP::Ref<VulkanDevice> m_device;

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
@@ -7,8 +7,8 @@
 #include "Graphics/API/RendererAPI.h"
 #include "Graphics/API/Vulkan/VulkanCommon.h"
 #include "Graphics/API/Vulkan/VulkanRenderer.h"
+#include "Graphics/API/Vulkan/Utils/VulkanLoader.h"
 #include "Utils/Dialogs/Dialogs.h"
-#include <vulkan/vulkan_core.h>
 
 std::multimap<uint32_t, std::array<uint8_t, 16>> TRAP::Graphics::API::VulkanPhysicalDevice::s_availablePhysicalDeviceUUIDs{};
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanPhysicalDevice.cpp
@@ -194,7 +194,7 @@ TRAP::Graphics::API::VulkanPhysicalDevice::VulkanPhysicalDevice(const TRAP::Ref<
 			}
 		}
 	}
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -582,13 +582,12 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 					 "\" Failed Required PhysicalDevice Extensions Test!");
 			continue;
 		}
-#endif
 
 		// Required: Create Vulkan Instance
 
 		// Init WindowingAPI needed here for instance extensions
 		// Disabled in Headless mode.
-#ifndef TRAP_HEADLESS_MODE
+
 		if (!INTERNAL::WindowingAPI::Init())
 		{
 			Utils::Dialogs::ShowMsgBox("Failed to initialize WindowingAPI", "The WindowingAPI couldn't be initialized!\n"
@@ -597,11 +596,9 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 			TP_CRITICAL(Log::RendererVulkanPrefix, "The WindowingAPI couldn't be initialized! (0x0011)");
 			exit(0x0011);
 		}
-#endif
 
 		// Required: Create Vulkan Surface Test Window
 		// Disabled in Headless mode.
-#ifndef TRAP_HEADLESS_MODE
 		INTERNAL::WindowingAPI::WindowHint(INTERNAL::WindowingAPI::Hint::Visible, false);
 		INTERNAL::WindowingAPI::WindowHint(INTERNAL::WindowingAPI::Hint::Focused, false);
 		INTERNAL::WindowingAPI::InternalWindow* vulkanTestWindow = INTERNAL::WindowingAPI::CreateWindow(400,
@@ -616,11 +613,10 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 					 "\" Failed Vulkan Surface Test Window creation!");
 			continue;
 		}
-#endif
 
 		// Required: Check if Surface can be created
 		// Disabled in Headless mode
-#ifndef TRAP_HEADLESS_MODE
+
 		VkSurfaceKHR surface = VK_NULL_HANDLE;
 		VkResult res{};
 		VkCall(res = TRAP::INTERNAL::WindowingAPI::CreateWindowSurface(instance, *vulkanTestWindow, nullptr,
@@ -632,7 +628,7 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 			TP_ERROR(Log::RendererVulkanPrefix, "Device: \"", devProps.deviceName, "\" Failed Surface creation!");
 			continue;
 		}
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 
 		// Required: Get Queue Families
 		uint32_t queueFamilyPropertyCount = 0;
@@ -644,7 +640,7 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 #ifndef TRAP_HEADLESS_MODE
 			vkDestroySurfaceKHR(instance, surface, nullptr);
 			TRAP::INTERNAL::WindowingAPI::DestroyWindow(vulkanTestWindow);
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 			vkDestroyInstance(instance, nullptr);
 			TP_ERROR(Log::RendererVulkanPrefix, "Device: \"", devProps.deviceName,
 					 "\" Failed Querying Queue Family Properties!");
@@ -666,7 +662,7 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 #ifndef TRAP_HEADLESS_MODE
 			vkDestroySurfaceKHR(instance, surface, nullptr);
 			TRAP::INTERNAL::WindowingAPI::DestroyWindow(vulkanTestWindow);
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 			vkDestroyInstance(instance, nullptr);
 			TP_ERROR(Log::RendererVulkanPrefix, "Device: \"", devProps.deviceName, "\" Failed Graphics Queue Test!");
 			continue;
@@ -691,11 +687,10 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 					 "\" Failed Present Queue Test!");
 			continue;
 		}
-#endif
 
 		// Required: Check if Surface contains present modes
 		// Disabled in Headless mode.
-#ifndef TRAP_HEADLESS_MODE
+
 		uint32_t surfacePresentModeCount = 0;
 		VkCall(vkGetPhysicalDeviceSurfacePresentModesKHR(dev, surface, &surfacePresentModeCount, nullptr));
 		std::vector<VkPresentModeKHR> presentModes(surfacePresentModeCount);
@@ -709,11 +704,10 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 			TP_ERROR(Log::RendererVulkanPrefix, "Device: \"", devProps.deviceName, "\" Failed Present Mode Test!");
 			continue;
 		}
-#endif
 
 		// Required: Check if Surface contains formats
 		// Disabled in Headless mode.
-#ifndef TRAP_HEADLESS_MODE
+
 		uint32_t surfaceFormatCount = 0;
 		VkCall(vkGetPhysicalDeviceSurfaceFormatsKHR(dev, surface, &surfaceFormatCount, nullptr));
 		std::vector<VkSurfaceFormatKHR> surfaceFormats(surfaceFormatCount);
@@ -727,7 +721,7 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 					 "\" Failed Surface Format Test!");
 			continue;
 		}
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 
 		// Big Optionally: Check if PhysicalDevice supports Compute queue
 		bool foundComputeQueue = false;
@@ -878,12 +872,10 @@ void TRAP::Graphics::API::VulkanPhysicalDevice::RatePhysicalDevices(const std::v
 		else
 			TP_WARN(Log::RendererVulkanPrefix, "Device: \"", devProps.deviceName,
 					"\" Failed Optimal Surface Format Test!");
-#endif
 
-#ifndef TRAP_HEADLESS_MODE
 		vkDestroySurfaceKHR(instance, surface, nullptr);
 		TRAP::INTERNAL::WindowingAPI::DestroyWindow(vulkanTestWindow);
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 
 		// Optionally: Check VRAM size (1e+9 == Bytes to Gigabytes)
 		// Get PhysicalDevice Memory Properties

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.cpp
@@ -211,10 +211,6 @@ void TRAP::Graphics::API::VulkanQueue::Submit(const RendererAPI::QueueSubmitDesc
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
 
-#ifdef TRAP_HEADLESS_MODE
-	TRAP_ASSERT(RendererAPI::GPUSettings.PresentSupported, "VulkanQueue::Present(): Present is not supported by the system!");
-#endif
-
 	const std::vector<TRAP::Ref<Semaphore>>& waitSemaphores = desc.WaitSemaphores;
 	RendererAPI::PresentStatus presentStatus = RendererAPI::PresentStatus::Failed;
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.cpp
@@ -206,6 +206,7 @@ void TRAP::Graphics::API::VulkanQueue::Submit(const RendererAPI::QueueSubmitDesc
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] TRAP::Graphics::RendererAPI::PresentStatus TRAP::Graphics::API::VulkanQueue::Present(const RendererAPI::QueuePresentDesc& desc) const
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
@@ -256,6 +257,7 @@ void TRAP::Graphics::API::VulkanQueue::Submit(const RendererAPI::QueueSubmitDesc
 
 	return presentStatus;
 }
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanQueue.h
@@ -88,12 +88,14 @@ namespace TRAP::Graphics::API
 		/// <param name="desc">Queue submit description.</param>
 		void Submit(const RendererAPI::QueueSubmitDesc& desc) const override;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Queue an image for presentation.
 		/// </summary>
 		/// <param name="desc">Queue presentation description.</param>
 		/// <returns>Presentation status.</returns>
 		[[nodiscard]] RendererAPI::PresentStatus Present(const RendererAPI::QueuePresentDesc& desc) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
 	private:
 		/// <summary>

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderPass.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanRenderPass.cpp
@@ -4,7 +4,7 @@
 #include "VulkanDevice.h"
 #include "VulkanInits.h"
 #include "Graphics/API/Vulkan/VulkanCommon.h"
-#include <vulkan/vulkan_core.h>
+#include "Graphics/API/Vulkan/Utils/VulkanLoader.h"
 
 TRAP::Graphics::API::VulkanRenderPass::VulkanRenderPass(TRAP::Ref<VulkanDevice> device,
                                                         const VulkanRenderer::RenderPassDesc& desc)

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSemaphore.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSemaphore.h
@@ -45,8 +45,10 @@ namespace TRAP::Graphics::API
 		[[nodiscard]] VkSemaphore GetVkSemaphore() const noexcept;
 
 	private:
+#ifndef TRAP_HEADLESS_MODE
 		friend std::optional<uint32_t> TRAP::Graphics::API::VulkanSwapChain::AcquireNextImage(const TRAP::Ref<Semaphore>& signalSemaphore,
 		                                                                                      const TRAP::Ref<Fence>& fence) const;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		VkSemaphore m_semaphore;
 

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.cpp
@@ -145,19 +145,31 @@ TRAP::Graphics::API::VulkanShader::~VulkanShader()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanShader::Use(const Window* const window)
+#else
+void TRAP::Graphics::API::VulkanShader::Use()
+#endif /*TRAP_HEADLESS_MODE*/
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
 
+#ifndef TRAP_HEADLESS_MODE
 	TRAP_ASSERT(window, "VulkanShader::Use(): Window is nullptr");
 
 	dynamic_cast<VulkanRenderer*>(RendererAPI::GetRenderer())->BindShader(this, window);
+#else
+	dynamic_cast<VulkanRenderer*>(RendererAPI::GetRenderer())->BindShader(this);
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(m_rootSignature) //Only do the following if the shader actually uses descriptors
 	{
 		//Following some descriptor set allocation and reusing logic
 
+#ifndef TRAP_HEADLESS_MODE
 		const uint32_t currImageIndex = RendererAPI::GetCurrentImageIndex(window);
+#else
+		const uint32_t currImageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 		if(m_lastImageIndex != std::numeric_limits<uint32_t>::max())
 		{
@@ -203,13 +215,20 @@ void TRAP::Graphics::API::VulkanShader::Use(const Window* const window)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanShader::UseTexture(const uint32_t set, const uint32_t binding,
                                                    Ref<TRAP::Graphics::Texture> const texture, const Window* const window) const
+#else
+void TRAP::Graphics::API::VulkanShader::UseTexture(const uint32_t set, const uint32_t binding,
+                                                   Ref<TRAP::Graphics::Texture> const texture) const
+#endif /*TRAP_HEADLESS_MODE*/
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
 
 	TRAP_ASSERT(texture, "VulkanShader::UseTexture(): Texture is nullptr!");
+#ifndef TRAP_HEADLESS_MODE
 	TRAP_ASSERT(window, "VulkanShader::UseTexture(): Window is nullptr");
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(!m_valid)
 		return;
@@ -237,21 +256,32 @@ void TRAP::Graphics::API::VulkanShader::UseTexture(const uint32_t set, const uin
 		GetDescriptorSets()[set]->Update(0, params);
 	else
 	{
+#ifndef TRAP_HEADLESS_MODE
 		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(window);
+#else
+		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 		GetDescriptorSets()[set]->Update(imageIndex, params);
 	}
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanShader::UseTextures(const uint32_t set, const uint32_t binding,
 													const std::vector<Ref<TRAP::Graphics::Texture>>& textures,
 													const Window* const window) const
+#else
+void TRAP::Graphics::API::VulkanShader::UseTextures(const uint32_t set, const uint32_t binding,
+													const std::vector<Ref<TRAP::Graphics::Texture>>& textures) const
+#endif /*TRAP_HEADLESS_MODE*/
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
 
 	TRAP_ASSERT(!textures.empty(), "VulkanShader::UseTextures(): Textures are empty!");
+#ifndef TRAP_HEADLESS_MODE
 	TRAP_ASSERT(window, "VulkanShader::UseTextures(): Window is nullptr");
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(!m_valid)
 		return;
@@ -281,20 +311,31 @@ void TRAP::Graphics::API::VulkanShader::UseTextures(const uint32_t set, const ui
 		GetDescriptorSets()[set]->Update(0, params);
 	else
 	{
+#ifndef TRAP_HEADLESS_MODE
 		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(window);
+#else
+		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 		GetDescriptorSets()[set]->Update(imageIndex, params);
 	}
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanShader::UseSampler(const uint32_t set, const uint32_t binding,
 	                                               TRAP::Graphics::Sampler* const sampler, const Window* const window) const
+#else
+void TRAP::Graphics::API::VulkanShader::UseSampler(const uint32_t set, const uint32_t binding,
+	                                               TRAP::Graphics::Sampler* const sampler) const
+#endif /*TRAP_HEADLESS_MODE*/
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
 
 	TRAP_ASSERT(sampler, "VulkanShader::UseSampler(): Sampler is nullptr!");
+#ifndef TRAP_HEADLESS_MODE
 	TRAP_ASSERT(window, "VulkanShader::UseSampler(): Window is nullptr");
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(!m_valid)
 		return;
@@ -315,21 +356,32 @@ void TRAP::Graphics::API::VulkanShader::UseSampler(const uint32_t set, const uin
 		GetDescriptorSets()[set]->Update(0, params);
 	else
 	{
+#ifndef TRAP_HEADLESS_MODE
 		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(window);
+#else
+		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 		GetDescriptorSets()[set]->Update(imageIndex, params);
 	}
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanShader::UseSamplers(const uint32_t set, const uint32_t binding,
 	                                                const std::vector<TRAP::Graphics::Sampler*>& samplers,
 													const Window* const window) const
+#else
+void TRAP::Graphics::API::VulkanShader::UseSamplers(const uint32_t set, const uint32_t binding,
+	                                                const std::vector<TRAP::Graphics::Sampler*>& samplers) const
+#endif /*TRAP_HEADLESS_MODE*/
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
 
 	TRAP_ASSERT(!samplers.empty(), "VulkanShader::UseSamplers(): Samplers are empty!");
+#ifndef TRAP_HEADLESS_MODE
 	TRAP_ASSERT(window, "VulkanShader::UseSamplers(): Window is nullptr");
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(!m_valid)
 		return;
@@ -352,16 +404,21 @@ void TRAP::Graphics::API::VulkanShader::UseSamplers(const uint32_t set, const ui
 		GetDescriptorSets()[set]->Update(0, params);
 	else
 	{
+#ifndef TRAP_HEADLESS_MODE
 		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(window);
+#else
+		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 		GetDescriptorSets()[set]->Update(imageIndex, params);
 	}
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanShader::UseUBO(const uint32_t set, const uint32_t binding,
                                                const TRAP::Graphics::UniformBuffer* const uniformBuffer,
-											   const uint64_t size,  const uint64_t offset, const Window* const window) const
+											   const uint64_t size, const uint64_t offset, const Window* const window) const
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
 
@@ -376,9 +433,28 @@ void TRAP::Graphics::API::VulkanShader::UseUBO(const uint32_t set, const uint32_
 
 	UseBuffer(set, binding, uniformBuffer->GetUBOs()[UBOIndex].get(), size != 0u ? size : uniformBuffer->GetSize(), offset, window);
 }
+#else
+void TRAP::Graphics::API::VulkanShader::UseUBO(const uint32_t set, const uint32_t binding,
+                                               const TRAP::Graphics::UniformBuffer* const uniformBuffer,
+											   const uint64_t size, const uint64_t offset) const
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
+
+	TRAP_ASSERT(uniformBuffer, "VulkanShader::UseUBO(): UniformBuffer is nullptr!");
+
+	if(!m_valid)
+		return;
+
+	const uint32_t UBOIndex = (uniformBuffer->GetUpdateFrequency() == RendererAPI::DescriptorUpdateFrequency::Static) ?
+		                          0 : RendererAPI::GetCurrentImageIndex();
+
+	UseBuffer(set, binding, uniformBuffer->GetUBOs()[UBOIndex].get(), size != 0u ? size : uniformBuffer->GetSize(), offset);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanShader::UseSSBO(const uint32_t set, const uint32_t binding,
                                                 const TRAP::Graphics::StorageBuffer* const storageBuffer,
 											    const uint64_t size, const Window* const window) const
@@ -396,6 +472,24 @@ void TRAP::Graphics::API::VulkanShader::UseSSBO(const uint32_t set, const uint32
 
 	UseBuffer(set, binding, storageBuffer->GetSSBOs()[SSBOIndex].get(), size != 0u ? size : storageBuffer->GetSize(), 0, window);
 }
+#else
+void TRAP::Graphics::API::VulkanShader::UseSSBO(const uint32_t set, const uint32_t binding,
+                                                const TRAP::Graphics::StorageBuffer* const storageBuffer,
+											    const uint64_t size) const
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
+
+	TRAP_ASSERT(storageBuffer, "VulkanShader::UseSSBO(): StorageBuffer is nullptr!");
+
+	if(!m_valid)
+		return;
+
+	const uint32_t SSBOIndex = (storageBuffer->GetUpdateFrequency() == RendererAPI::DescriptorUpdateFrequency::Static) ?
+		                           0 : RendererAPI::GetCurrentImageIndex();
+
+	UseBuffer(set, binding, storageBuffer->GetSSBOs()[SSBOIndex].get(), size != 0u ? size : storageBuffer->GetSize(), 0);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -634,9 +728,14 @@ void TRAP::Graphics::API::VulkanShader::SetShaderStageName(const std::string_vie
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanShader::UseBuffer(const uint32_t set, const uint32_t binding,
 												  TRAP::Graphics::Buffer* const buffer, uint64_t size, uint64_t offset,
 												  const Window* const window) const
+#else
+void TRAP::Graphics::API::VulkanShader::UseBuffer(const uint32_t set, const uint32_t binding,
+												  TRAP::Graphics::Buffer* const buffer, uint64_t size, uint64_t offset) const
+#endif /*TRAP_HEADLESS_MODE*/
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
 
@@ -681,7 +780,11 @@ void TRAP::Graphics::API::VulkanShader::UseBuffer(const uint32_t set, const uint
 	}
 	else
 	{
+#ifndef TRAP_HEADLESS_MODE
 		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(window);
+#else
+		const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 		params[0].Resource = std::vector<TRAP::Graphics::Buffer*>{buffer};
 		GetDescriptorSets()[set]->Update(imageIndex, params);
 	}

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanShader.h
@@ -82,11 +82,19 @@ namespace TRAP::Graphics::API
 		/// <returns>Entry point names.</returns>
 		[[nodiscard]] const std::vector<std::string>& GetEntryNames() const noexcept;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use shader for rendering on the given window.
 		/// </summary>
 		/// <param name="window">Window to use the shader for.</param>
 		void Use(const Window* window) override;
+#else
+		/// <summary>
+		/// Use shader for rendering.
+		/// </summary>
+		void Use() override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use texture with this shader on the given window.
 		/// </summary>
@@ -96,7 +104,17 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to use the shader for.</param>
 		void UseTexture(uint32_t set, uint32_t binding, Ref<TRAP::Graphics::Texture> texture,
 		                const Window* window) const override;
+#else
+		/// <summary>
+		/// Use texture with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the texture with.</param>
+		/// <param name="binding">Binding point of the texture.</param>
+		/// <param name="texture">Texture to use.</param>
+		void UseTexture(uint32_t set, uint32_t binding, Ref<TRAP::Graphics::Texture> texture) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use multiple textures with this shader on the given window.
 		/// </summary>
@@ -107,6 +125,18 @@ namespace TRAP::Graphics::API
 		void UseTextures(uint32_t set, uint32_t binding,
 						 const std::vector<Ref<TRAP::Graphics::Texture>>& textures,
 						 const Window* window) const override;
+#else
+		/// <summary>
+		/// Use multiple textures with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the textures with.</param>
+		/// <param name="binding">Binding point of the textures.</param>
+		/// <param name="textures">Textures to use.</param>
+		void UseTextures(uint32_t set, uint32_t binding,
+						 const std::vector<Ref<TRAP::Graphics::Texture>>& textures) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use sampler with this shader on the given window.
 		/// </summary>
@@ -116,6 +146,16 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to use the shader for.</param>
 		void UseSampler(uint32_t set, uint32_t binding, TRAP::Graphics::Sampler* sampler,
 		                const Window* window) const override;
+#else
+		/// <summary>
+		/// Use sampler with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the sampler with.</param>
+		/// <param name="binding">Binding point of the sampler.</param>
+		/// <param name="sampler">Sampler to use.</param>
+		void UseSampler(uint32_t set, uint32_t binding, TRAP::Graphics::Sampler* sampler) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use multiple samplers with this shader on the given window.
 		/// </summary>
@@ -126,6 +166,18 @@ namespace TRAP::Graphics::API
 		void UseSamplers(uint32_t set, uint32_t binding,
 		                 const std::vector<TRAP::Graphics::Sampler*>& samplers,
 						 const Window* window) const override;
+#else
+		/// <summary>
+		/// Use multiple samplers with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the samplers with.</param>
+		/// <param name="binding">Binding point of the samplers.</param>
+		/// <param name="samplers">Samplers to use.</param>
+		void UseSamplers(uint32_t set, uint32_t binding,
+		                 const std::vector<TRAP::Graphics::Sampler*>& samplers) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use uniform buffer object with this shader on the given window.
 		/// </summary>
@@ -137,6 +189,20 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to use the shader for.</param>
 		void UseUBO(uint32_t set, uint32_t binding, const TRAP::Graphics::UniformBuffer* constuniformBuffer,
 		            uint64_t size, uint64_t offset, const Window* window) const override;
+#else
+		/// <summary>
+		/// Use uniform buffer object with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the UBO with.</param>
+		/// <param name="binding">Binding point of the UBO.</param>
+		/// <param name="uniformBuffer">Uniform buffer to use.</param>
+		/// <param name="size">Size of the UBO.</param>
+		/// <param name="offset">Offset of the UBO.</param>
+		void UseUBO(uint32_t set, uint32_t binding, const TRAP::Graphics::UniformBuffer* constuniformBuffer,
+		            uint64_t size, uint64_t offset) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use shader storage buffer object with this shader on the given window.
 		/// </summary>
@@ -147,6 +213,17 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to use the shader for.</param>
 		void UseSSBO(uint32_t set, uint32_t binding, const TRAP::Graphics::StorageBuffer* storageBuffer,
 		             uint64_t size, const Window* window) const override;
+#else
+		/// <summary>
+		/// Use shader storage buffer object with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the SSBO with.</param>
+		/// <param name="binding">Binding point of the SSBO.</param>
+		/// <param name="storageBuffer">Storage buffer to use.</param>
+		/// <param name="size">Size of the SSBO.</param>
+		void UseSSBO(uint32_t set, uint32_t binding, const TRAP::Graphics::StorageBuffer* storageBuffer,
+		             uint64_t size) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Retrieve the shaders thread count per work group.
@@ -173,6 +250,7 @@ namespace TRAP::Graphics::API
 		/// <param name="stage">Shader stage to name.</param>
 		void SetShaderStageName(std::string_view name, VkShaderModule stage) const;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use a buffer object with this shader on the given window.
 		/// </summary>
@@ -184,6 +262,18 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to use the buffer for.</param>
 		void UseBuffer(uint32_t set, uint32_t binding, TRAP::Graphics::Buffer* buffer,
 		               uint64_t size, uint64_t offset, const Window* window) const;
+#else
+		/// <summary>
+		/// Use a buffer object with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the buffer with.</param>
+		/// <param name="binding">Binding point of the buffer.</param>
+		/// <param name="buffer">Buffer to use.</param>
+		/// <param name="size">Size of the buffer.</param>
+		/// <param name="offset">Offset into the buffer to start at.</param>
+		void UseBuffer(uint32_t set, uint32_t binding, TRAP::Graphics::Buffer* buffer,
+		               uint64_t size, uint64_t offset) const;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		///	Retrieve a descriptor's name via its set, binding, descriptor type and size.

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSurface.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSurface.cpp
@@ -1,6 +1,8 @@
 #include "TRAPPCH.h"
 #include "VulkanSurface.h"
 
+#ifndef TRAP_HEADLESS_MODE
+
 #include "VulkanPhysicalDevice.h"
 #include "VulkanDevice.h"
 #include "VulkanInstance.h"
@@ -94,3 +96,5 @@ TRAP::Graphics::API::VulkanSurface::~VulkanSurface()
 
 	return m_surfacePresentModes;
 }
+
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSurface.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSurface.h
@@ -1,6 +1,8 @@
 #ifndef TRAP_VULKANSURFACE_H
 #define TRAP_VULKANSURFACE_H
 
+#ifndef TRAP_HEADLESS_MODE
+
 #include "Window/WindowingAPI.h"
 
 namespace TRAP::Graphics::API
@@ -73,5 +75,7 @@ namespace TRAP::Graphics::API
 		TRAP::Ref<VulkanInstance> m_instance;
 	};
 }
+
+#endif /*TRAP_HEADLESS_MODE*/
 
 #endif /*TRAP_VULKANSURFACE_H*/

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.cpp
@@ -1,6 +1,8 @@
 #include "TRAPPCH.h"
 #include "VulkanSwapChain.h"
 
+#ifndef TRAP_HEADLESS_MODE
+
 #include "VulkanSemaphore.h"
 #include "VulkanFence.h"
 #include "VulkanCommandBuffer.h"
@@ -415,3 +417,5 @@ void TRAP::Graphics::API::VulkanSwapChain::UpdateFramebufferSize()
 
 	return m_presentQueue;
 }
+
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.h
+++ b/TRAP/src/Graphics/API/Vulkan/Objects/VulkanSwapChain.h
@@ -1,6 +1,8 @@
 #ifndef TRAP_VULKANSWAPCHAIN_H
 #define TRAP_VULKANSWAPCHAIN_H
 
+#ifndef TRAP_HEADLESS_MODE
+
 #include "Graphics/API/RendererAPI.h"
 #include "Graphics/API/Objects/SwapChain.h"
 
@@ -98,5 +100,7 @@ namespace TRAP::Graphics::API
 		RendererAPI::SwapChainDesc m_desc;
 	};
 }
+
+#endif /*TRAP_HEADLESS_MODE*/
 
 #endif /*TRAP_VULKANSWAPCHAIN_H*/

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -573,7 +573,7 @@ void TRAP::Graphics::API::VulkanRenderer::Flush() const
 			p->SwapChain->ToggleVSync();
 		p->CurrentVSync = p->NewVSync;
 	}
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(p->RenderScale != p->NewRenderScale)
 		p->RenderScale = p->NewRenderScale;
@@ -3027,13 +3027,11 @@ void TRAP::Graphics::API::VulkanRenderer::WaitIdle() const
 
 	if(!VulkanInstance::IsExtensionSupported(std::get<0>(reqExt)) || !VulkanInstance::IsExtensionSupported(std::get<1>(reqExt)))
 	{
-#ifndef TRAP_HEADLESS_MODE
 		Utils::Dialogs::ShowMsgBox("Vulkan API error", "Mandatory Vulkan surface extensions are unsupported!\n"
 								   "Error code: 0x0003", Utils::Dialogs::Style::Error,
 								   Utils::Dialogs::Buttons::Quit);
 		TP_CRITICAL(Log::RendererVulkanPrefix, "Mandatory Vulkan surface extensions are unsupported! (0x0003)");
 		exit(0x0003);
-#endif
 	}
 	else
 	{

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -783,6 +783,18 @@ void TRAP::Graphics::API::VulkanRenderer::SetResolution(const uint32_t width, co
 
 //------------------------------------------------------------------------------------------------------------------//
 
+#ifdef TRAP_HEADLESS_MODE
+void TRAP::Graphics::API::VulkanRenderer::GetResolution(uint32_t& width, uint32_t& height) const
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
+
+	width = s_perViewportData->NewWidth;
+	height = s_perViewportData->NewHeight;
+}
+#endif /*TRAP_HEADLESS_MODE*/
+
+//------------------------------------------------------------------------------------------------------------------//
+
 #ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanRenderer::SetDepthTesting(const bool enabled, const Window* const window) const
 #else

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -35,6 +35,7 @@
 #include "Graphics/API/Objects/RootSignature.h"
 #include "Graphics/API/Objects/PipelineCache.h"
 #include "Graphics/API/Objects/QueryPool.h"
+#include "Graphics/API/Objects/SwapChain.h"
 #include "Graphics/Buffers/VertexBufferLayout.h"
 #include "Graphics/Shaders/Shader.h"
 #include "Graphics/Shaders/ShaderManager.h"
@@ -3021,6 +3022,7 @@ void TRAP::Graphics::API::VulkanRenderer::WaitIdle() const
 
 	std::vector<std::string> extensions{};
 
+#ifndef TRAP_HEADLESS_MODE
 	const auto reqExt = INTERNAL::WindowingAPI::GetRequiredInstanceExtensions();
 
 	if(!VulkanInstance::IsExtensionSupported(std::get<0>(reqExt)) || !VulkanInstance::IsExtensionSupported(std::get<1>(reqExt)))
@@ -3038,6 +3040,7 @@ void TRAP::Graphics::API::VulkanRenderer::WaitIdle() const
 		extensions.push_back(std::get<0>(reqExt));
 		extensions.push_back(std::get<1>(reqExt));
 	}
+#endif /*TRAP_HEADLESS_MODE*/
 
 	//Vulkan 1.1 core
 	//VK_KHR_get_physical_device_properties2
@@ -3069,6 +3072,7 @@ void TRAP::Graphics::API::VulkanRenderer::WaitIdle() const
 #endif
 #endif
 
+#ifndef TRAP_HEADLESS_MODE
 	///HDR support (requires surface extension)
 	if (VulkanInstance::IsExtensionSupported(VK_KHR_SURFACE_EXTENSION_NAME) &&
 	    VulkanInstance::IsExtensionSupported(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME))
@@ -3076,6 +3080,7 @@ void TRAP::Graphics::API::VulkanRenderer::WaitIdle() const
 		extensions.emplace_back(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME);
 		s_swapchainColorSpaceExtension = true;
 	}
+#endif /*TRAP_HEADLESS_MODE*/
 
 	return extensions;
 }
@@ -3088,6 +3093,7 @@ void TRAP::Graphics::API::VulkanRenderer::WaitIdle() const
 
 	std::vector<std::string> extensions{};
 
+#ifndef TRAP_HEADLESS_MODE
 	if(physicalDevice->IsExtensionSupported(VK_KHR_SWAPCHAIN_EXTENSION_NAME))
 		extensions.emplace_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 	else
@@ -3098,6 +3104,7 @@ void TRAP::Graphics::API::VulkanRenderer::WaitIdle() const
 		TP_CRITICAL(Log::RendererVulkanPrefix, "Mandatory Vulkan swapchain extension is unsupported! (0x0004)");
 		exit(0x0004);
 	}
+#endif /*TRAP_HEADLESS_MODE*/
 
 	//Vulkan 1.1 core
 	//VK_KHR_maintenance1

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.cpp
@@ -2746,7 +2746,7 @@ void TRAP::Graphics::API::VulkanRenderer::SetLatencyMode([[maybe_unused]] const 
 #ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::API::VulkanRenderer::InitPerViewportData(Window* const window) const
 #else
-void TRAP::Graphics::API::VulkanRenderer::InitPerViewportData() const
+void TRAP::Graphics::API::VulkanRenderer::InitPerViewportData(const uint32_t width, const uint32_t height) const
 #endif /*TRAP_HEADLESS_MODE*/
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Vulkan);
@@ -2769,6 +2769,9 @@ void TRAP::Graphics::API::VulkanRenderer::InitPerViewportData() const
 
 #ifndef TRAP_HEADLESS_MODE
 	p->Window = window;
+#else
+	p->NewWidth = width;
+	p->NewHeight = height;
 #endif /*TRAP_HEADLESS_MODE*/
 
 	p->GraphicsFrameTime = 0.0f;

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -208,6 +208,14 @@ namespace TRAP::Graphics::API
 		/// <param name="height">New height.</param>
 		void SetResolution(uint32_t width, uint32_t height) const override;
 #endif
+#ifdef TRAP_HEADLESS_MODE
+		/// <summary>
+		/// Get the resolution of the render targets.
+		/// </summary>
+		/// <param name="width">Output: Width.</param>
+		/// <param name="height">Output: Height.</param>
+		void GetResolution(uint32_t& width, uint32_t& height) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable depth testing for the given window.

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -63,6 +63,7 @@ namespace TRAP::Graphics::API
 		/// <param name="gameName">Name of the game.</param>
 		void InitInternal(std::string_view gameName) override;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Flush renderer for the given window.
 		///
@@ -71,18 +72,39 @@ namespace TRAP::Graphics::API
 		/// 3. Presents the rendered image to the screen.
 		/// 4. Starts graphics and compute recording for the next frame.
 		/// </summary>
-		/// <param name="window">Window to present.</param>
+		/// <param name="window">Window to flush.</param>
 		void Flush(const Window* window) const override;
+#else
+		/// <summary>
+		/// Flush renderer.
+		///
+		/// 1. Stops graphics and compute recording.
+		/// 2. Submits the graphics and compute commands.
+		/// 3. Starts graphics and compute recording for the next frame.
+		/// </summary>
+		void Flush() const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Dispatch to the given window.
 		/// </summary>
 		/// <param name="workGroupElements">
-		/// Amount of elements for each work group.
-		/// These values will be divided by the shader's work group size and rounded up.
+		/// Number of elements to dispatch for each dimension.
+		/// The elements are automatically divided by the number of threads in the work group and rounded up.
 		/// </param>
 		/// <param name="window">Window to Dispatch.</param>
 		void Dispatch(std::array<uint32_t, 3> workGroupElements, const Window* window) const override;
+#else
+		/// <summary>
+		/// Dispatch.
+		/// </summary>
+		/// <param name="workGroupElements">
+		/// Number of elements to dispatch for each dimension.
+		/// The elements are automatically divided by the number of threads in the work group and rounded up.
+		/// </param>
+		void Dispatch(std::array<uint32_t, 3> workGroupElements) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 		//TODO DispatchIndirect
 
 #ifndef TRAP_HEADLESS_MODE
@@ -105,6 +127,7 @@ namespace TRAP::Graphics::API
 		void SetReflexFPSLimit(uint32_t limit) override;
 #endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the render scale for the given window.
 		/// Note: This functon takes effect on the next frame.
@@ -112,59 +135,122 @@ namespace TRAP::Graphics::API
 		/// <param name="scale">Render scale value (valid range: 0.5f-1.0f inclusive).</param>
 		/// <param name="window">Window to set render scale for.</param>
 		void SetRenderScale(float scale, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the render scale.
+		/// Note: This functon takes effect on the next frame.
+		/// </summary>
+		/// <param name="scale">Render scale value (valid range: 0.5f-1.0f inclusive).</param>
+		void SetRenderScale(float scale) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the used render scale value of the given window.
 		/// </summary>
 		/// <param name="window">Window to retrieve render scale from.</param>
 		/// <returns>Render scale (between 0.5f and 2.0f inclusive).</returns>
-		float GetRenderScale(const Window* window) const override;
+		[[nodiscard]] float GetRenderScale(const Window* window) const override;
+#else
+		/// <summary>
+		/// Retrieve the used render scale value.
+		/// </summary>
+		/// <returns>Render scale (between 0.5f and 2.0f inclusive).</returns>
+		[[nodiscard]] float GetRenderScale() const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clear color to be used by the given window.
 		/// </summary>
 		/// <param name="color">New clear color.</param>
 		/// <param name="window">Window to set clear color for.</param>
-		void SetClearColor(const RendererAPI::Color& color, const Window* window) const override;
+		void SetClearColor(const Color& color /*= { 0.1f, 0.1f, 0.1f, 1.0f }*/,
+		                   const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the clear color.
+		/// </summary>
+		/// <param name="color">New clear color.</param>
+		void SetClearColor(const Color& color /*= { 0.1f, 0.1f, 0.1f, 1.0f }*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clear depth value to be used by the given window.
 		/// </summary>
 		/// <param name="depth">New clear depth value. Must be between 0.0f and 1.0f</param>
 		/// <param name="window">Window to set clear depth value for.</param>
-		void SetClearDepth(float depth, const Window* window) const override;
+		void SetClearDepth(float depth /*= 0.0f*/, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the clear depth value.
+		/// </summary>
+		/// <param name="depth">New clear depth value. Must be between 0.0f and 1.0f</param>
+		void SetClearDepth(float depth /*= 0.0f*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clear stencil value to be used by the given window.
 		/// </summary>
 		/// <param name="stencil">New clear stencil value.</param>
 		/// <param name="window">Window to set clear stencil value for.</param>
-		void SetClearStencil(uint32_t stencil, const Window* window) const override;
+		void SetClearStencil(uint32_t stencil /*= 0*/, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the clear stencil value.
+		/// </summary>
+		/// <param name="stencil">New clear stencil value.</param>
+		void SetClearStencil(uint32_t stencil /*= 0*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 #ifdef TRAP_HEADLESS_MODE
 		/// <summary>
-		/// Set the resolution of the render targets used by the given window.
-		///
-		/// Note: This function is only available in Headless mode.
+		/// Set the resolution of the render targets.
 		/// </summary>
 		/// <param name="width">New width.</param>
 		/// <param name="height">New height.</param>
-		/// <param name="window">Window to set resolution for.</param>
-		void SetResolution(uint32_t width, uint32_t height, const Window* window) const override;
+		void SetResolution(uint32_t width, uint32_t height) const override;
 #endif
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable depth testing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth testing.</param>
 		/// <param name="window">Window to set depth testing for.</param>
 		void SetDepthTesting(bool enabled, const Window* window) const override;
+#else
+		/// <summary>
+		/// Enable or disable depth testing.
+		/// </summary>
+		/// <param name="enabled">Enable or disable depth testing.</param>
+		void SetDepthTesting(bool enabled) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable depth writing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth writing.</param>
 		/// <param name="window">Window to set depth writing for.</param>
 		void SetDepthWriting(bool enabled, const Window* window) const override;
+#else
+		/// <summary>
+		/// Enable or disable depth writing.
+		/// </summary>
+		/// <param name="enabled">Enable or disable depth writing.</param>
+		void SetDepthWriting(bool enabled) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the depth function for the given window.
 		/// </summary>
 		/// <param name="function">Function to use for depth testing.</param>
 		/// <param name="window">Window to set depth function for.</param>
 		void SetDepthFunction(CompareMode function, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the depth function.
+		/// </summary>
+		/// <param name="function">Function to use for depth testing.</param>
+		void SetDepthFunction(CompareMode function) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the depth action to perform when depth testing fails for the given window.
 		/// </summary>
@@ -172,24 +258,57 @@ namespace TRAP::Graphics::API
 		/// <param name="back">Depth action to perform when depth testing fails.</param>
 		/// <param name="window">Window to set the depth fail action for.</param>
 		void SetDepthFail(StencilOp front, StencilOp back, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the depth action to perform when depth testing fails.
+		/// </summary>
+		/// <param name="front">Depth action to perform when depth testing fails.</param>
+		/// <param name="back">Depth action to perform when depth testing fails.</param>
+		void SetDepthFail(StencilOp front, StencilOp back) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the depth bias (scalar factor to add to each fragments depth value) for the given window.
 		/// </summary>
 		/// <param name="depthBias">Depth bias.</param>
 		/// <param name="window">Window to set the depth bias for.</param>
 		void SetDepthBias(int32_t depthBias, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the depth bias (scalar factor to add to each fragments depth value).
+		/// </summary>
+		/// <param name="depthBias">Depth bias.</param>
+		void SetDepthBias(int32_t depthBias) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the depth bias slope factor (scalar factor applied to fragment's slope in depth bias calculation) for the given window.
 		/// </summary>
 		/// <param name="factor">Depth bias slope factor.</param>
 		/// <param name="window">Window to set the depth bias slope factor for.</param>
 		void SetDepthBiasSlopeFactor(float factor, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the depth bias slope factor (scalar factor applied to fragment's slope in depth bias calculation).
+		/// </summary>
+		/// <param name="factor">Depth bias slope factor.</param>
+		void SetDepthBiasSlopeFactor(float factor) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable stencil testing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable stencil testing.</param>
 		/// <param name="window">Window to set stencil testing for.</param>
 		void SetStencilTesting(bool enabled, const Window* window) const override;
+#else
+		/// <summary>
+		/// Enable or disable stencil testing.
+		/// </summary>
+		/// <param name="enabled">Enable or disable stencil testing.</param>
+		void SetStencilTesting(bool enabled) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the stencil action to perform when stencil testing fails for the given window.
 		/// </summary>
@@ -197,6 +316,15 @@ namespace TRAP::Graphics::API
 		/// <param name="back">Stencil action to perform when stencil testing fails.</param>
 		/// <param name="window">Window to set the stencil fail action for.</param>
 		void SetStencilFail(StencilOp front, StencilOp back, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the stencil action to perform when stencil testing fails.
+		/// </summary>
+		/// <param name="front">Stencil action to perform when stencil testing fails.</param>
+		/// <param name="back">Stencil action to perform when stencil testing fails.</param>
+		void SetStencilFail(StencilOp front, StencilOp back) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the stencil action to perform when stencil testing and depth testing passes for the given window.
 		/// </summary>
@@ -204,6 +332,15 @@ namespace TRAP::Graphics::API
 		/// <param name="back">Stencil action to perform when passed.</param>
 		/// <param name="window">Window to set the stencil pass action for.</param>
 		void SetStencilPass(StencilOp front, StencilOp back, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the stencil action to perform when stencil testing and depth testing passes.
+		/// </summary>
+		/// <param name="front">Stencil action to perform when passed.</param>
+		/// <param name="back">Stencil action to perform when passed.</param>
+		void SetStencilPass(StencilOp front, StencilOp back) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the stencil functions for the given window.
 		/// </summary>
@@ -211,6 +348,15 @@ namespace TRAP::Graphics::API
 		/// <param name="back">Function to use on the back for stencil testing.</param>
 		/// <param name="window">Window to set stencil functions for.</param>
 		void SetStencilFunction(CompareMode front, CompareMode back, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the stencil functions.
+		/// </summary>
+		/// <param name="front">Function to use on the front for stencil testing.</param>
+		/// <param name="back">Function to use on the back for stencil testing.</param>
+		void SetStencilFunction(CompareMode front, CompareMode back) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the stencil mask for the given window.
 		/// </summary>
@@ -218,30 +364,71 @@ namespace TRAP::Graphics::API
 		/// <param name="write">Select the bits of the stencil values updated by the stencil test.</param>
 		/// <param name="window">Window to set stencil mask for.</param>
 		void SetStencilMask(uint8_t read, uint8_t write, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the stencil mask.
+		/// </summary>
+		/// <param name="read">Select the bits of the stencil values to test.</param>
+		/// <param name="write">Select the bits of the stencil values updated by the stencil test.</param>
+		void SetStencilMask(uint8_t read, uint8_t write) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the cull mode for the given window.
 		/// </summary>
 		/// <param name="mode">Cull mode to use.</param>
 		/// <param name="window">Window to set cull mode for.</param>
 		void SetCullMode(CullMode mode, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the cull mode.
+		/// </summary>
+		/// <param name="mode">Cull mode to use.</param>
+		void SetCullMode(CullMode mode) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the fill mode for the given window.
 		/// </summary>
 		/// <param name="mode">Fill mode to use.</param>
 		/// <param name="window">Window to set fill mode for.</param>
 		void SetFillMode(FillMode mode, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the fill mode.
+		/// </summary>
+		/// <param name="mode">Fill mode to use.</param>
+		void SetFillMode(FillMode mode) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the primitive topology for the given window.
 		/// </summary>
 		/// <param name="topology">Primitive topology to use.</param>
 		/// <param name="window">Window to set primitive topology for.</param>
 		void SetPrimitiveTopology(PrimitiveTopology topology, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the primitive topology.
+		/// </summary>
+		/// <param name="topology">Primitive topology to use.</param>
+		void SetPrimitiveTopology(PrimitiveTopology topology) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the front face winding order for the given window.
 		/// </summary>
 		/// <param name="face">Front face winding order to use.</param>
 		/// <param name="window">Window to set front face winding order for.</param>
 		void SetFrontFace(FrontFace face, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the front face winding order.
+		/// </summary>
+		/// <param name="face">Front face winding order to use.</param>
+		void SetFrontFace(FrontFace face) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the blend mode for the given window.
 		/// </summary>
@@ -249,6 +436,15 @@ namespace TRAP::Graphics::API
 		/// <param name="modeAlpha">Blend mode to use for the alpha channel.</param>
 		/// <param name="window">Window to set the blend mode for.</param>
 		void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the blend mode.
+		/// </summary>
+		/// <param name="modeRGB">Blend mode to use for the RGB channels.</param>
+		/// <param name="modeAlpha">Blend mode to use for the alpha channel.</param>
+		void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the blend constants/factors for the given window.
 		/// </summary>
@@ -258,8 +454,20 @@ namespace TRAP::Graphics::API
 		/// <param name="destinationAlpha">Specified how the alpha destination blending factor is computed.</param>
 		/// <param name="window">Window to set the blend constants for.</param>
 		void SetBlendConstant(BlendConstant sourceRGB, BlendConstant sourceAlpha,
-							  BlendConstant destinationRGB, BlendConstant destinationAlpha,
+			                  BlendConstant destinationRGB, BlendConstant destinationAlpha,
 							  const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the blend constants/factors.
+		/// </summary>
+		/// <param name="sourceRGB">Specifies how the red, green, and blue blending factors are computed.</param>
+		/// <param name="sourceAlpha">Specifies how the alpha source blending factor is computed.</param>
+		/// <param name="destinationRGB">Specifies how the red, green, and blue destination blending factors are computed.</param>
+		/// <param name="destinationAlpha">Specified how the alpha destination blending factor is computed.</param>
+		void SetBlendConstant(BlendConstant sourceRGB, BlendConstant sourceAlpha,
+			                  BlendConstant destinationRGB, BlendConstant destinationAlpha) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the pipeline fragment shading rate and combiner operation for the command buffer.
 		/// </summary>
@@ -268,9 +476,21 @@ namespace TRAP::Graphics::API
 		/// <param name="finalRate">Shading rate combiner to use.</param>
 		/// <param name="window">Window to set the shading rate for.</param>
 		void SetShadingRate(ShadingRate shadingRate,
-							ShadingRateCombiner postRasterizerRate,
+		                    ShadingRateCombiner postRasterizerRate,
 							ShadingRateCombiner finalRate, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the pipeline fragment shading rate and combiner operation for the command buffer.
+		/// </summary>
+		/// <param name="shadingRate">Shading rate to use.</param>
+		/// <param name="postRasterizerRate">Shading rate combiner to use.</param>
+		/// <param name="finalRate">Shading rate combiner to use.</param>
+		void SetShadingRate(ShadingRate shadingRate,
+		                    ShadingRateCombiner postRasterizerRate,
+							ShadingRateCombiner finalRate) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 		//TODO EXPERIMENTAL
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the pipeline fragment shading rate via texture.
 		/// </summary>
@@ -280,14 +500,33 @@ namespace TRAP::Graphics::API
 		/// </param>
 		/// <param name="window">Window to set shading rate for.</param>
 		void SetShadingRate(Ref<RenderTarget> texture, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set the pipeline fragment shading rate via texture.
+		/// </summary>
+		/// <param name="texture">
+		/// Shading rate texture to use.
+		/// Note: The texture must be in ResourceState::ShadingRateSource.
+		/// </param>
+		void SetShadingRate(Ref<RenderTarget> texture) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Clear the given window's render target.
 		/// </summary>
 		/// <param name="clearType">Type of buffer to clear.</param>
 		/// <param name="window">Window to clear.</param>
 		void Clear(ClearBufferType clearType, const Window* window) const override;
+#else
+		/// <summary>
+		/// Clear the given render target.
+		/// </summary>
+		/// <param name="clearType">Type of buffer to clear.</param>
+		void Clear(ClearBufferType clearType) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set viewport size for the given window.
 		/// </summary>
@@ -295,11 +534,25 @@ namespace TRAP::Graphics::API
 		/// <param name="y">Y coordinate of the top left corner of the viewport.</param>
 		/// <param name="width">New viewport width.</param>
 		/// <param name="height">New viewport height.</param>
-		/// <param name="minDepth">New min depth value.</param>
-		/// <param name="maxDepth">New max depth value.</param>
+		/// <param name="minDepth">New min depth value. Default: 0.0f.</param>
+		/// <param name="maxDepth">New max depth value. Default: 1.0f.</param>
 		/// <param name="window">Window to set viewport for.</param>
-		void SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height, float minDepth,
-		                 float maxDepth, const Window* window) const override;
+		void SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height, float minDepth /*= 0.0f*/,
+		                 float maxDepth /*= 1.0f*/, const Window* window) const override;
+#else
+		/// <summary>
+		/// Set viewport size.
+		/// </summary>
+		/// <param name="x">X coordinate of the top left corner of the viewport.</param>
+		/// <param name="y">Y coordinate of the top left corner of the viewport.</param>
+		/// <param name="width">New viewport width.</param>
+		/// <param name="height">New viewport height.</param>
+		/// <param name="minDepth">New min depth value. Default: 0.0f.</param>
+		/// <param name="maxDepth">New max depth value. Default: 1.0f.</param>
+		void SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height, float minDepth /*= 0.0f*/,
+		                 float maxDepth /*= 1.0f*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set scissor size for the given window.
 		/// </summary>
@@ -308,53 +561,118 @@ namespace TRAP::Graphics::API
 		/// <param name="width">New scissor width.</param>
 		/// <param name="height">New scissor height.</param>
 		/// <param name="window">Window to set scissor size for.</param>
-		void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height, const Window* window) const override;
+		void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height,
+		                const Window* window) const override;
+#else
+		/// <summary>
+		/// Set scissor size.
+		/// </summary>
+		/// <param name="x">Upper left corner.</param>
+		/// <param name="y">Upper left corner.</param>
+		/// <param name="width">New scissor width.</param>
+		/// <param name="height">New scissor height.</param>
+		void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw non-indexed, non-instanced geometry for the given window.
 		/// </summary>
 		/// <param name="vertexCount">Number of vertices to draw.</param>
-		/// <param name="firstVertex">Index of the first vertex to draw.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for.</param>
-		void Draw(uint32_t vertexCount, uint32_t firstVertex, const Window* window) const override;
+		void Draw(uint32_t vertexCount, uint32_t firstVertex /*= 0*/, const Window* window) const override;
+#else
+		/// <summary>
+		/// Draw non-indexed, non-instanced geometry.
+		/// </summary>
+		/// <param name="vertexCount">Number of vertices to draw.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		void Draw(uint32_t vertexCount, uint32_t firstVertex /*= 0*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw indexed, non-instanced geometry for the given window.
 		/// </summary>
 		/// <param name="indexCount">Number of indices to draw.</param>
-		/// <param name="firstIndex">Index of the first indice to draw.</param>
-		/// <param name="firstVertex">Index of the first vertex to draw.</param>
+		/// <param name="firstIndex">Index of the first indice to draw. Default: 0.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for.</param>
-		void DrawIndexed(uint32_t indexCount, uint32_t firstIndex, uint32_t firstVertex,
+		void DrawIndexed(uint32_t indexCount, uint32_t firstIndex /*= 0*/, uint32_t firstVertex /*= 0*/,
 		                 const Window* window) const override;
+#else
+		/// <summary>
+		/// Draw indexed, non-instanced geometry.
+		/// </summary>
+		/// <param name="indexCount">Number of indices to draw.</param>
+		/// <param name="firstIndex">Index of the first indice to draw. Default: 0.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		void DrawIndexed(uint32_t indexCount, uint32_t firstIndex /*= 0*/, uint32_t firstVertex /*= 0*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw non-indexed, instanced geometry for the given window.
 		/// </summary>
 		/// <param name="vertexCount">Number of vertices to draw.</param>
 		/// <param name="instanceCount">Number of instances to draw.</param>
-		/// <param name="firstVertex">Index of the first vertex to draw.</param>
-		/// <param name="firstInstance">Index of the first instance to draw.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for.</param>
-		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
-		                   uint32_t firstInstance, const Window* window) const override;
+		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex /*= 0*/,
+		                   uint32_t firstInstance /*= 0*/, const Window* window) const override;
+#else
+		/// <summary>
+		/// Draw non-indexed, instanced geometry.
+		/// </summary>
+		/// <param name="vertexCount">Number of vertices to draw.</param>
+		/// <param name="instanceCount">Number of instances to draw.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
+		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex /*= 0*/,
+		                   uint32_t firstInstance /*= 0*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw indexed, instanced geometry for the given window.
 		/// </summary>
 		/// <param name="indexCount">Number of indices to draw.</param>
 		/// <param name="instanceCount">Number of instances to draw.</param>
-		/// <param name="firstIndex">Index of the first indice to draw.</param>
-		/// <param name="firstInstance">Index of the first instance to draw.</param>
-		/// <param name="firstVertex">Index of the first vertex to draw.</param>
+		/// <param name="firstIndex">Index of the first indice to draw. Default: 0.</param>
+		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
 		/// <param name="window">Window to draw for.</param>
 		void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
-		                          uint32_t firstIndex, uint32_t firstInstance,
-							      uint32_t firstVertex, const Window* window) const override;
+		                          uint32_t firstIndex /*= 0*/, uint32_t firstInstance /*= 0*/,
+								  uint32_t firstVertex /*= 0*/, const Window* window) const override;
+#else
+		/// <summary>
+		/// Draw indexed, instanced geometry.
+		/// </summary>
+		/// <param name="indexCount">Number of indices to draw.</param>
+		/// <param name="instanceCount">Number of instances to draw.</param>
+		/// <param name="firstIndex">Index of the first indice to draw. Default: 0.</param>
+		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+		                          uint32_t firstIndex /*= 0*/, uint32_t firstInstance /*= 0*/,
+								  uint32_t firstVertex /*= 0*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind shader on the given window.
 		/// </summary>
 		/// <param name="shader">Shader to bind.</param>
 		/// <param name="window">Window to bind the shader for.</param>
 		void BindShader(Shader* shader, const Window* window) const;
+#else
+		/// <summary>
+		/// Bind shader on the given window.
+		/// </summary>
+		/// <param name="shader">Shader to bind.</param>
+		void BindShader(Shader* shader) const;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind vertex buffer on the given window.
 		/// </summary>
@@ -363,6 +681,15 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to bind the vertex buffer for.</param>
 		void BindVertexBuffer(const TRAP::Ref<Buffer>& vBuffer, const VertexBufferLayout& layout,
 		                      const Window* window) const override;
+#else
+		/// <summary>
+		/// Bind vertex buffer.
+		/// </summary>
+		/// <param name="vBuffer">Vertex buffer to bind.</param>
+		/// <param name="layout">Layout of the vertex buffer.</param>
+		void BindVertexBuffer(const TRAP::Ref<Buffer>& vBuffer, const VertexBufferLayout& layout) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind an index buffer on the given window.
 		/// </summary>
@@ -371,14 +698,36 @@ namespace TRAP::Graphics::API
 		/// <param name="window">Window to bind the vertex buffer for.</param>
 		void BindIndexBuffer(const TRAP::Ref<Buffer>& iBuffer, IndexType indexType,
 		                     const Window* window) const override;
+#else
+		/// <summary>
+		/// Bind an index buffer.
+		/// </summary>
+		/// <param name="iBuffer">Index buffer to bind.</param>
+		/// <param name="indexType">Data type used by the index buffer.</param>
+		void BindIndexBuffer(const TRAP::Ref<Buffer>& iBuffer, IndexType indexType) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind a descriptor set on the given window.
 		/// </summary>
 		/// <param name="dSet">Descriptor set to bind.</param>
 		/// <param name="index">Index for which descriptor set to bind.</param>
-		/// <param name="queueType">Queue type on which to perform the bind operation.</param>
+		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
 		/// <param name="window">Window to bind the descriptor set for.</param>
-		void BindDescriptorSet(DescriptorSet& dSet, uint32_t index, QueueType queueType, const Window* window) const override;
+		void BindDescriptorSet(DescriptorSet& dSet, uint32_t index,
+		                       QueueType queueType /*= QueueType::Graphics*/,
+							   const Window* window) const override;
+#else
+		/// <summary>
+		/// Bind a descriptor set.
+		/// </summary>
+		/// <param name="dSet">Descriptor set to bind.</param>
+		/// <param name="index">Index for which descriptor set to bind.</param>
+		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
+		void BindDescriptorSet(DescriptorSet& dSet, uint32_t index,
+		                       QueueType queueType /*= QueueType::Graphics*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind push constant buffer data on the given window.
 		/// Note: There is an optimized function which uses the index into the RootSignature
@@ -386,105 +735,233 @@ namespace TRAP::Graphics::API
 		/// </summary>
 		/// <param name="name">Name of the push constant block.</param>
 		/// <param name="constantsData">Pointer to the constant buffer data.</param>
-		/// <param name="queueType">Queue type on which to perform the bind operation.</param>
+		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
 		/// <param name="window">Window to bind the push constants for.</param>
-		void BindPushConstants(const char* name, const void* constantsData, QueueType queueType, const Window* window) const override;
+		void BindPushConstants(const char* name, const void* constantsData,
+		                       QueueType queueType /*= QueueType::Graphics*/,
+							   const Window* window) const override;
+#else
+		/// <summary>
+		/// Bind push constant buffer data.
+		/// Note: There is an optimized function which uses the index into the RootSignature
+		///       instead of the name of the push constant block.
+		/// </summary>
+		/// <param name="name">Name of the push constant block.</param>
+		/// <param name="constantsData">Pointer to the constant buffer data.</param>
+		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
+		void BindPushConstants(const char* name, const void* constantsData,
+		                       QueueType queueType /*= QueueType::Graphics*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind push constant buffer data on the given window.
 		/// </summary>
 		/// <param name="paramIndex">Index of the push constant block in the RootSignatures descriptors array.</param>
 		/// <param name="constantsData">Pointer to the constant buffer data.</param>
-		/// <param name="queueType">Queue type on which to perform the bind operation.</param>
+		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
 		/// <param name="window">Window to bind the push constants for.</param>
-		void BindPushConstantsByIndex(uint32_t paramIndex, const void* constantsData, QueueType queueType,
-		                              const Window* window) const override;
+		void BindPushConstantsByIndex(uint32_t paramIndex, const void* constantsData,
+									  QueueType queueType /*= QueueType::Graphics*/,
+									  const Window* window) const override;
+#else
+		/// <summary>
+		/// Bind push constant buffer data.
+		/// </summary>
+		/// <param name="paramIndex">Index of the push constant block in the RootSignatures descriptors array.</param>
+		/// <param name="constantsData">Pointer to the constant buffer data.</param>
+		/// <param name="queueType">Queue type on which to perform the bind operation. Default: Graphics.</param>
+		void BindPushConstantsByIndex(uint32_t paramIndex, const void* constantsData,
+									  QueueType queueType /*= QueueType::Graphics*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind render target(s) on the given window.
 		///
 		/// Note: This functions ends the currently running render pass and starts a new one.
 		/// </summary>
 		/// <param name="colorTarget">Color render target to bind.</param>
-		/// <param name="depthStencil">Optional depth stencil target to bind.</param>
-		/// <param name="loadActions">Optional load actions for each render target.</param>
-		/// <param name="colorArraySlices">Optional color array slices for each render target.</param>
-		/// <param name="colorMipSlices">Optional color mip slices for each render target.</param>
-		/// <param name="depthArraySlice">Optional depth array slice for the depth stencil target.</param>
-		/// <param name="depthMipSlice">Optional depth mip slice for the depth stencil target.</param>
+		/// <param name="depthStencil">Optional depth stencil target to bind. Default: nullptr.</param>
+		/// <param name="loadActions">Optional load actions for each render target. Default: nullptr.</param>
+		/// <param name="colorArraySlices">Optional color array slices for each render target. Default: nullptr.</param>
+		/// <param name="colorMipSlices">Optional color mip slices for each render target. Default: nullptr.</param>
+		/// <param name="depthArraySlice">Optional depth array slice for the depth stencil target. Default: -1.</param>
+		/// <param name="depthMipSlice">Optional depth mip slice for the depth stencil target. Default: -1.</param>
 		/// <param name="window">Window to bind the render target(s) for.</param>
 		void BindRenderTarget(const TRAP::Ref<Graphics::RenderTarget>& colorTarget,
-		                      const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
-							  const RendererAPI::LoadActionsDesc* loadActions,
-							  std::vector<uint32_t>* colorArraySlices,
-							  std::vector<uint32_t>* colorMipSlices,
-							  uint32_t depthArraySlice, uint32_t depthMipSlice,
+		                      const TRAP::Ref<Graphics::RenderTarget>& depthStencil /*= nullptr*/,
+							  const RendererAPI::LoadActionsDesc* loadActions /*= nullptr*/,
+							  std::vector<uint32_t>* colorArraySlices /*= nullptr*/,
+							  std::vector<uint32_t>* colorMipSlices /*= nullptr*/,
+							  uint32_t depthArraySlice /*= -1*/, uint32_t depthMipSlice /*= -1*/,
 							  const Window* window) const override;
+#else
+		/// <summary>
+		/// Bind render target(s).
+		///
+		/// Note: This functions ends the currently running render pass and starts a new one.
+		/// </summary>
+		/// <param name="colorTarget">Color render target to bind.</param>
+		/// <param name="depthStencil">Optional depth stencil target to bind. Default: nullptr.</param>
+		/// <param name="loadActions">Optional load actions for each render target. Default: nullptr.</param>
+		/// <param name="colorArraySlices">Optional color array slices for each render target. Default: nullptr.</param>
+		/// <param name="colorMipSlices">Optional color mip slices for each render target. Default: nullptr.</param>
+		/// <param name="depthArraySlice">Optional depth array slice for the depth stencil target. Default: -1.</param>
+		/// <param name="depthMipSlice">Optional depth mip slice for the depth stencil target. Default: -1.</param>
+		void BindRenderTarget(const TRAP::Ref<Graphics::RenderTarget>& colorTarget,
+		                      const TRAP::Ref<Graphics::RenderTarget>& depthStencil /*= nullptr*/,
+							  const RendererAPI::LoadActionsDesc* loadActions /*= nullptr*/,
+							  std::vector<uint32_t>* colorArraySlices /*= nullptr*/,
+							  std::vector<uint32_t>* colorMipSlices /*= nullptr*/,
+							  uint32_t depthArraySlice /*= -1*/, uint32_t depthMipSlice /*= -1*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Bind render target(s) on the given window.
 		///
 		/// Note: This functions ends the currently running render pass and starts a new one.
 		/// </summary>
 		/// <param name="colorTargets">Color render target(s) to bind.</param>
-		/// <param name="depthStencil">Optional depth stencil target to bind.</param>
-		/// <param name="loadActions">Optional load actions for each render target.</param>
-		/// <param name="colorArraySlices">Optional color array slices for each render target.</param>
-		/// <param name="colorMipSlices">Optional color mip slices for each render target.</param>
-		/// <param name="depthArraySlice">Optional depth array slice for the depth stencil target.</param>
-		/// <param name="depthMipSlice">Optional depth mip slice for the depth stencil target.</param>
+		/// <param name="depthStencil">Optional depth stencil target to bind. Default: nullptr.</param>
+		/// <param name="loadActions">Optional load actions for each render target. Default: nullptr.</param>
+		/// <param name="colorArraySlices">Optional color array slices for each render target. Default: nullptr.</param>
+		/// <param name="colorMipSlices">Optional color mip slices for each render target. Default: nullptr.</param>
+		/// <param name="depthArraySlice">Optional depth array slice for the depth stencil target. Default: -1.</param>
+		/// <param name="depthMipSlice">Optional depth mip slice for the depth stencil target. Default: -1.</param>
 		/// <param name="window">Window to bind the render target(s) for.</param>
 		void BindRenderTargets(const std::vector<TRAP::Ref<Graphics::RenderTarget>>& colorTargets,
-		                       const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
-							   const RendererAPI::LoadActionsDesc* loadActions,
-							   std::vector<uint32_t>* colorArraySlices,
-							   std::vector<uint32_t>* colorMipSlices,
-							   uint32_t depthArraySlice, uint32_t depthMipSlice,
+		                       const TRAP::Ref<Graphics::RenderTarget>& depthStencil /*= nullptr*/,
+							   const RendererAPI::LoadActionsDesc* loadActions /*= nullptr*/,
+							   std::vector<uint32_t>* colorArraySlices /*= nullptr*/,
+							   std::vector<uint32_t>* colorMipSlices /*= nullptr*/,
+							   uint32_t depthArraySlice /*= -1*/, uint32_t depthMipSlice /*= -1*/,
 							   const Window* window) const override;
+#else
+		/// <summary>
+		/// Bind render target(s).
+		///
+		/// Note: This functions ends the currently running render pass and starts a new one.
+		/// </summary>
+		/// <param name="colorTargets">Color render target(s) to bind.</param>
+		/// <param name="depthStencil">Optional depth stencil target to bind. Default: nullptr.</param>
+		/// <param name="loadActions">Optional load actions for each render target. Default: nullptr.</param>
+		/// <param name="colorArraySlices">Optional color array slices for each render target. Default: nullptr.</param>
+		/// <param name="colorMipSlices">Optional color mip slices for each render target. Default: nullptr.</param>
+		/// <param name="depthArraySlice">Optional depth array slice for the depth stencil target. Default: -1.</param>
+		/// <param name="depthMipSlice">Optional depth mip slice for the depth stencil target. Default: -1.</param>
+		void BindRenderTargets(const std::vector<TRAP::Ref<Graphics::RenderTarget>>& colorTargets,
+		                       const TRAP::Ref<Graphics::RenderTarget>& depthStencil /*= nullptr*/,
+							   const RendererAPI::LoadActionsDesc* loadActions /*= nullptr*/,
+							   std::vector<uint32_t>* colorArraySlices /*= nullptr*/,
+							   std::vector<uint32_t>* colorMipSlices /*= nullptr*/,
+							   uint32_t depthArraySlice /*= -1*/, uint32_t depthMipSlice /*= -1*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
 		/// <param name="bufferBarrier">Buffer barrier.</param>
-		/// <param name="queueType">Queue type on which to perform the barrier operation.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
 		/// <param name="window">Window to add the barrier for.</param>
-		void ResourceBufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier, QueueType queueType,
-		                           const Window* window) const override;
+		void ResourceBufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
+								   QueueType queueType /*= QueueType::Graphics*/,
+								   const Window* window) const override;
+#else
+		/// <summary>
+		/// Add a resource barrier (memory dependency).
+		/// </summary>
+		/// <param name="bufferBarrier">Buffer barrier.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		void ResourceBufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
+								   QueueType queueType /*= QueueType::Graphics*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
 		/// <param name="bufferBarriers">Buffer barriers.</param>
-		/// <param name="queueType">Queue type on which to perform the barrier operation.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
 		/// <param name="window">Window to add the barriers for.</param>
 		void ResourceBufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
-									QueueType queueType, const Window* window) const override;
+									QueueType queueType /*= QueueType::Graphics*/,
+									const Window* window) const override;
+#else
+		/// <summary>
+		/// Add resource barriers (memory dependencies).
+		/// </summary>
+		/// <param name="bufferBarriers">Buffer barriers.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		void ResourceBufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
+									QueueType queueType /*= QueueType::Graphics*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
 		/// <param name="textureBarrier">Texture barrier.</param>
-		/// <param name="queueType">Queue type on which to perform the barrier operation.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
 		/// <param name="window">Window to add the barrier for.</param>
-		void ResourceTextureBarrier(const RendererAPI::TextureBarrier& textureBarrier, QueueType queueType,
-		                            const Window* window) const override;
+		void ResourceTextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
+									QueueType queueType /*= QueueType::Graphics*/,
+									const Window* window) const override;
+#else
+		/// <summary>
+		/// Add a resource barrier (memory dependency).
+		/// </summary>
+		/// <param name="textureBarrier">Texture barrier.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		void ResourceTextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
+									QueueType queueType /*= QueueType::Graphics*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
 		/// <param name="textureBarriers">Texture barriers.</param>
-		/// <param name="queueType">Queue type on which to perform the barrier operation.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
 		/// <param name="window">Window to add the barriers for.</param>
 		void ResourceTextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
-									 QueueType queueType, const Window* window) const override;
+									 QueueType queueType /*= QueueType::Graphics*/,
+									 const Window* window) const override;
+#else
+		/// <summary>
+		/// Add resource barriers (memory dependencies).
+		/// </summary>
+		/// <param name="textureBarriers">Texture barriers.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		void ResourceTextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
+									 QueueType queueType /*= QueueType::Graphics*/) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add a resource barrier (memory dependency) for the given window.
 		/// </summary>
 		/// <param name="renderTargetBarrier">Render target barrier.</param>
 		/// <param name="window">Window to add the barrier for.</param>
 		void ResourceRenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier,
-		                                 const Window* window) const override;
+									     const Window* window) const override;
+#else
+		/// <summary>
+		/// Add a resource barrier (memory dependency).
+		/// </summary>
+		/// <param name="renderTargetBarrier">Render target barrier.</param>
+		void ResourceRenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier) const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Add resource barriers (memory dependencies) for the given window.
 		/// </summary>
 		/// <param name="renderTargetBarriers">Render target barriers.</param>
 		/// <param name="window">Window to add the barriers for.</param>
 		void ResourceRenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers,
-								          const Window* window) const override;
+									      const Window* window) const override;
+#else
+		/// <summary>
+		/// Add resource barriers (memory dependencies).
+		/// </summary>
+		/// <param name="renderTargetBarriers">Render target barriers.</param>
+		void ResourceRenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>
@@ -544,12 +1021,20 @@ namespace TRAP::Graphics::API
 		/// <returns>List of all supported GPUs.</returns>
 		[[nodiscard]] std::vector<std::pair<std::string, std::array<uint8_t, 16>>> GetAllGPUs() const override;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Capture a screenshot of the last presented frame.
 		/// </summary>
 		/// <param name="window">Window to capture screenshot on.</param>
 		/// <returns>Captured screenshot as TRAP::Image on success, Black 1x1 TRAP::Image otherwise.</returns>
 		[[nodiscard]] TRAP::Scope<TRAP::Image> CaptureScreenshot(const Window* window) const override;
+#else
+		/// <summary>
+		/// Capture a screenshot of the last presented frame.
+		/// </summary>
+		/// <returns>Captured screenshot as TRAP::Image on success, Black 1x1 TRAP::Image otherwise.</returns>
+		[[nodiscard]] TRAP::Scope<TRAP::Image> CaptureScreenshot() const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Resolve a MSAA render target to a non MSAA render target.
@@ -566,9 +1051,10 @@ namespace TRAP::Graphics::API
 		/// <summary>
 		/// Update the internal RenderTargets used for render scaling.
 		/// </summary>
-		/// <param name="winData">PerViewportData to update.</param>
-		void UpdateInternalRenderTargets(PerViewportData* winData) const;
+		/// <param name="viewportData">PerViewportData to update.</param>
+		void UpdateInternalRenderTargets(PerViewportData* viewportData) const;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Scale image from internal resolution to the final output resolution.
 		///
@@ -578,8 +1064,19 @@ namespace TRAP::Graphics::API
 		/// <param name="destination">Destination render target to resolve into.</param>
 		/// <param name="window">Window to do the scaling pass on.</param>
 		void RenderScalePass(TRAP::Ref<RenderTarget> source,
-		                     TRAP::Ref<RenderTarget> destination,
+							 TRAP::Ref<RenderTarget> destination,
 		                     const Window* window) const override;
+#else
+		/// <summary>
+		/// Scale image from internal resolution to the final output resolution.
+		///
+		/// Note: source and destination must be in ResourceState::RenderTarget.
+		/// </summary>
+		/// <param name="source">Source render target to resolve.</param>
+		/// <param name="destination">Destination render target to resolve into.</param>
+		void RenderScalePass(TRAP::Ref<RenderTarget> source,
+							 TRAP::Ref<RenderTarget> destination) const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>
@@ -601,16 +1098,30 @@ namespace TRAP::Graphics::API
 		[[nodiscard]] LatencyMode GetLatencyMode(const Window* window) const override;
 #endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Initialize the internal rendering data of the given window.
 		/// </summary>
 		/// <param name="window">Window to initialize the internal rendering data for.</param>
 		void InitPerViewportData(Window* window) const override;
+#else
+		/// <summary>
+		/// Initialize the internal rendering data.
+		/// </summary>
+		void InitPerViewportData() const override;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Remove the internal rendering data of the given window.
 		/// </summary>
 		/// <param name="window">Window to remove the internal rendering data from.</param>
 		void RemovePerViewportData(const Window* window) const override;
+#else
+		/// <summary>
+		/// Remove the internal rendering data.
+		/// </summary>
+		void RemovePerViewportData() const override;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		void WaitIdle() const override;
 

--- a/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
+++ b/TRAP/src/Graphics/API/Vulkan/VulkanRenderer.h
@@ -1108,7 +1108,9 @@ namespace TRAP::Graphics::API
 		/// <summary>
 		/// Initialize the internal rendering data.
 		/// </summary>
-		void InitPerViewportData() const override;
+		/// <param name="width">Width for the viewport.</param>
+		/// <param name="height">Height for the viewport.</param>
+		void InitPerViewportData(uint32_t width, uint32_t height) const override;
 #endif /*TRAP_HEADLESS_MODE*/
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>

--- a/TRAP/src/Graphics/Buffers/IndexBuffer.cpp
+++ b/TRAP/src/Graphics/Buffers/IndexBuffer.cpp
@@ -99,12 +99,21 @@ void TRAP::Graphics::IndexBuffer::SetData(const uint32_t* const indices, const u
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::IndexBuffer::Use(const Window* const window) const
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
 
 	RendererAPI::GetRenderer()->BindIndexBuffer(m_indexBuffer, m_indexType, window);
 }
+#else
+void TRAP::Graphics::IndexBuffer::Use() const
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
+
+	RendererAPI::GetRenderer()->BindIndexBuffer(m_indexBuffer, m_indexType);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Graphics/Buffers/IndexBuffer.h
+++ b/TRAP/src/Graphics/Buffers/IndexBuffer.h
@@ -55,11 +55,18 @@ namespace TRAP::Graphics
 		/// <returns>Update frequency.</returns>
 		[[nodiscard]] UpdateFrequency GetUpdateFrequency() const noexcept;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use this buffer for rendering on the given window.
 		/// </summary>
 		/// <param name="window">Window to use index buffer on. Default: Main Window.</param>
 		void Use(const Window* window = TRAP::Application::GetWindow()) const;
+#else
+		/// <summary>
+		/// Use this buffer for rendering.
+		/// </summary>
+		void Use() const;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Update the buffers index data.

--- a/TRAP/src/Graphics/Buffers/VertexBuffer.cpp
+++ b/TRAP/src/Graphics/Buffers/VertexBuffer.cpp
@@ -88,12 +88,21 @@ void TRAP::Graphics::VertexBuffer::SetLayout(const VertexBufferLayout& layout)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::VertexBuffer::Use(const Window* const window) const
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
 
 	RendererAPI::GetRenderer()->BindVertexBuffer(m_vertexBuffer, m_bufferLayout, window);
 }
+#else
+void TRAP::Graphics::VertexBuffer::Use() const
+{
+	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
+
+	RendererAPI::GetRenderer()->BindVertexBuffer(m_vertexBuffer, m_bufferLayout);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Graphics/Buffers/VertexBuffer.h
+++ b/TRAP/src/Graphics/Buffers/VertexBuffer.h
@@ -73,11 +73,18 @@ namespace TRAP::Graphics
 		/// <param name="offset">Byte offset into the currently used vertex data.</param>
 		void SetData(const float* data, uint64_t size, uint64_t offset = 0);
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use this buffer for rendering on the given window.
 		/// </summary>
 		/// <param name="window">Window to use vertex buffer on. Default: Main Window.</param>
 		void Use(const Window* window = TRAP::Application::GetWindow()) const;
+#else
+		/// <summary>
+		/// Use this buffer for rendering.
+		/// </summary>
+		void Use() const;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Check whether uploading data to the GPU has finished.

--- a/TRAP/src/Graphics/RenderCommand.cpp
+++ b/TRAP/src/Graphics/RenderCommand.cpp
@@ -456,6 +456,15 @@ void TRAP::Graphics::RenderCommand::SetResolution(const uint32_t width, const ui
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifdef TRAP_HEADLESS_MODE
+void TRAP::Graphics::RenderCommand::GetResolution(uint32_t& width, uint32_t& height)
+{
+	RendererAPI::GetRenderer()->GetResolution(width, height);
+}
+#endif /*TRAP_HEADLESS_MODE*/
+
+//-------------------------------------------------------------------------------------------------------------------//
+
 #ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetRenderScale(const float scale, const Window* const window)
 {

--- a/TRAP/src/Graphics/RenderCommand.cpp
+++ b/TRAP/src/Graphics/RenderCommand.cpp
@@ -452,7 +452,7 @@ void TRAP::Graphics::RenderCommand::SetResolution(const uint32_t width, const ui
 {
 	RendererAPI::GetRenderer()->SetResolution(width, height);
 }
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Graphics/RenderCommand.cpp
+++ b/TRAP/src/Graphics/RenderCommand.cpp
@@ -1,9 +1,8 @@
 #include "TRAPPCH.h"
 #include "RenderCommand.h"
 
-#include <utility>
-
 #include "Application.h"
+#include "ImageLoader/Image.h"
 
 #ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::Flush(const Window* const window)

--- a/TRAP/src/Graphics/RenderCommand.cpp
+++ b/TRAP/src/Graphics/RenderCommand.cpp
@@ -5,10 +5,17 @@
 
 #include "Application.h"
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::Flush(const Window* const window)
 {
 	RendererAPI::GetRenderer()->Flush(window);
 }
+#else
+void TRAP::Graphics::RenderCommand::Flush()
+{
+	RendererAPI::GetRenderer()->Flush();
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -30,157 +37,306 @@ void TRAP::Graphics::RenderCommand::SetVSync(const bool vsync, const Window* con
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::RenderCommand::Clear(const ClearBuffer buffer, const Window* const window)
+#ifndef TRAP_HEADLESS_MODE
+void TRAP::Graphics::RenderCommand::Clear(const ClearBuffer clearType, const Window* const window)
 {
-	RendererAPI::GetRenderer()->Clear(buffer, window);
+	RendererAPI::GetRenderer()->Clear(clearType, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::Clear(const ClearBuffer clearType)
+{
+	RendererAPI::GetRenderer()->Clear(clearType);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetClearColor(const RendererAPI::Color& color, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetClearColor(color, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetClearColor(const RendererAPI::Color& color)
+{
+	RendererAPI::GetRenderer()->SetClearColor(color);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetClearDepth(const float depth, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetClearDepth(depth, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetClearDepth(const float depth)
+{
+	RendererAPI::GetRenderer()->SetClearDepth(depth);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetClearStencil(const uint32_t stencil, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetClearStencil(stencil, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetClearStencil(const uint32_t stencil)
+{
+	RendererAPI::GetRenderer()->SetClearStencil(stencil);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetDepthTesting(const bool enabled, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetDepthTesting(enabled, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetDepthTesting(const bool enabled)
+{
+	RendererAPI::GetRenderer()->SetDepthTesting(enabled);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetDepthWriting(const bool enabled, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetDepthWriting(enabled, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetDepthWriting(const bool enabled)
+{
+	RendererAPI::GetRenderer()->SetDepthWriting(enabled);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetDepthFunction(const CompareMode compareMode, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetDepthFunction(compareMode, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetDepthFunction(const CompareMode compareMode)
+{
+	RendererAPI::GetRenderer()->SetDepthFunction(compareMode);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetDepthFail(const StencilOperation front, const StencilOperation back,
 												 const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetDepthFail(front, back, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetDepthFail(const StencilOperation front, const StencilOperation back)
+{
+	RendererAPI::GetRenderer()->SetDepthFail(front, back);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetDepthBias(const int32_t bias, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetDepthBias(bias, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetDepthBias(const int32_t bias)
+{
+	RendererAPI::GetRenderer()->SetDepthBias(bias);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetDepthBiasSlopeFactor(const float slopeFactor, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetDepthBiasSlopeFactor(slopeFactor, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetDepthBiasSlopeFactor(const float slopeFactor)
+{
+	RendererAPI::GetRenderer()->SetDepthBiasSlopeFactor(slopeFactor);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetStencilTesting(const bool enabled, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetStencilTesting(enabled, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetStencilTesting(const bool enabled)
+{
+	RendererAPI::GetRenderer()->SetStencilTesting(enabled);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetStencilFail(const StencilOperation front, const StencilOperation back,
 												   const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetStencilFail(front, back, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetStencilFail(const StencilOperation front, const StencilOperation back)
+{
+	RendererAPI::GetRenderer()->SetStencilFail(front, back);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetStencilPass(const StencilOperation front, const StencilOperation back,
 												   const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetStencilPass(front, back, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetStencilPass(const StencilOperation front, const StencilOperation back)
+{
+	RendererAPI::GetRenderer()->SetStencilPass(front, back);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetStencilFunction(const CompareMode front, const CompareMode back,
 													   const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetStencilFunction(front, back, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetStencilFunction(const CompareMode front, const CompareMode back)
+{
+	RendererAPI::GetRenderer()->SetStencilFunction(front, back);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetStencilMask(const uint8_t read, const uint8_t write, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetStencilMask(read, write, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetStencilMask(const uint8_t read, const uint8_t write)
+{
+	RendererAPI::GetRenderer()->SetStencilMask(read, write);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetCullMode(const CullMode cullMode, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetCullMode(cullMode, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetCullMode(const CullMode cullMode)
+{
+	RendererAPI::GetRenderer()->SetCullMode(cullMode);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetFillMode(const FillMode fillMode, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetFillMode(fillMode, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetFillMode(const FillMode fillMode)
+{
+	RendererAPI::GetRenderer()->SetFillMode(fillMode);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetPrimitiveTopology(const PrimitiveTopology topology, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetPrimitiveTopology(topology, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetPrimitiveTopology(const PrimitiveTopology topology)
+{
+	RendererAPI::GetRenderer()->SetPrimitiveTopology(topology);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetFrontFace(const FrontFace face, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetFrontFace(face, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetFrontFace(const FrontFace face)
+{
+	RendererAPI::GetRenderer()->SetFrontFace(face);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetShadingRate(const ShadingRate shadingRate,
 												   const ShadingRateCombiner postRasterizerRate,
 												   const ShadingRateCombiner finalRate, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetShadingRate(shadingRate, postRasterizerRate, finalRate, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetShadingRate(const ShadingRate shadingRate,
+												   const ShadingRateCombiner postRasterizerRate,
+												   const ShadingRateCombiner finalRate)
+{
+	RendererAPI::GetRenderer()->SetShadingRate(shadingRate, postRasterizerRate, finalRate);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetShadingRate(TRAP::Ref<TRAP::Graphics::RenderTarget> texture,
                                                    const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetShadingRate(std::move(texture), window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetShadingRate(TRAP::Ref<TRAP::Graphics::RenderTarget> texture)
+{
+	RendererAPI::GetRenderer()->SetShadingRate(std::move(texture));
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -212,93 +368,171 @@ void TRAP::Graphics::RenderCommand::SetAnisotropyLevel(const SampleCount anisotr
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetBlendMode(const BlendMode modeRGB, const BlendMode modeAlpha, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetBlendMode(modeRGB, modeAlpha, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetBlendMode(const BlendMode modeRGB, const BlendMode modeAlpha)
+{
+	RendererAPI::GetRenderer()->SetBlendMode(modeRGB, modeAlpha);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetBlendConstant(const BlendConstant sourceRGBA,
                                                      const BlendConstant destinationRGBA, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetBlendConstant(sourceRGBA, sourceRGBA, destinationRGBA, destinationRGBA, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetBlendConstant(const BlendConstant sourceRGBA,
+                                                     const BlendConstant destinationRGBA)
+{
+	RendererAPI::GetRenderer()->SetBlendConstant(sourceRGBA, sourceRGBA, destinationRGBA, destinationRGBA);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetBlendConstant(const BlendConstant sourceRGB, const BlendConstant sourceAlpha,
 	  												 const BlendConstant destinationRGB,
 													 const BlendConstant destinationAlpha, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetBlendConstant(sourceRGB, sourceAlpha, destinationRGB, destinationAlpha, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetBlendConstant(const BlendConstant sourceRGB, const BlendConstant sourceAlpha,
+	  												 const BlendConstant destinationRGB,
+													 const BlendConstant destinationAlpha)
+{
+	RendererAPI::GetRenderer()->SetBlendConstant(sourceRGB, sourceAlpha, destinationRGB, destinationAlpha);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetViewport(const uint32_t x, const uint32_t y, const uint32_t width,
                                                 const uint32_t height, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetViewport(x, y, width, height, 0.0f, 1.0f, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetViewport(const uint32_t x, const uint32_t y, const uint32_t width,
+                                                const uint32_t height)
+{
+	RendererAPI::GetRenderer()->SetViewport(x, y, width, height, 0.0f, 1.0f);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetScissor(const uint32_t x, const uint32_t y, const uint32_t width,
 											   const uint32_t height, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetScissor(x, y, width, height, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetScissor(const uint32_t x, const uint32_t y, const uint32_t width,
+											   const uint32_t height)
+{
+	RendererAPI::GetRenderer()->SetScissor(x, y, width, height);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
 #ifdef TRAP_HEADLESS_MODE
-void TRAP::Graphics::RenderCommand::SetResolution(const uint32_t width, const uint32_t height, const Window* const window)
+void TRAP::Graphics::RenderCommand::SetResolution(const uint32_t width, const uint32_t height)
 {
-	RendererAPI::GetRenderer()->SetResolution(width, height, window);
+	RendererAPI::GetRenderer()->SetResolution(width, height);
 }
 #endif
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetRenderScale(const float scale, const Window* const window)
 {
 	RendererAPI::GetRenderer()->SetRenderScale(scale, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetRenderScale(const float scale)
+{
+	RendererAPI::GetRenderer()->SetRenderScale(scale);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] float TRAP::Graphics::RenderCommand::GetRenderScale(const Window* const window)
 {
 	return RendererAPI::GetRenderer()->GetRenderScale(window);
 }
+#else
+[[nodiscard]] float TRAP::Graphics::RenderCommand::GetRenderScale()
+{
+	return RendererAPI::GetRenderer()->GetRenderScale();
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::Draw(const uint32_t vertexCount, const uint32_t firstVertex, const Window* const window)
 {
 	RendererAPI::GetRenderer()->Draw(vertexCount, firstVertex, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::Draw(const uint32_t vertexCount, const uint32_t firstVertex)
+{
+	RendererAPI::GetRenderer()->Draw(vertexCount, firstVertex);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::DrawIndexed(const uint32_t indexCount, const uint32_t firstIndex,
 												const uint32_t firstVertex, const Window* const window)
 {
 	RendererAPI::GetRenderer()->DrawIndexed(indexCount, firstIndex, firstVertex, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::DrawIndexed(const uint32_t indexCount, const uint32_t firstIndex,
+												const uint32_t firstVertex)
+{
+	RendererAPI::GetRenderer()->DrawIndexed(indexCount, firstIndex, firstVertex);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::DrawInstanced(const uint32_t vertexCount, const uint32_t instanceCount,
 	                                              const uint32_t firstVertex, const uint32_t firstInstance,
 												  const Window* const window)
 {
 	RendererAPI::GetRenderer()->DrawInstanced(vertexCount, instanceCount, firstVertex, firstInstance, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::DrawInstanced(const uint32_t vertexCount, const uint32_t instanceCount,
+	                                              const uint32_t firstVertex, const uint32_t firstInstance)
+{
+	RendererAPI::GetRenderer()->DrawInstanced(vertexCount, instanceCount, firstVertex, firstInstance);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::DrawIndexedInstanced(const uint32_t indexCount, const uint32_t instanceCount,
 														 const uint32_t firstIndex, const uint32_t firstInstance,
 														 const uint32_t firstVertex, const Window* const window)
@@ -306,52 +540,48 @@ void TRAP::Graphics::RenderCommand::DrawIndexedInstanced(const uint32_t indexCou
 	RendererAPI::GetRenderer()->DrawIndexedInstanced(indexCount, instanceCount, firstIndex, firstInstance,
 	                                                 firstVertex, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::DrawIndexedInstanced(const uint32_t indexCount, const uint32_t instanceCount,
+														 const uint32_t firstIndex, const uint32_t firstInstance,
+														 const uint32_t firstVertex)
+{
+	RendererAPI::GetRenderer()->DrawIndexedInstanced(indexCount, instanceCount, firstIndex, firstInstance,
+	                                                 firstVertex);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::Dispatch(const std::array<uint32_t, 3>& workGroupElementSizes, const Window* const window)
 {
 	RendererAPI::GetRenderer()->Dispatch(workGroupElementSizes, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::Dispatch(const std::array<uint32_t, 3>& workGroupElementSizes)
+{
+	RendererAPI::GetRenderer()->Dispatch(workGroupElementSizes);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::SetPushConstants(const char* name, const void* data, const QueueType queueType,
                                                      const Window* const window)
 {
 	RendererAPI::GetRenderer()->BindPushConstants(name, data, queueType, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::SetPushConstants(const char* name, const void* data, const QueueType queueType)
+{
+	RendererAPI::GetRenderer()->BindPushConstants(name, data, queueType);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-// void TRAP::Graphics::RenderCommand::BindRenderTarget(const TRAP::Ref<Graphics::RenderTarget>& colorTarget,
-// 		                                             const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
-// 									                 const RendererAPI::LoadActionsDesc* loadActions,
-// 									                 std::vector<uint32_t>* colorArraySlices,
-// 									                 std::vector<uint32_t>* colorMipSlices,
-// 									                 const uint32_t depthArraySlice, const uint32_t depthMipSlice,
-// 									                 const Window* const window)
-// {
-// 	RendererAPI::GetRenderer()->BindRenderTarget(colorTarget, depthStencil, loadActions, colorArraySlices,
-// 												 colorMipSlices, depthArraySlice, depthMipSlice, window);
-// }
-
-//-------------------------------------------------------------------------------------------------------------------//
-
-// void TRAP::Graphics::RenderCommand::BindRenderTargets(const std::vector<TRAP::Ref<Graphics::RenderTarget>>& colorTargets,
-// 		                                             const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
-// 									                 const RendererAPI::LoadActionsDesc* const loadActions,
-// 									                 std::vector<uint32_t>* const colorArraySlices,
-// 									                 std::vector<uint32_t>* const colorMipSlices,
-// 									                 const uint32_t depthArraySlice, const uint32_t depthMipSlice,
-// 									                 const Window* const window)
-// {
-// 	RendererAPI::GetRenderer()->BindRenderTargets(colorTargets, depthStencil, loadActions, colorArraySlices,
-// 												 colorMipSlices, depthArraySlice, depthMipSlice, window);
-// }
-
-//-------------------------------------------------------------------------------------------------------------------//
-
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::BindRenderTarget(const TRAP::Ref<Graphics::RenderTarget>& colorTarget,
 		                                             const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
 									                 const RendererAPI::LoadActionsDesc* const loadActions,
@@ -360,9 +590,19 @@ void TRAP::Graphics::RenderCommand::BindRenderTarget(const TRAP::Ref<Graphics::R
 	RendererAPI::GetRenderer()->BindRenderTarget(colorTarget, depthStencil, loadActions, nullptr, nullptr,
 												 static_cast<uint32_t>(-1), static_cast<uint32_t>(-1), window);
 }
+#else
+void TRAP::Graphics::RenderCommand::BindRenderTarget(const TRAP::Ref<Graphics::RenderTarget>& colorTarget,
+		                                             const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
+									                 const RendererAPI::LoadActionsDesc* const loadActions)
+{
+	RendererAPI::GetRenderer()->BindRenderTarget(colorTarget, depthStencil, loadActions, nullptr, nullptr,
+												 static_cast<uint32_t>(-1), static_cast<uint32_t>(-1));
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::BindRenderTargets(const std::vector<TRAP::Ref<Graphics::RenderTarget>>& colorTargets,
 		                                             const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
 									                 const RendererAPI::LoadActionsDesc* const loadActions,
@@ -371,96 +611,183 @@ void TRAP::Graphics::RenderCommand::BindRenderTargets(const std::vector<TRAP::Re
 	RendererAPI::GetRenderer()->BindRenderTargets(colorTargets, depthStencil, loadActions, nullptr, nullptr,
 												  static_cast<uint32_t>(-1), static_cast<uint32_t>(-1), window);
 }
+#else
+void TRAP::Graphics::RenderCommand::BindRenderTargets(const std::vector<TRAP::Ref<Graphics::RenderTarget>>& colorTargets,
+		                                             const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
+									                 const RendererAPI::LoadActionsDesc* const loadActions)
+{
+	RendererAPI::GetRenderer()->BindRenderTargets(colorTargets, depthStencil, loadActions, nullptr, nullptr,
+												  static_cast<uint32_t>(-1), static_cast<uint32_t>(-1));
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::StartRenderPass(const Window* const window)
 {
 	RendererAPI::StartRenderPass(window);
 }
+#else
+void TRAP::Graphics::RenderCommand::StartRenderPass()
+{
+	RendererAPI::StartRenderPass();
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::StopRenderPass(const Window* const window)
 {
 	RendererAPI::StopRenderPass(window);
 }
+#else
+void TRAP::Graphics::RenderCommand::StopRenderPass()
+{
+	RendererAPI::StopRenderPass();
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::BufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
                                                   const QueueType queueType, const Window* const window)
 {
 	RendererAPI::GetRenderer()->ResourceBufferBarrier(bufferBarrier, queueType, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::BufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
+                                                  const QueueType queueType)
+{
+	RendererAPI::GetRenderer()->ResourceBufferBarrier(bufferBarrier, queueType);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::BufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
                                                    const QueueType queueType, const Window* const window)
 {
 	RendererAPI::GetRenderer()->ResourceBufferBarriers(bufferBarriers, queueType, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::BufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
+                                                   const QueueType queueType)
+{
+	RendererAPI::GetRenderer()->ResourceBufferBarriers(bufferBarriers, queueType);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::TextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
                                                    const QueueType queueType, const Window* const window)
 {
 	RendererAPI::GetRenderer()->ResourceTextureBarrier(textureBarrier, queueType, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::TextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
+                                                   const QueueType queueType)
+{
+	RendererAPI::GetRenderer()->ResourceTextureBarrier(textureBarrier, queueType);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::TextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
            										    const QueueType queueType, const Window* const window)
 {
 	RendererAPI::GetRenderer()->ResourceTextureBarriers(textureBarriers, queueType, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::TextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
+           										    const QueueType queueType)
+{
+	RendererAPI::GetRenderer()->ResourceTextureBarriers(textureBarriers, queueType);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::RenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier,
  														const Window* const window)
 {
 	RendererAPI::GetRenderer()->ResourceRenderTargetBarrier(renderTargetBarrier, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::RenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier)
+{
+	RendererAPI::GetRenderer()->ResourceRenderTargetBarrier(renderTargetBarrier);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::RenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers,
  														 const Window* const window)
 {
 	RendererAPI::GetRenderer()->ResourceRenderTargetBarriers(renderTargetBarriers, window);
 }
+#else
+void TRAP::Graphics::RenderCommand::RenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers)
+{
+	RendererAPI::GetRenderer()->ResourceRenderTargetBarriers(renderTargetBarriers);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] TRAP::Scope<TRAP::Image> TRAP::Graphics::RenderCommand::CaptureScreenshot(const Window* const window)
 {
 	return RendererAPI::GetRenderer()->CaptureScreenshot(window);
 }
+#else
+[[nodiscard]] TRAP::Scope<TRAP::Image> TRAP::Graphics::RenderCommand::CaptureScreenshot()
+{
+	return RendererAPI::GetRenderer()->CaptureScreenshot();
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-void TRAP::Graphics::RenderCommand::Transition(Ref<Texture> texture, const RendererAPI::ResourceState oldLayout,
+void TRAP::Graphics::RenderCommand::Transition(const Ref<Texture>& texture, const RendererAPI::ResourceState oldLayout,
 											   const RendererAPI::ResourceState newLayout, const QueueType queueType)
 {
-	RendererAPI::Transition(std::move(texture), oldLayout, newLayout, queueType);
+	RendererAPI::Transition(texture, oldLayout, newLayout, queueType);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 void TRAP::Graphics::RenderCommand::MSAAResolvePass(TRAP::Ref<RenderTarget> source,
                                                     TRAP::Ref<RenderTarget> destination, const Window* const window)
 {
 	TRAP_ASSERT(window, "RenderCommand::MSAAResolvePass(): Window is nullptr!");
 
-	const auto& winData = TRAP::Graphics::RendererAPI::GetWindowData(window);
-	CommandBuffer* const cmd = winData.GraphicCommandBuffers[winData.ImageIndex];
+	const auto& viewportData = TRAP::Graphics::RendererAPI::GetViewportData(window);
+	CommandBuffer* const cmd = viewportData.GraphicCommandBuffers[viewportData.ImageIndex];
 
 	RendererAPI::GetRenderer()->MSAAResolvePass(std::move(source), std::move(destination), cmd);
 }
+#else
+void TRAP::Graphics::RenderCommand::MSAAResolvePass(TRAP::Ref<RenderTarget> source,
+                                                    TRAP::Ref<RenderTarget> destination)
+{
+	const auto& viewportData = TRAP::Graphics::RendererAPI::GetViewportData();
+	CommandBuffer* const cmd = viewportData.GraphicCommandBuffers[viewportData.ImageIndex];
+
+	RendererAPI::GetRenderer()->MSAAResolvePass(std::move(source), std::move(destination), cmd);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -471,12 +798,21 @@ void TRAP::Graphics::RenderCommand::MSAAResolvePass(TRAP::Ref<RenderTarget> sour
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] uint32_t TRAP::Graphics::RenderCommand::GetGPUFPS(const Window* const window)
 {
 	const float maxGPUFrameTime = TRAP::Math::Max(RendererAPI::GetGPUGraphicsFrameTime(window), RendererAPI::GetGPUComputeFrameTime(window));
 
 	return static_cast<uint32_t>(1000.0f / maxGPUFrameTime);
 }
+#else
+[[nodiscard]] uint32_t TRAP::Graphics::RenderCommand::GetGPUFPS()
+{
+	const float maxGPUFrameTime = TRAP::Math::Max(RendererAPI::GetGPUGraphicsFrameTime(), RendererAPI::GetGPUComputeFrameTime());
+
+	return static_cast<uint32_t>(1000.0f / maxGPUFrameTime);
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -487,17 +823,31 @@ void TRAP::Graphics::RenderCommand::MSAAResolvePass(TRAP::Ref<RenderTarget> sour
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] float TRAP::Graphics::RenderCommand::GetGPUGraphicsFrameTime(const Window* const window)
 {
 	return RendererAPI::GetGPUGraphicsFrameTime(window);
 }
+#else
+[[nodiscard]] float TRAP::Graphics::RenderCommand::GetGPUGraphicsFrameTime()
+{
+	return RendererAPI::GetGPUGraphicsFrameTime();
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] float TRAP::Graphics::RenderCommand::GetGPUComputeFrameTime(const Window* const window)
 {
 	return RendererAPI::GetGPUComputeFrameTime(window);
 }
+#else
+[[nodiscard]] float TRAP::Graphics::RenderCommand::GetGPUComputeFrameTime()
+{
+	return RendererAPI::GetGPUComputeFrameTime();
+}
+#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Graphics/RenderCommand.h
+++ b/TRAP/src/Graphics/RenderCommand.h
@@ -607,6 +607,14 @@ namespace TRAP::Graphics
 		/// <param name="height">Height.</param>
 		static void SetResolution(uint32_t width, uint32_t height);
 #endif
+#ifdef TRAP_HEADLESS_MODE
+		/// <summary>
+		/// Get RenderTarget resolution.
+		/// </summary>
+		/// <param name="width">Output: Width.</param>
+		/// <param name="height">Output: Height.</param>
+		static void GetResolution(uint32_t& width, uint32_t& height);
+#endif
 
 #ifndef TRAP_HEADLESS_MODE
 		/// <summary>

--- a/TRAP/src/Graphics/RenderCommand.h
+++ b/TRAP/src/Graphics/RenderCommand.h
@@ -97,6 +97,7 @@ namespace TRAP::Graphics
 	class RenderCommand
 	{
 	public:
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Flush renderer for the given window.
 		///
@@ -109,6 +110,16 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <param name="window">Window to flush renderer. Default: Main Window.</param>
 		static void Flush(const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Flush renderer.
+		///
+		/// 1. Stops graphics and compute recording.
+		/// 2. Submits the graphics and compute commands.
+		/// 3. Starts graphics and compute recording for the next frame.
+		/// </summary>
+		static void Flush();
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//VSync functions
 
@@ -129,51 +140,108 @@ namespace TRAP::Graphics
 
 		//Clear functions
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Clear the RenderTarget of the given window.
 		/// </summary>
-		/// <param name="buffer">Type of buffer to clear.</param>
+		/// <param name="clearType">Type of buffer to clear.</param>
 		/// <param name="window">Window to clear RenderTarget for. Default: Main Window.</param>
-		static void Clear(ClearBuffer buffer, const Window* window = TRAP::Application::GetWindow());
+		static void Clear(ClearBuffer clearType, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Clear the given render target.
+		/// </summary>
+		/// <param name="clearType">Type of buffer to clear.</param>
+		static void Clear(ClearBuffer clearType);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clear color for the given window.
 		/// </summary>
 		/// <param name="color">New clear color. Default: Very dark gray.</param>
 		/// <param name="window">Window to set clear color for. Default: Main Window.</param>
 		static void SetClearColor(const RendererAPI::Color& color = { 0.1, 0.1, 0.1, 1.0 }, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the clear color.
+		/// </summary>
+		/// <param name="color">New clear color.</param>
+		static void SetClearColor(const RendererAPI::Color& color = { 0.1, 0.1, 0.1, 1.0 });
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clear depth value for the given window.
 		/// </summary>
-		/// <param name="depth">New depth value (range [0,1]). Default: 1.</param>
+		/// <param name="depth">New clear depth value (range [0,1]). Default: 1.</param>
 		/// <param name="window">Window to set clear depth value for. Default: Main Window.</param>
 		static void SetClearDepth(float depth = 0.0f, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the clear depth value.
+		/// </summary>
+		/// <param name="depth">New clear depth value. Must be between 0.0f and 1.0f</param>
+		static void SetClearDepth(float depth = 0.0f);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the clear stencil value for the given window.
 		/// </summary>
-		/// <param name="stencil">New stencil value. Default: 0.</param>
+		/// <param name="stencil">New clear stencil value. Default: 0.</param>
 		/// <param name="window">Window to set clear stencil value for. Default: Main Window.</param>
 		static void SetClearStencil(uint32_t stencil = 0, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the clear stencil value.
+		/// </summary>
+		/// <param name="stencil">New clear stencil value.</param>
+		static void SetClearStencil(uint32_t stencil = 0);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Depth functions
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable depth testing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth testing.</param>
 		/// <param name="window">Window to set depth testing for. Default: Main Window.</param>
 		static void SetDepthTesting(bool enabled, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Enable or disable depth testing.
+		/// </summary>
+		/// <param name="enabled">Enable or disable depth testing.</param>
+		static void SetDepthTesting(bool enabled);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable depth writing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable depth writing.</param>
 		/// <param name="window">Window to set depth writing for. Default: Main Window.</param>
 		static void SetDepthWriting(bool enabled, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Enable or disable depth writing.
+		/// </summary>
+		/// <param name="enabled">Enable or disable depth writing.</param>
+		static void SetDepthWriting(bool enabled);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set depth function for the given window.
 		/// </summary>
 		/// <param name="compareMode">Depth compare mode. Default: CompareMode::Less.</param>
 		/// <param name="window">Window to set depth function for. Default: Main Window.</param>
 		static void SetDepthFunction(CompareMode compareMode = CompareMode::Less, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the depth function.
+		/// </summary>
+		/// <param name="compareMode">Depth compare mode. Default: CompareMode::Less.</param>
+		static void SetDepthFunction(CompareMode compareMode = CompareMode::Less);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set operation for when depth testing fails for the given window.
 		/// </summary>
@@ -181,27 +249,60 @@ namespace TRAP::Graphics
 		/// <param name="back">Depth/Stencil operation.</param>
 		/// <param name="window">Window to set depth fail operation for. Default: Main Window.</param>
 		static void SetDepthFail(StencilOperation front, StencilOperation back, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the depth action to perform when depth testing fails.
+		/// </summary>
+		/// <param name="front">Depth action to perform when depth testing fails.</param>
+		/// <param name="back">Depth action to perform when depth testing fails.</param>
+		static void SetDepthFail(StencilOperation front, StencilOperation back);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set depth bias constant factor for the given window.
 		/// </summary>
 		/// <param name="bias">Depth bias constant factor.</param>
 		/// <param name="window">Window to set depth bias for. Default: Main Window.</param>
 		static void SetDepthBias(int32_t bias, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the depth bias (scalar factor to add to each fragments depth value).
+		/// </summary>
+		/// <param name="bias">Depth bias constant factor.</param>
+		static void SetDepthBias(int32_t bias);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set depth bias slope factor for the given window.
 		/// </summary>
 		/// <param name="slopeFactor">Depth bias slope factor.</param>
 		/// <param name="window">Window to set depth bias for. Default: Main Window.</param>
 		static void SetDepthBiasSlopeFactor(float slopeFactor, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the depth bias slope factor (scalar factor applied to fragment's slope in depth bias calculation).
+		/// </summary>
+		/// <param name="slopeFactor">Depth bias slope factor.</param>
+		static void SetDepthBiasSlopeFactor(float slopeFactor);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Stencil functions
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable stencil testing for the given window.
 		/// </summary>
 		/// <param name="enabled">Enable or disable stencil testing.</param>
 		/// <param name="window">Window to set stencil testing for. Default: Main Window.</param>
 		static void SetStencilTesting(bool enabled, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Enable or disable stencil testing.
+		/// </summary>
+		/// <param name="enabled">Enable or disable stencil testing.</param>
+		static void SetStencilTesting(bool enabled);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set operation for when stencil testing fails for the given window.
 		/// </summary>
@@ -209,6 +310,15 @@ namespace TRAP::Graphics
 		/// <param name="back">Stencil operation.</param>
 		/// <param name="window">Window to set stencil fail operation for. Default: Main Window.</param>
 		static void SetStencilFail(StencilOperation front, StencilOperation back, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the stencil action to perform when stencil testing fails.
+		/// </summary>
+		/// <param name="front">Stencil action to perform when stencil testing fails.</param>
+		/// <param name="back">Stencil action to perform when stencil testing fails.</param>
+		static void SetStencilFail(StencilOperation front, StencilOperation back);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set operation for when stencil testing passes for the given window.
 		/// </summary>
@@ -216,6 +326,15 @@ namespace TRAP::Graphics
 		/// <param name="back">Stencil operation.</param>
 		/// <param name="window">Window to set stencil pass operation for. Default: Main Window.</param>
 		static void SetStencilPass(StencilOperation front, StencilOperation back, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set operation for when stencil testing passes.
+		/// </summary>
+		/// <param name="front">Stencil action to perform when passed.</param>
+		/// <param name="back">Stencil action to perform when passed.</param>
+		static void SetStencilPass(StencilOperation front, StencilOperation back);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set stencil function for the given window.
 		/// </summary>
@@ -223,6 +342,15 @@ namespace TRAP::Graphics
 		/// <param name="back">Compare mode.</param>
 		/// <param name="window">Window to set stencil function for. Default: Main Window.</param>
 		static void SetStencilFunction(CompareMode front, CompareMode back, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the stencil functions.
+		/// </summary>
+		/// <param name="front">Function to use on the front for stencil testing.</param>
+		/// <param name="back">Function to use on the back for stencil testing.</param>
+		static void SetStencilFunction(CompareMode front, CompareMode back);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set stencil mask for the given window.
 		/// </summary>
@@ -230,33 +358,74 @@ namespace TRAP::Graphics
 		/// <param name="write">Bits to write/update.</param>
 		/// <param name="window">Window to set stencil mask for. Default: Main Window.</param>
 		static void SetStencilMask(uint8_t read, uint8_t write, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the stencil mask.
+		/// </summary>
+		/// <param name="read">Select the bits of the stencil values to test.</param>
+		/// <param name="write">Select the bits of the stencil values updated by the stencil test.</param>
+		static void SetStencilMask(uint8_t read, uint8_t write);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Miscellaneous functions
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set cull mode for the given window.
 		/// </summary>
 		/// <param name="cullMode">Cull mode.</param>
 		/// <param name="window">Window to set cull mode for. Default: Main Window.</param>
 		static void SetCullMode(CullMode cullMode, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the cull mode.
+		/// </summary>
+		/// <param name="cullMode">Cull mode to use.</param>
+		static void SetCullMode(CullMode cullMode);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set fill mode for the given window.
 		/// </summary>
 		/// <param name="fillMode">Fill mode.</param>
 		/// <param name="window">Window to set fill mode for. Default: Main Window.</param>
 		static void SetFillMode(FillMode fillMode, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the fill mode.
+		/// </summary>
+		/// <param name="fillMode">Fill mode to use.</param>
+		static void SetFillMode(FillMode fillMode);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set primitive topology for the given window.
 		/// </summary>
 		/// <param name="topology">Primitive topology.</param>
 		/// <param name="window">Window to set primitive topology for. Default: Main Window.</param>
 		static void SetPrimitiveTopology(PrimitiveTopology topology, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the primitive topology.
+		/// </summary>
+		/// <param name="topology">Primitive topology to use.</param>
+		static void SetPrimitiveTopology(PrimitiveTopology topology);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set front face for the given window.
 		/// </summary>
 		/// <param name="face">Front face.</param>
 		/// <param name="window">Window to set front face for. Default: Main Window.</param>
 		static void SetFrontFace(FrontFace face, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the front face winding order.
+		/// </summary>
+		/// <param name="face">Front face winding order to use.</param>
+		static void SetFrontFace(FrontFace face);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set the pipeline fragment shading rate and combiner operation for the command buffer.
 		/// </summary>
@@ -267,6 +436,18 @@ namespace TRAP::Graphics
 		static void SetShadingRate(ShadingRate shadingRate,
 		                           ShadingRateCombiner postRasterizerRate,
 							       ShadingRateCombiner finalRate, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the pipeline fragment shading rate and combiner operation for the command buffer.
+		/// </summary>
+		/// <param name="shadingRate">Shading rate to use.</param>
+		/// <param name="postRasterizerRate">Shading rate combiner to use.</param>
+		/// <param name="finalRate">Shading rate combiner to use.</param>
+		static void SetShadingRate(ShadingRate shadingRate,
+		                           ShadingRateCombiner postRasterizerRate,
+							       ShadingRateCombiner finalRate);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// TODO EXPERIMENTAL
 		/// Set the pipeline fragment shading rate via texture.
@@ -277,6 +458,16 @@ namespace TRAP::Graphics
 		/// </param>
 		/// <param name="window">Window to set shading rate for. Default: Main Window.</param>
 		static void SetShadingRate(Ref<RenderTarget> texture, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the pipeline fragment shading rate via texture.
+		/// </summary>
+		/// <param name="texture">
+		/// Shading rate texture to use.
+		/// Note: The texture must be in ResourceState::ShadingRateSource.
+		/// </param>
+		static void SetShadingRate(Ref<RenderTarget> texture);
+#endif /*TRAP_HEADLESS_MODE*/
 		/// <summary>
 		/// Set the anti aliasing method and the sample count.
 		/// Use AntiAliasing::Off to disable anti aliasing.
@@ -308,6 +499,7 @@ namespace TRAP::Graphics
 
 		//Blending functions
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set blend mode for the given window.
 		/// </summary>
@@ -315,6 +507,15 @@ namespace TRAP::Graphics
 		/// <param name="modeAlpha">Blend mode for alpha.</param>
 		/// <param name="window">Window to set blend mode for. Default: Main Window.</param>
 		static void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the blend mode.
+		/// </summary>
+		/// <param name="modeRGB">Blend mode to use for the RGB channels.</param>
+		/// <param name="modeAlpha">Blend mode to use for the alpha channel.</param>
+		static void SetBlendMode(BlendMode modeRGB, BlendMode modeAlpha);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set combined blend constant for the given window.
 		/// </summary>
@@ -323,6 +524,16 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to set blend constant for. Default: Main Window.</param>
 		static void SetBlendConstant(BlendConstant sourceRGBA, BlendConstant destinationRGBA,
 									 const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set combined blend constant.
+		/// </summary>
+		/// <param name="sourceRGBA">Blend constant for source RGBA.</param>
+		/// <param name="destinationRGBA">Blend constant for destination RGBA.</param>
+		static void SetBlendConstant(BlendConstant sourceRGBA, BlendConstant destinationRGBA);
+#endif /*TRAP_HEADLESS_MODE*/
+
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set separate blend constant for the given window.
 		/// </summary>
@@ -334,9 +545,21 @@ namespace TRAP::Graphics
 		static void SetBlendConstant(BlendConstant sourceRGB, BlendConstant sourceAlpha,
 									 BlendConstant destinationRGB, BlendConstant destinationAlpha,
 									 const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the blend constants/factors.
+		/// </summary>
+		/// <param name="sourceRGB">Specifies how the red, green, and blue blending factors are computed.</param>
+		/// <param name="sourceAlpha">Specifies how the alpha source blending factor is computed.</param>
+		/// <param name="destinationRGB">Specifies how the red, green, and blue destination blending factors are computed.</param>
+		/// <param name="destinationAlpha">Specified how the alpha destination blending factor is computed.</param>
+		static void SetBlendConstant(BlendConstant sourceRGB, BlendConstant sourceAlpha,
+			                         BlendConstant destinationRGB, BlendConstant destinationAlpha);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Viewport/Scissor functions
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set viewport size for the given window.
 		/// </summary>
@@ -346,6 +569,17 @@ namespace TRAP::Graphics
 		/// <param name="height">Viewport height.</param>
 		/// <param name="window">Window to set viewport size for. Default: Main Window.</param>
 		static void SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set viewport size.
+		/// </summary>
+		/// <param name="x">X coordinate of the top left corner of the viewport. Default: 0.</param>
+		/// <param name="y">Y coordinate of the top left corner of the viewport. Default: 0.</param>
+		/// <param name="width">Viewport width.</param>
+		/// <param name="height">Viewport height.</param>
+		static void SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set scissor size for the given window.
 		/// </summary>
@@ -355,17 +589,26 @@ namespace TRAP::Graphics
 		/// <param name="height">Scissor height.</param>
 		/// <param name="window">Window to set scissor size for. Default: Main Window.</param>
 		static void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set scissor size.
+		/// </summary>
+		/// <param name="x">Upper left corner. Default: 0.</param>
+		/// <param name="y">Upper left corner. Default: 0.</param>
+		/// <param name="width">Scissor width.</param>
+		/// <param name="height">Scissor height.</param>
+		static void SetScissor(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+#endif /*TRAP_HEADLESS_MODE*/
 #ifdef TRAP_HEADLESS_MODE
 		/// <summary>
-		/// Set RenderTarget resolution for the given window.
-		/// Note: Only usable in Headless mode.
+		/// Set RenderTarget resolution.
 		/// </summary>
 		/// <param name="width">Width.</param>
 		/// <param name="height">Height.</param>
-		/// <param name="window">Window to set resolution for. Default: Main Window.</param>
-		static void SetResolution(uint32_t width, uint32_t height, const Window* window = TRAP::Application::GetWindow());
+		static void SetResolution(uint32_t width, uint32_t height);
 #endif
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// TODO EXPERIMENTAL
 		/// Set the render scale for the given window.
@@ -374,6 +617,15 @@ namespace TRAP::Graphics
 		/// <param name="scale">Render scale value (valid range: 0.5f-1.0f inclusive).</param>
 		/// <param name="window">Window to set render scale for. Default: Main Window.</param>
 		static void SetRenderScale(float scale, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set the render scale.
+		/// Note: This functon takes effect on the next frame.
+		/// </summary>
+		/// <param name="scale">Render scale value (valid range: 0.5f-1.0f inclusive).</param>
+		static void SetRenderScale(float scale);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// TODO EXPERIMENTAL
 		/// Retrieve the used render scale value of the given window.
@@ -381,9 +633,17 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to retrieve render scale from. Default: Main Window.</param>
 		/// <returns>Render scale (between 0.5f and 2.0f inclusive).</returns>
 		[[nodiscard]] static float GetRenderScale(const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Retrieve the used render scale value.
+		/// </summary>
+		/// <returns>Render scale (between 0.5f and 2.0f inclusive).</returns>
+		[[nodiscard]] static float GetRenderScale();
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Drawing functions
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw non-indexed, non-instanced geometry for the given window.
 		/// </summary>
@@ -391,6 +651,15 @@ namespace TRAP::Graphics
 		/// <param name="firstVertex">Index of the first vertex to draw.</param>
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		static void Draw(uint32_t vertexCount, uint32_t firstVertex = 0, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Draw non-indexed, non-instanced geometry.
+		/// </summary>
+		/// <param name="vertexCount">Number of vertices to draw.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		static void Draw(uint32_t vertexCount, uint32_t firstVertex = 0);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw indexed, non-instanced geometry for the given window.
 		/// </summary>
@@ -400,6 +669,16 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		static void DrawIndexed(uint32_t indexCount, uint32_t firstIndex = 0, uint32_t firstVertex = 0,
 		                        const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Draw indexed, non-instanced geometry.
+		/// </summary>
+		/// <param name="indexCount">Number of indices to draw.</param>
+		/// <param name="firstIndex">Index of the first indice to draw. Default: 0.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		static void DrawIndexed(uint32_t indexCount, uint32_t firstIndex = 0, uint32_t firstVertex = 0);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw non-indexed, instanced geometry for the given window.
 		/// </summary>
@@ -410,6 +689,18 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		static void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex = 0,
 		                          uint32_t firstInstance = 0, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Draw non-indexed, instanced geometry.
+		/// </summary>
+		/// <param name="vertexCount">Number of vertices to draw.</param>
+		/// <param name="instanceCount">Number of instances to draw.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
+		static void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex = 0,
+		                          uint32_t firstInstance = 0);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Draw indexed, instanced geometry for the given window.
 		/// </summary>
@@ -422,9 +713,23 @@ namespace TRAP::Graphics
 		static void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex = 0,
 		                                 uint32_t firstInstance = 0, uint32_t firstVertex = 0,
 										 const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Draw indexed, instanced geometry.
+		/// </summary>
+		/// <param name="indexCount">Number of indices to draw.</param>
+		/// <param name="instanceCount">Number of instances to draw.</param>
+		/// <param name="firstIndex">Index of the first indice to draw. Default: 0.</param>
+		/// <param name="firstInstance">Index of the first instance to draw. Default: 0.</param>
+		/// <param name="firstVertex">Index of the first vertex to draw. Default: 0.</param>
+		static void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount,
+		                                 uint32_t firstIndex = 0, uint32_t firstInstance = 0,
+										 uint32_t firstVertex = 0);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Compute functions
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Dispatch compute work on the given window.
 		/// </summary>
@@ -434,11 +739,22 @@ namespace TRAP::Graphics
 		/// </param>
 		/// <param name="window">Window to draw for. Default: Main Window.</param>
 		static void Dispatch(const std::array<uint32_t, 3>& workGroupElementSizes, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Dispatch.
+		/// </summary>
+		/// <param name="workGroupElements">
+		/// Number of elements to dispatch for each dimension.
+		/// The elements are automatically divided by the number of threads in the work group and rounded up.
+		/// </param>
+		static void Dispatch(const std::array<uint32_t, 3>& workGroupElements);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//TODO DispatchIndirect
 
 		//CommandBuffer functions
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set push constant for the given window.
 		/// Note: Minimum guaranteed size is 128 bytes.
@@ -449,22 +765,19 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to set push constant for. Default: Main Window.</param>
 		static void SetPushConstants(const char* name, const void* data,
 		                             QueueType queueType = QueueType::Graphics, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set push constant.
+		/// Note: Minimum guaranteed size is 128 bytes.
+		/// </summary>
+		/// <param name="name">Name of the push constant.</param>
+		/// <param name="data">Data to set push constant to.</param>
+		/// <param name="queueType">Queue type on which to perform the operation. Default: Graphics.</param>
+		static void SetPushConstants(const char* name, const void* data,
+		                             QueueType queueType = QueueType::Graphics);
+#endif /*TRAP_HEADLESS_MODE*/
 
-		// static void BindRenderTarget(const TRAP::Ref<Graphics::RenderTarget>& colorTarget,
-		//                              const TRAP::Ref<Graphics::RenderTarget>& depthStencil = nullptr,
-		// 							 const RendererAPI::LoadActionsDesc* loadActions = nullptr,
-		// 							 std::vector<uint32_t>* colorArraySlices = nullptr,
-		// 							 std::vector<uint32_t>* colorMipSlices = nullptr,
-		// 							 uint32_t depthArraySlice = -1, uint32_t depthMipSlice = -1,
-		// 							 const Window* window = TRAP::Application::GetWindow());
-		// static void BindRenderTargets(const std::vector<TRAP::Ref<Graphics::RenderTarget>>& colorTargets,
-		//                               const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
-		// 							  const RendererAPI::LoadActionsDesc* loadActions = nullptr,
-		// 							  std::vector<uint32_t>* colorArraySlices = nullptr,
-		// 							  std::vector<uint32_t>* colorMipSlices = nullptr,
-		// 							  uint32_t depthArraySlice = -1, uint32_t depthMipSlice = -1,
-		// 							  const Window* window = TRAP::Application::GetWindow());
-
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set render target for the given window.
 		/// </summary>
@@ -476,6 +789,18 @@ namespace TRAP::Graphics
 		                             const TRAP::Ref<Graphics::RenderTarget>& depthStencil = nullptr,
 									 const RendererAPI::LoadActionsDesc* loadActions = nullptr,
 									 const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set render target.
+		/// </summary>
+		/// <param name="colorTarget">Color target to set.</param>
+		/// <param name="depthStencil">Depth stencil target to set.</param>
+		/// <param name="loadActions">Load actions.</param>
+		static void BindRenderTarget(const TRAP::Ref<Graphics::RenderTarget>& colorTarget,
+		                             const TRAP::Ref<Graphics::RenderTarget>& depthStencil = nullptr,
+									 const RendererAPI::LoadActionsDesc* loadActions = nullptr);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Set multiple render targets for the given window.
 		/// </summary>
@@ -487,6 +812,18 @@ namespace TRAP::Graphics
 		                              const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
 									  const RendererAPI::LoadActionsDesc* loadActions = nullptr,
 									  const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Set multiple render targets.
+		/// </summary>
+		/// <param name="colorTargets">Color targets to set.</param>
+		/// <param name="depthStencil">Depth stencil target to set.</param>
+		/// <param name="loadActions">Load actions.</param>
+		static void BindRenderTargets(const std::vector<TRAP::Ref<Graphics::RenderTarget>>& colorTargets,
+		                              const TRAP::Ref<Graphics::RenderTarget>& depthStencil,
+									  const RendererAPI::LoadActionsDesc* loadActions = nullptr);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Start a new render pass for the given window.
 		///
@@ -494,11 +831,27 @@ namespace TRAP::Graphics
 		/// </summary>
 		/// <param name="window">Window to start render pass for. Default: Main Window.</param>
 		static void StartRenderPass(const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Start a render pass.
+		///
+		/// Note: This will bind the render target for the current frame again.
+		/// </summary>
+		static void StartRenderPass();
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Stop the running render pass for the given window.
 		/// </summary>
 		/// <param name="window">Window to stop render pass for. Default: Main Window.</param>
 		static void StopRenderPass(const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Stop running render pass.
+		/// </summary>
+		static void StopRenderPass();
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Buffer barrier used to synchronize and transition the buffer.
 		/// </summary>
@@ -507,6 +860,16 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to sync and transition buffer for. Default: Main Window.</param>
 		static void BufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
 		                          QueueType queueType = QueueType::Graphics, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Buffer barrier used to synchronize and transition the buffer.
+		/// </summary>
+		/// <param name="bufferBarrier">Buffer barrier to use.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		static void BufferBarrier(const RendererAPI::BufferBarrier& bufferBarrier,
+		                          QueueType queueType = QueueType::Graphics);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Buffer barrier used to synchronize and transition multiple buffers.
 		/// </summary>
@@ -515,6 +878,16 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to sync and transition buffers for. Default: Main Window.</param>
 		static void BufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
 								   QueueType queueType = QueueType::Graphics, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Buffer barrier used to synchronize and transition multiple buffers.
+		/// </summary>
+		/// <param name="bufferBarriers">Buffer barriers to use.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		static void BufferBarriers(const std::vector<RendererAPI::BufferBarrier>& bufferBarriers,
+								   QueueType queueType = QueueType::Graphics);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Texture barrier used to synchronize and transition the texture.
 		/// </summary>
@@ -523,6 +896,16 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to sync and transition texture for. Default: Main Window.</param>
 		static void TextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
 		                           QueueType queueType = QueueType::Graphics, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Texture barrier used to synchronize and transition the texture.
+		/// </summary>
+		/// <param name="textureBarrier">Texture barrier to use.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		static void TextureBarrier(const RendererAPI::TextureBarrier& textureBarrier,
+		                           QueueType queueType = QueueType::Graphics);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Texture barrier used to synchronize and transition multiple textures.
 		/// </summary>
@@ -531,27 +914,60 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to sync and transition textures for. Default: Main Window.</param>
 		static void TextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
 		                            QueueType queueType = QueueType::Graphics, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Texture barrier used to synchronize and transition multiple textures.
+		/// </summary>
+		/// <param name="textureBarriers">Texture barriers to use.</param>
+		/// <param name="queueType">Queue type on which to perform the barrier operation. Default: Graphics.</param>
+		static void TextureBarriers(const std::vector<RendererAPI::TextureBarrier>& textureBarriers,
+		                            QueueType queueType = QueueType::Graphics);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// RenderTarget barrier used to synchronize and transition the RenderTarget.
 		/// </summary>
 		/// <param name="renderTargetBarrier">RenderTarget barrier to use.</param>
 		/// <param name="window">Window to sync and transition RenderTarget for. Default: Main Window.</param>
 		static void RenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// RenderTarget barrier used to synchronize and transition the RenderTarget.
+		/// </summary>
+		/// <param name="renderTargetBarrier">RenderTarget barrier to use.</param>
+		static void RenderTargetBarrier(const RendererAPI::RenderTargetBarrier& renderTargetBarrier);
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// RenderTarget barrier used to synchronize and transition multiple RenderTargets.
 		/// </summary>
 		/// <param name="renderTargetBarriers">RenderTarget barriers to use.</param>
 		/// <param name="window">Window to sync and transition RenderTargets for. Default: Main Window.</param>
 		static void RenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers, const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// RenderTarget barrier used to synchronize and transition multiple RenderTargets.
+		/// </summary>
+		/// <param name="renderTargetBarriers">RenderTarget barriers to use.</param>
+		static void RenderTargetBarriers(const std::vector<RendererAPI::RenderTargetBarrier>& renderTargetBarriers);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		//Utility
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Take a screenshot of the RenderTarget from the given window.
 		/// </summary>
 		/// <param name="window">Window to take screenshot from. Default: Main Window.</param>
 		/// <returns>Captured screenshot.</returns>
 		[[nodiscard]] static TRAP::Scope<TRAP::Image> CaptureScreenshot(const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Capture a screenshot of the last presented frame.
+		/// </summary>
+		/// <returns>Captured screenshot as TRAP::Image on success, Black 1x1 TRAP::Image otherwise.</returns>
+		[[nodiscard]] static TRAP::Scope<TRAP::Image> CaptureScreenshot();
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Transition a texture from old layout to the new layout.
@@ -561,10 +977,11 @@ namespace TRAP::Graphics
 		/// <param name="oldLayout">Current resource state of the given texture.</param>
 		/// <param name="newLayout">New resource state for the given texture.</param>
 		/// <param name="queueType">Queue type on which to perform the transition. Default: Graphics.</param>
-		static void Transition(Ref<Texture> texture, RendererAPI::ResourceState oldLayout,
+		static void Transition(const Ref<Texture>& texture, RendererAPI::ResourceState oldLayout,
 		                       RendererAPI::ResourceState newLayout,
 		                       QueueType queueType = QueueType::Graphics);
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Resolve an MSAA render target to a non MSAA render target.
 		/// Needed to transfer MSAA rendered image data to a presentable non-MSAA target.
@@ -576,36 +993,70 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to do the resolve pass on.</param>
 		static void MSAAResolvePass(TRAP::Ref<RenderTarget> source, TRAP::Ref<RenderTarget> destination,
 		                            const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Resolve an MSAA render target to a non MSAA render target.
+		/// Needed to transfer MSAA rendered image data to a presentable non-MSAA target.
+		///
+		/// Note: source and destination must be in ResourceState::RenderTarget.
+		/// </summary>
+		/// <param name="source">Source MSAA render target to resolve.</param>
+		/// <param name="destination">Destination non MSAA render target to resolve into.</param>
+		static void MSAAResolvePass(TRAP::Ref<RenderTarget> source, TRAP::Ref<RenderTarget> destination);
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Retrieve the CPU side frames per second.
 		/// </summary>
 		/// <returns>CPU frames per second.</returns>
 		[[nodiscard]] static uint32_t GetCPUFPS();
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the GPU side frames per second.
 		/// </summary>
 		/// <param name="window">Window to get frames per second from.</param>
 		/// <returns>GPU frames per second.</returns>
 		[[nodiscard]] static uint32_t GetGPUFPS(const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Retrieve the GPU side frames per second.
+		/// </summary>
+		/// <returns>GPU frames per second.</returns>
+		[[nodiscard]] static uint32_t GetGPUFPS();
+#endif /*TRAP_HEADLESS_MODE*/
 		/// <summary>
 		/// Retrieve the CPU side frame time.
 		/// </summary>
 		/// <returns>CPU frame time in milliseconds.</returns>
 		[[nodiscard]] static float GetCPUFrameTime();
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the GPU side frame time for the graphics queue.
 		/// </summary>
 		/// <param name="window">Window to get frame time from.</param>
 		/// <returns>GPU Graphics frame time in milliseconds.</returns>
 		[[nodiscard]] static float GetGPUGraphicsFrameTime(const Window* window = TRAP::Application::GetWindow());
+#else
+		/// <summary>
+		/// Retrieve the GPU side frame time for the graphics queue.
+		/// </summary>
+		/// <returns>GPU Graphics frame time in milliseconds.</returns>
+		[[nodiscard]] static float GetGPUGraphicsFrameTime();
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Retrieve the GPU side frame time for the compute queue.
 		/// </summary>
 		/// <param name="window">Window to get frame time from.</param>
 		/// <returns>GPU Compute frame time in milliseconds.</returns>
 		[[nodiscard]] static float GetGPUComputeFrameTime(const Window* window = TRAP::Application::GetWindow());
-
+#else
+		/// <summary>
+		/// Retrieve the GPU side frame time for the compute queue.
+		/// </summary>
+		/// <returns>GPU Compute frame time in milliseconds.</returns>
+		[[nodiscard]] static float GetGPUComputeFrameTime();
+#endif /*TRAP_HEADLESS_MODE*/
 		/// <summary>
 		/// Retrieve the name of the GPU that is currently used by the RendererAPI.
 		/// </summary>

--- a/TRAP/src/Graphics/Renderer2D.cpp
+++ b/TRAP/src/Graphics/Renderer2D.cpp
@@ -289,7 +289,11 @@ void TRAP::Graphics::Renderer2DData::QuadData::InitBuffers()
 	              buffers[DataBufferIndex].TextureSlots.end(), WhiteTexture);
 	}
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 	VertexBufferPtr = DataBuffers[imageIndex][DataBufferIndex].Vertices.data();
 	TextureSlotIndex = 1;
 }
@@ -312,7 +316,11 @@ void TRAP::Graphics::Renderer2DData::QuadData::Reset()
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(!DataBuffers[imageIndex].empty())
 	{
@@ -334,7 +342,11 @@ void TRAP::Graphics::Renderer2DData::QuadData::ExtendBuffers()
 
 	DataBufferIndex++;
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(DataBufferIndex < DataBuffers[imageIndex].size()) //Already allocated
 		return;
@@ -361,7 +373,11 @@ uint32_t TRAP::Graphics::Renderer2DData::QuadData::DrawBuffers(UniformBuffer* ca
 
 	uint32_t drawcalls = 0;
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	for(auto& buffers : DataBuffers[imageIndex])
 	{
@@ -408,7 +424,11 @@ uint32_t TRAP::Graphics::Renderer2DData::QuadData::DrawBuffers(UniformBuffer* ca
 	TRAP_ASSERT(texture, "Renderer2DData::QuadData::GetTextureIndex(): Texture is nullptr!");
 	TRAP_ASSERT(texture->GetType() == TextureType::Texture2D, "Renderer2DData::QuadData::GetTextureIndex(): Texture is not a Texture2D!");
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	const auto res = std::find(DataBuffers[imageIndex][DataBufferIndex].TextureSlots.begin(),
 	                           DataBuffers[imageIndex][DataBufferIndex].TextureSlots.end(), texture);
@@ -471,8 +491,11 @@ void TRAP::Graphics::Renderer2DData::CircleData::InitBuffers()
 		buffers[DataBufferIndex].VertexBuffer->SetLayout(VertexLayout);
 	}
 
-
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 	VertexBufferPtr = DataBuffers[imageIndex][DataBufferIndex].Vertices.data();
 }
 
@@ -492,7 +515,11 @@ void TRAP::Graphics::Renderer2DData::CircleData::Reset()
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(!DataBuffers[imageIndex].empty())
 		VertexBufferPtr = DataBuffers[imageIndex][DataBufferIndex].Vertices.data();
@@ -506,7 +533,11 @@ void TRAP::Graphics::Renderer2DData::CircleData::ExtendBuffers()
 
 	DataBufferIndex++;
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(DataBufferIndex < DataBuffers[imageIndex].size()) //Already allocated
 		return;
@@ -530,7 +561,11 @@ uint32_t TRAP::Graphics::Renderer2DData::CircleData::DrawBuffers(UniformBuffer* 
 
 	uint32_t drawcalls = 0;
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	for(auto& buffers : DataBuffers[imageIndex])
 	{
@@ -593,7 +628,11 @@ void TRAP::Graphics::Renderer2DData::LineData::InitBuffers()
 		buffers[DataBufferIndex].VertexBuffer->SetLayout(VertexLayout);
 	}
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 	VertexBufferPtr = DataBuffers[imageIndex][DataBufferIndex].Vertices.data();
 }
 
@@ -612,7 +651,11 @@ void TRAP::Graphics::Renderer2DData::LineData::Reset()
 {
 	ZoneNamedC(__tracy, tracy::Color::Red, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Graphics);
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(!DataBuffers[imageIndex].empty())
 		VertexBufferPtr = DataBuffers[imageIndex][DataBufferIndex].Vertices.data();
@@ -626,7 +669,11 @@ void TRAP::Graphics::Renderer2DData::LineData::ExtendBuffers()
 
 	DataBufferIndex++;
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if(DataBufferIndex < DataBuffers[imageIndex].size()) //Already allocated
 		return;
@@ -650,7 +697,11 @@ uint32_t TRAP::Graphics::Renderer2DData::LineData::DrawBuffers(UniformBuffer* ca
 
 	uint32_t drawcalls = 0;
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	for(auto& buffers : DataBuffers[imageIndex])
 	{
@@ -930,7 +981,11 @@ void TRAP::Graphics::Renderer2D::DrawQuad(const Math::Mat4& transform, const Mat
 	if(std::get<0>(currData.QuadData.DataBuffers).empty())
 		currData.QuadData.InitBuffers();
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if (currData.QuadData.DataBuffers[imageIndex][currData.QuadData.DataBufferIndex].QuadCount * 6 >= Renderer2DData::QuadData::MaxQuadIndices ||
 	    currData.QuadData.TextureSlotIndex >= Renderer2DData::QuadData::MaxTextureSlots)
@@ -971,7 +1026,11 @@ void TRAP::Graphics::Renderer2D::DrawCircle(const Math::Mat4& transform, const M
 	if(std::get<0>(currData.CircleData.DataBuffers).empty())
 		currData.CircleData.InitBuffers();
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if (currData.CircleData.DataBuffers[imageIndex][currData.CircleData.DataBufferIndex].CircleCount * 6 >= Renderer2DData::CircleData::MaxCircleIndices)
 	{
@@ -1017,7 +1076,11 @@ void TRAP::Graphics::Renderer2D::DrawLine(const TRAP::Math::Vec3& p0, const TRAP
 	if(std::get<0>(currData.LineData.DataBuffers).empty())
 		currData.LineData.InitBuffers();
 
+#ifndef TRAP_HEADLESS_MODE
 	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex(TRAP::Application::GetWindow());
+#else
+	const uint32_t imageIndex = RendererAPI::GetCurrentImageIndex();
+#endif /*TRAP_HEADLESS_MODE*/
 
 	if (currData.LineData.DataBuffers[imageIndex][currData.LineData.DataBufferIndex].LineCount * 2 >= Renderer2DData::LineData::MaxLineVertices)
 	{

--- a/TRAP/src/Graphics/Shaders/Shader.h
+++ b/TRAP/src/Graphics/Shaders/Shader.h
@@ -107,11 +107,19 @@ namespace TRAP::Graphics
 		/// <returns>True if shader is valid, false otherwise.</returns>
 		[[nodiscard]] bool IsShaderValid() const noexcept;
 
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use shader for rendering on the given window.
 		/// </summary>
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void Use(const Window* window = TRAP::Application::GetWindow()) = 0;
+#else
+		/// <summary>
+		/// Use shader for rendering.
+		/// </summary>
+		virtual void Use() = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use texture with this shader on the given window.
 		/// </summary>
@@ -121,6 +129,17 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseTexture(uint32_t set, uint32_t binding, Ref<TRAP::Graphics::Texture> texture,
 		                        const Window* window = TRAP::Application::GetWindow()) const = 0;
+#else
+		/// <summary>
+		/// Use texture with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the texture with.</param>
+		/// <param name="binding">Binding point of the texture.</param>
+		/// <param name="texture">Texture to use.</param>
+		virtual void UseTexture(uint32_t set, uint32_t binding, Ref<TRAP::Graphics::Texture> texture) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use multiple textures with this shader on the given window.
 		/// </summary>
@@ -131,6 +150,18 @@ namespace TRAP::Graphics
 		virtual void UseTextures(uint32_t set, uint32_t binding,
 		                         const std::vector<Ref<TRAP::Graphics::Texture>>& textures,
 								 const Window* window = TRAP::Application::GetWindow()) const = 0;
+#else
+		/// <summary>
+		/// Use multiple textures with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the textures with.</param>
+		/// <param name="binding">Binding point of the textures.</param>
+		/// <param name="textures">Textures to use.</param>
+		virtual void UseTextures(uint32_t set, uint32_t binding,
+		                         const std::vector<Ref<TRAP::Graphics::Texture>>& textures) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use sampler with this shader on the given window.
 		/// </summary>
@@ -140,6 +171,16 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseSampler(uint32_t set, uint32_t binding, TRAP::Graphics::Sampler* sampler,
 		                        const Window* window = TRAP::Application::GetWindow()) const = 0;
+#else
+		/// <summary>
+		/// Use sampler with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the sampler with.</param>
+		/// <param name="binding">Binding point of the sampler.</param>
+		/// <param name="sampler">Sampler to use.</param>
+		virtual void UseSampler(uint32_t set, uint32_t binding, TRAP::Graphics::Sampler* sampler) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use multiple samplers with this shader on the given window.
 		/// </summary>
@@ -150,6 +191,18 @@ namespace TRAP::Graphics
 		virtual void UseSamplers(uint32_t set, uint32_t binding,
 		                         const std::vector<TRAP::Graphics::Sampler*>& samplers,
 								 const Window* window = TRAP::Application::GetWindow()) const = 0;
+#else
+		/// <summary>
+		/// Use multiple samplers with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the samplers with.</param>
+		/// <param name="binding">Binding point of the samplers.</param>
+		/// <param name="samplers">Samplers to use.</param>
+		virtual void UseSamplers(uint32_t set, uint32_t binding,
+		                         const std::vector<TRAP::Graphics::Sampler*>& samplers) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use uniform buffer object with this shader on the given window.
 		/// </summary>
@@ -161,6 +214,20 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseUBO(uint32_t set, uint32_t binding, const TRAP::Graphics::UniformBuffer* uniformBuffer,
 							uint64_t size = 0, uint64_t offset = 0, const Window* window = TRAP::Application::GetWindow()) const = 0;
+#else
+		/// <summary>
+		/// Use uniform buffer object with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the UBO with.</param>
+		/// <param name="binding">Binding point of the UBO.</param>
+		/// <param name="uniformBuffer">Uniform buffer to use.</param>
+		/// <param name="size">Size of the UBO.</param>
+		/// <param name="offset">Offset of the UBO.</param>
+		virtual void UseUBO(uint32_t set, uint32_t binding, const TRAP::Graphics::UniformBuffer* uniformBuffer,
+							uint64_t size = 0, uint64_t offset = 0) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
+
+#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Use shader storage buffer object with this shader on the given window.
 		/// </summary>
@@ -171,6 +238,17 @@ namespace TRAP::Graphics
 		/// <param name="window">Window to use the shader for. Default: Main Window.</param>
 		virtual void UseSSBO(uint32_t set, uint32_t binding, const TRAP::Graphics::StorageBuffer* storageBuffer,
 							 uint64_t size = 0, const Window* window = TRAP::Application::GetWindow()) const = 0;
+#else
+		/// <summary>
+		/// Use shader storage buffer object with this shader.
+		/// </summary>
+		/// <param name="set">Descriptor set to use the SSBO with.</param>
+		/// <param name="binding">Binding point of the SSBO.</param>
+		/// <param name="storageBuffer">Storage buffer to use.</param>
+		/// <param name="size">Size of the SSBO.</param>
+		virtual void UseSSBO(uint32_t set, uint32_t binding, const TRAP::Graphics::StorageBuffer* storageBuffer,
+							 uint64_t size = 0) const = 0;
+#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Retrieve the shaders thread count per work group.

--- a/TRAP/src/Graphics/Textures/Texture.h
+++ b/TRAP/src/Graphics/Textures/Texture.h
@@ -2,11 +2,7 @@
 #define TRAP_TEXTURE_H
 
 #include "Graphics/API/ResourceLoader.h"
-
-namespace TRAP
-{
-	class Image;
-}
+#include "ImageLoader/Image.h"
 
 namespace TRAP::Graphics
 {

--- a/TRAP/src/Input/ControllerMappings.h
+++ b/TRAP/src/Input/ControllerMappings.h
@@ -1,6 +1,8 @@
 #ifndef TRAP_CONTROLLERMAPPINGS_H
 #define TRAP_CONTROLLERMAPPINGS_H
 
+#ifndef TRAP_HEADLESS_MODE
+
 #include <vector>
 #include <string>
 
@@ -1360,5 +1362,7 @@ namespace TRAP::Embed
 #endif /*TRAP_BUILD_LINUX_MAPPINGS*/
 	};
 }
+
+#endif /*TRAP_HEADLESS_MODE*/
 
 #endif /*TRAP_CONTROLLERMAPPINGS_H*/

--- a/TRAP/src/Input/ControllerMappings.h.in
+++ b/TRAP/src/Input/ControllerMappings.h.in
@@ -1,6 +1,8 @@
 #ifndef TRAP_CONTROLLERMAPPINGS_H
 #define TRAP_CONTROLLERMAPPINGS_H
 
+#ifndef TRAP_HEADLESS_MODE
+
 #include <vector>
 #include <string>
 
@@ -47,5 +49,7 @@ namespace TRAP::Embed
 #endif /*TRAP_BUILD_LINUX_MAPPINGS*/
 	};
 }
+
+#endif /*TRAP_HEADLESS_MODE*/
 
 #endif /*TRAP_CONTROLLERMAPPINGS_H*/

--- a/TRAP/src/Input/Input.cpp
+++ b/TRAP/src/Input/Input.cpp
@@ -29,6 +29,8 @@ The above license only applies to some of the Controller specific parts of this 
 #include "TRAPPCH.h"
 #include "Input.h"
 
+#ifndef TRAP_HEADLESS_MODE
+
 #ifdef TRAP_PLATFORM_WINDOWS
 #define TRAP_BUILD_WIN32_MAPPINGS
 #elif defined(TRAP_PLATFORM_LINUX)
@@ -1194,3 +1196,5 @@ void TRAP::Input::InitControllerMappings()
 
 	return ControllerDPad::Centered;
 }
+
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Input/Input.h
+++ b/TRAP/src/Input/Input.h
@@ -29,6 +29,8 @@ The above license only applies to some of the Controller specific parts of this 
 #ifndef TRAP_INPUT_H
 #define TRAP_INPUT_H
 
+#ifndef TRAP_HEADLESS_MODE
+
 #include "Core/PlatformDetection.h" //Needed for OS dependent includes
 
 #include <functional>
@@ -1071,5 +1073,7 @@ namespace TRAP
 }
 
 MAKE_ENUM_FLAG(TRAP::Input::ControllerDPad);
+
+#endif /*TRAP_HEADLESS_MODE*/
 
 #endif /*TRAP_INPUT_H*/

--- a/TRAP/src/Input/LinuxInput.cpp
+++ b/TRAP/src/Input/LinuxInput.cpp
@@ -348,7 +348,6 @@ bool TRAP::Input::OpenControllerDeviceLinux(std::filesystem::path path)
 
 	PollABSStateLinux(con);
 
-#ifndef TRAP_HEADLESS_MODE
 	if (!s_eventCallback)
 		return false;
 
@@ -362,7 +361,6 @@ bool TRAP::Input::OpenControllerDeviceLinux(std::filesystem::path path)
 
 	Events::ControllerConnectEvent event(static_cast<Controller>(index));
 	s_eventCallback(event);
-#endif /*TRAP_HEADLESS_MODE*/
 
 	return true;
 }
@@ -395,7 +393,6 @@ void TRAP::Input::CloseController(Controller controller)
 
 	*con = {};
 
-#ifndef TRAP_HEADLESS_MODE
 	if (!s_eventCallback)
 		return;
 
@@ -404,7 +401,6 @@ void TRAP::Input::CloseController(Controller controller)
 		Events::ControllerDisconnectEvent event(static_cast<Controller>(controller));
 		s_eventCallback(event);
 	}
-#endif /*TRAP_HEADLESS_MODE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Input/LinuxInput.cpp
+++ b/TRAP/src/Input/LinuxInput.cpp
@@ -28,6 +28,8 @@ Modified by: Jan "GamesTrap" Schuerkamp
 #include "TRAPPCH.h"
 #include "Input/Input.h"
 
+#ifndef TRAP_HEADLESS_MODE
+
 #ifdef TRAP_PLATFORM_LINUX
 
 #include <regex>
@@ -606,4 +608,6 @@ void TRAP::Input::UpdateControllerGUID([[maybe_unused]] std::string& guid)
 	return TRAP::INTERNAL::WindowingAPI::GetLinuxKeyboardLayoutName();
 }
 
-#endif
+#endif /*TRAP_PLATFORM_LINUX*/
+
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Input/WindowsInput.cpp
+++ b/TRAP/src/Input/WindowsInput.cpp
@@ -196,13 +196,11 @@ void TRAP::Input::DetectControllerConnectionWin32()
 			con->WinCon.Index = index;
 			con->WinCon.XInput = true;
 
-#ifndef TRAP_HEADLESS_MODE
 			if (!s_eventCallback)
 				continue;
 
 			Events::ControllerConnectEvent event(static_cast<Controller>(cID));
 			s_eventCallback(event);
-#endif /*TRAP_HEADLESS_MODE*/
 		}
 	}
 
@@ -458,7 +456,6 @@ void TRAP::Input::CloseController(Controller controller)
 
 	s_controllerInternal[static_cast<uint32_t>(controller)] = {};
 
-#ifndef TRAP_HEADLESS_MODE
 	if (!s_eventCallback)
 		return;
 
@@ -467,7 +464,6 @@ void TRAP::Input::CloseController(Controller controller)
 		Events::ControllerDisconnectEvent event(controller);
 		s_eventCallback(event);
 	}
-#endif /*TRAP_HEADLESS_MODE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -795,7 +791,6 @@ BOOL CALLBACK TRAP::Input::DeviceCallback(const DIDEVICEINSTANCE* deviceInstance
 	/*if (forceFeedback)
 		controller->WinCon.ForceFeedback = true;*/
 
-#ifndef TRAP_HEADLESS_MODE
 	if (!s_eventCallback)
 		return DIENUM_STOP;
 
@@ -807,7 +802,6 @@ BOOL CALLBACK TRAP::Input::DeviceCallback(const DIDEVICEINSTANCE* deviceInstance
 
 	Events::ControllerConnectEvent event(static_cast<Controller>(index));
 	s_eventCallback(event);
-#endif /*TRAP_HEADLESS_MODE*/
 
 	return DIENUM_STOP;
 }

--- a/TRAP/src/Input/WindowsInput.cpp
+++ b/TRAP/src/Input/WindowsInput.cpp
@@ -26,9 +26,11 @@ Modified by: Jan "GamesTrap" Schuerkamp
 */
 
 #include "TRAPPCH.h"
-#include "Core/PlatformDetection.h"
-
 #include "Input/Input.h"
+
+#ifndef TRAP_HEADLESS_MODE
+
+#include "Core/PlatformDetection.h"
 #include "Utils/String/String.h"
 
 #ifdef TRAP_PLATFORM_WINDOWS
@@ -845,4 +847,6 @@ BOOL CALLBACK TRAP::Input::DeviceCallback(const DIDEVICEINSTANCE* deviceInstance
 	return TRAP::Utils::String::CreateUTF8StringFromWideStringWin32(language);
 }
 
-#endif
+#endif /*TRAP_PLATFORM_WINDOWS*/
+
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
@@ -137,7 +137,7 @@ void TRAP::ImGuiLayer::OnAttach()
 	);
 
 	//Setup Platform/Renderer bindings
-	const auto& winData = TRAP::Graphics::RendererAPI::GetWindowData(TRAP::Application::GetWindow());
+	const auto& viewportData = TRAP::Graphics::RendererAPI::GetViewportData(TRAP::Application::GetWindow());
 
 	TP_TRACE(Log::ImGuiPrefix, "Init...");
 	if(!TRAP::INTERNAL::ImGuiWindowing::Init(window, true, Graphics::RendererAPI::GetRenderAPI()))
@@ -199,7 +199,7 @@ void TRAP::ImGuiLayer::OnAttach()
 
 		ImGui_ImplVulkan_Init(&initInfo, dynamic_cast<TRAP::Graphics::API::VulkanCommandBuffer*>
 		(
-			winData.GraphicCommandBuffers[winData.ImageIndex]
+			viewportData.GraphicCommandBuffers[viewportData.ImageIndex]
 		)->GetActiveVkRenderPass());
 
 		ImGui_ImplVulkan_UploadFontsTexture();
@@ -266,10 +266,10 @@ void TRAP::ImGuiLayer::Begin()
 	if (Graphics::RendererAPI::GetRenderAPI() == Graphics::RenderAPI::Vulkan)
 	{
 		//Bind SwapChain RenderTarget (this also updates the used RenderPass)
-		const auto& winData = TRAP::Graphics::RendererAPI::GetWindowData(TRAP::Application::GetWindow());
+		const auto& viewportData = TRAP::Graphics::RendererAPI::GetViewportData(TRAP::Application::GetWindow());
 		auto* const vkCmdBuffer = dynamic_cast<TRAP::Graphics::API::VulkanCommandBuffer*>
 		(
-			winData.GraphicCommandBuffers[winData.ImageIndex]
+			viewportData.GraphicCommandBuffers[viewportData.ImageIndex]
 		);
 		TRAP::Graphics::AntiAliasing aaMethod = TRAP::Graphics::AntiAliasing::Off;
 		TRAP::Graphics::SampleCount aaSamples = TRAP::Graphics::SampleCount::Two;
@@ -277,10 +277,10 @@ void TRAP::ImGuiLayer::Begin()
 
 		TRAP::Ref<TRAP::Graphics::RenderTarget> rT = nullptr;
 
-		if(aaMethod == TRAP::Graphics::RendererAPI::AntiAliasing::MSAA && winData.RenderScale == 1.0f) //MSAA and no RenderScale
-			rT = winData.InternalRenderTargets[winData.CurrentSwapChainImageIndex];
+		if(aaMethod == TRAP::Graphics::RendererAPI::AntiAliasing::MSAA && viewportData.RenderScale == 1.0f) //MSAA and no RenderScale
+			rT = viewportData.InternalRenderTargets[viewportData.CurrentSwapChainImageIndex];
 		else
-			rT = winData.SwapChain->GetRenderTargets()[winData.CurrentSwapChainImageIndex];
+			rT = viewportData.SwapChain->GetRenderTargets()[viewportData.CurrentSwapChainImageIndex];
 
 		//Cant use TRAP::Graphics::RenderCommand::StartRenderPass() here, because it would also bind the shading rate image
 		vkCmdBuffer->BindRenderTargets({ rT }, nullptr, nullptr, nullptr, nullptr,
@@ -288,7 +288,7 @@ void TRAP::ImGuiLayer::Begin()
 																				std::numeric_limits<uint32_t>::max());
 
 		//Only apply MSAA if no RenderScale is used (else it got already resolved to a non-MSAA texture)
-		if(aaMethod == TRAP::Graphics::AntiAliasing::MSAA && winData.RenderScale == 1.0f)
+		if(aaMethod == TRAP::Graphics::AntiAliasing::MSAA && viewportData.RenderScale == 1.0f)
 			ImGui_ImplVulkan_SetMSAASamples(static_cast<VkSampleCountFlagBits>(aaSamples));
 		else
 			ImGui_ImplVulkan_SetMSAASamples(VK_SAMPLE_COUNT_1_BIT);
@@ -318,13 +318,13 @@ void TRAP::ImGuiLayer::End()
 	ImGui::Render();
 	if (Graphics::RendererAPI::GetRenderAPI() == Graphics::RenderAPI::Vulkan)
 	{
-		const auto& winData = TRAP::Graphics::RendererAPI::GetWindowData(TRAP::Application::GetWindow());
+		const auto& viewportData = TRAP::Graphics::RendererAPI::GetViewportData(TRAP::Application::GetWindow());
 		if(!Application::GetWindow()->IsMinimized())
 		{
 			ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(),
 											dynamic_cast<TRAP::Graphics::API::VulkanCommandBuffer*>
 											(
-												winData.GraphicCommandBuffers[winData.ImageIndex]
+												viewportData.GraphicCommandBuffers[viewportData.ImageIndex]
 											)->GetVkCommandBuffer());
 		}
 	}

--- a/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiLayer.cpp
@@ -299,9 +299,7 @@ void TRAP::ImGuiLayer::Begin()
 	INTERNAL::ImGuiWindowing::NewFrame();
 
 	ImGui::NewFrame();
-#ifndef TRAP_HEADLESS_MODE
 	ImGuizmo::BeginFrame();
-#endif /*TRAP_HEADLESS_MODE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
+++ b/TRAP/src/Layers/ImGui/ImGuiVulkanBackend.cpp
@@ -756,9 +756,9 @@ void ImGui_ImplVulkan_UploadFontsTexture()
     //Destroy old font
     ImGui_ImplVulkan_DestroyFontsTexture();
 
-    const auto& winData = TRAP::Graphics::RendererAPI::GetWindowData(TRAP::Application::GetWindow());
+    const auto& viewportData = TRAP::Graphics::RendererAPI::GetViewportData(TRAP::Application::GetWindow());
     //Execute a GPU command to upload ImGui font textures
-    TRAP::Graphics::CommandBuffer* cmd = winData.GraphicCommandPools[winData.ImageIndex]->AllocateCommandBuffer(false);
+    TRAP::Graphics::CommandBuffer* cmd = viewportData.GraphicCommandPools[viewportData.ImageIndex]->AllocateCommandBuffer(false);
     cmd->Begin();
     ImGui_ImplVulkan_CreateFontsTexture(dynamic_cast<TRAP::Graphics::API::VulkanCommandBuffer*>
                                         (cmd)->GetVkCommandBuffer());
@@ -771,7 +771,7 @@ void ImGui_ImplVulkan_UploadFontsTexture()
     TRAP::Graphics::RendererAPI::GetGraphicsQueue()->Submit(submitDesc);
     submitFence->Wait();
     submitFence.reset();
-    winData.GraphicCommandPools[winData.ImageIndex]->FreeCommandBuffer(cmd);
+    viewportData.GraphicCommandPools[viewportData.ImageIndex]->FreeCommandBuffer(cmd);
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -1716,7 +1716,7 @@ void ImGui_ImplVulkan_SetMSAASamples(const VkSampleCountFlagBits sampleCount)
 {
 	ZoneNamedC(__tracy, tracy::Color::Brown, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Layers);
 
-	const auto& winData = TRAP::Graphics::RendererAPI::GetWindowData(TRAP::Application::GetWindow());
+	const auto& viewportData = TRAP::Graphics::RendererAPI::GetViewportData(TRAP::Application::GetWindow());
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
 
@@ -1726,7 +1726,7 @@ void ImGui_ImplVulkan_SetMSAASamples(const VkSampleCountFlagBits sampleCount)
     v->MSAASamples = sampleCount;
     bd->RenderPass = dynamic_cast<TRAP::Graphics::API::VulkanCommandBuffer*>
 		(
-			winData.GraphicCommandBuffers[winData.ImageIndex]
+			viewportData.GraphicCommandBuffers[viewportData.ImageIndex]
 		)->GetActiveVkRenderPass();
 
     //Delete old pipeline

--- a/TRAP/src/TRAP.h
+++ b/TRAP/src/TRAP.h
@@ -17,23 +17,29 @@
 #include "../src/Log/Log.h"
 //-----------------------
 
+#ifndef TRAP_HEADLESS_MODE
 //----INPUT--------------
 #include "../src/Input/Input.h"
 //-----------------------
+#endif /*TRAP_HEADLESS_MODE*/
 
 //----EVENTS-------------
 #include "../src/Events/Event.h"
+#include "../src/Events/HotReloadEvent.h"
+#include "../src/Events/FileEvent.h"
+#ifndef TRAP_HEADLESS_MODE
 #include "../src/Events/WindowEvent.h"
 #include "../src/Events/KeyEvent.h"
 #include "../src/Events/MouseEvent.h"
 #include "../src/Events/ControllerEvent.h"
-#include "../src/Events/HotReloadEvent.h"
-#include "../src/Events/FileEvent.h"
+#endif /*TRAP_HEADLESS_MODE*/
 //-----------------------
 
 //----LAYERS-------------
 #include "../src/Layers/Layer.h"
+#ifndef TRAP_HEADLESS_MODE
 #include "../src/Layers/ImGui/ImGuiLayer.h"
+#endif /*TRAP_HEADLESS_MODE*/
 //-----------------------
 
 //----FILE-SYSTEM--------
@@ -54,7 +60,10 @@
 #include "../src/Utils/Hash/SHA-3.h"
 #include "../src/Utils/Hash/UID.h"
 #include "../src/Utils/Hash/ConvertHashToString.h"
+#ifndef TRAP_HEADLESS_MODE
 #include "../src/Utils/Discord/DiscordGameSDK.h"
+#endif /*TRAP_HEADLESS_MODE*/
+#include "../src/Utils/Steam/SteamworksSDK.h"
 //-----------------------
 
 //----MATHS--------------
@@ -68,13 +77,17 @@
 #include "../src/Maths/Types.h"
 //-----------------------
 
+#ifndef TRAP_HEADLESS_MODE
 //----WINDOWS------------
 #include "../src/Window/Window.h"
 //-----------------------
+#endif /*TRAP_HEADLESS_MODE*/
 
+#ifndef TRAP_HEADLESS_MODE
 //----MONITORS-----------
 #include "../src/Window/Monitor.h"
 //-----------------------
+#endif /*TRAP_HEADLESS_MODE*/
 
 //----RENDERER-----------
 #include "../src/Graphics/Renderer.h"
@@ -109,8 +122,10 @@
 //----CAMERAS------------
 #include "../src/Graphics/Cameras/Camera.h"
 #include "../src/Graphics/Cameras/Orthographic/OrthographicCamera.h"
+#ifndef TRAP_HEADLESS_MODE
 #include "../src/Graphics/Cameras/Orthographic/OrthographicCameraController.h"
 #include "../src/Graphics/Cameras/Editor/EditorCamera.h"
+#endif /*TRAP_HEADLESS_MODE*/
 //-----------------------
 
 //----NETWORK------------

--- a/TRAP/src/Utils/String/String.inl
+++ b/TRAP/src/Utils/String/String.inl
@@ -79,6 +79,7 @@ template<typename T>
 	{
 		return input;
 	}
+#ifndef TRAP_HEADLESS_MODE
 	else if constexpr(std::is_same_v<T, TRAP::Window::DisplayMode>) //DisplayMode
 	{
 		if (Utils::String::CompareAnyCase("Windowed", input))
@@ -91,6 +92,7 @@ template<typename T>
 		TP_ERROR(TRAP::Log::ConfigPrefix, "Exception while converting string to TRAP::Window::DisplayMode!");
 		return Window::DisplayMode::Windowed;
 	}
+#endif /*TRAP_HEADLESS_MODE*/
 	else if constexpr(std::is_same_v<T, TRAP::Graphics::RenderAPI>) //RenderAPI
 	{
 		if (Utils::String::CompareAnyCase("Vulkan", input) || Utils::String::CompareAnyCase("VulkanAPI", input))
@@ -214,6 +216,7 @@ template<typename T>
 		TP_ERROR(TRAP::Log::ConfigPrefix, "Exception while converting string to TRAP::FileSystem::FileStatus!");
 		throw std::invalid_argument("Exception while converting string to TRAP::FileSystem::FileStatus!");
 	}
+#ifndef TRAP_HEADLESS_MODE
 	else if constexpr(std::is_same_v<T, TRAP::Input::MouseButton>) //MouseButton
 	{
 		if(Utils::String::CompareAnyCase("Left", input))
@@ -242,6 +245,7 @@ template<typename T>
 		TP_ERROR(TRAP::Log::ConfigPrefix, "Exception while converting string to TRAP::Input::MouseButton!");
 		throw std::invalid_argument("Exception while converting string to TRAP::Input::MouseButton!");
 	}
+#endif /*TRAP_HEADLESS_MODE*/
 	else if constexpr(std::is_same_v<T, TRAP::Rigidbody2DComponent::BodyType>) //Rigidbody2DComponent::BodyType
 	{
 		if(Utils::String::CompareAnyCase("Static", input))
@@ -288,6 +292,7 @@ template<typename T>
 	{
 		return std::to_string(value);
 	}
+#ifndef TRAP_HEADLESS_MODE
 	else if constexpr(std::is_same_v<T, TRAP::Window::DisplayMode>)
 	{
 		switch (value)
@@ -305,6 +310,7 @@ template<typename T>
 			return "Windowed";
 		}
 	}
+#endif /*TRAP_HEADLESS_MODE*/
 	else if constexpr(std::is_same_v<T, TRAP::Graphics::RenderAPI>)
 	{
 		switch (value)
@@ -442,6 +448,7 @@ template<typename T>
 			return "";
 		}
 	}
+#ifndef TRAP_HEADLESS_MODE
 	else if constexpr(std::is_same_v<T, TRAP::Input::MouseButton>) //MouseButton
 	{
 		switch(value)
@@ -483,6 +490,7 @@ template<typename T>
 			return "";
 		}
 	}
+#endif /*TRAP_HEADLESS_MODE*/
 	else if constexpr(std::is_same_v<T, TRAP::Rigidbody2DComponent::BodyType>) //Rigidbody2DComponent::BodyType
 	{
 		switch(value)

--- a/TRAP/src/Utils/Utils.cpp
+++ b/TRAP/src/Utils/Utils.cpp
@@ -582,10 +582,9 @@ static BOOL WINAPI SIGINTHandlerRoutine(_In_ DWORD dwCtrlType)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
+#ifdef TRAP_HEADLESS_MODE
 void TRAP::Utils::RegisterSIGINTCallback()
 {
-#ifdef TRAP_HEADLESS_MODE
-
 #ifdef TRAP_PLATFORM_LINUX
 	if(signal(SIGINT, [](int) {TRAP::Application::Shutdown(); }) == SIG_ERR)
 #elif defined(TRAP_PLATFORM_WINDOWS)
@@ -595,6 +594,5 @@ void TRAP::Utils::RegisterSIGINTCallback()
 		TP_ERROR(TRAP::Log::ApplicationPrefix, "Failed to register SIGINT callback!");
 		TP_ERROR(TRAP::Log::ApplicationPrefix, TRAP::Utils::String::GetStrError());
 	}
-
-#endif /*TRAP_HEADLESS_MODE*/
 }
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Utils/Utils.cpp
+++ b/TRAP/src/Utils/Utils.cpp
@@ -272,11 +272,11 @@
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-[[nodiscard]] TRAP::Utils::LinuxWindowManager TRAP::Utils::GetLinuxWindowManager()
+TRAP::Utils::LinuxWindowManager TRAP::Utils::GetLinuxWindowManager()
 {
 	ZoneNamedC(__tracy, tracy::Color::Violet, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Utils);
 
-	static LinuxWindowManager windowManager{};
+	static LinuxWindowManager windowManager = LinuxWindowManager::Unknown;
 
 #ifdef TRAP_PLATFORM_LINUX
 	if(windowManager != LinuxWindowManager::Unknown)
@@ -308,8 +308,10 @@
 
 	//Proceed with normal detection
 	session = "";
+
 	if(getenv("XDG_SESSION_TYPE"))
 		session = getenv("XDG_SESSION_TYPE");
+
 	if (getenv("WAYLAND_DISPLAY") || session == wl)
 		windowManager = LinuxWindowManager::Wayland;
 	else if (getenv("DISPLAY") || session == x11)
@@ -326,7 +328,7 @@
 		exit(0x0008);
 #else
 		return LinuxWindowManager::Unknown;
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
 	}
 
 #ifndef ENABLE_WAYLAND_SUPPORT
@@ -339,8 +341,8 @@
 		else
 			windowManager = LinuxWindowManager::Unknown;
 	}
-#endif
-#endif
+#endif /*ENABLE_WAYLAND_SUPPORT*/
+#endif /*TRAP_PLATFORM_LINUX*/
 
 	return windowManager;
 }

--- a/TRAP/src/Utils/Utils.h
+++ b/TRAP/src/Utils/Utils.h
@@ -185,11 +185,13 @@ namespace TRAP::Utils
 
 	//-------------------------------------------------------------------------------------------------------------------//
 
+#ifdef TRAP_HEADLESS_MODE
 	/// <summary>
 	/// Register the SIGINT callback function.
 	/// Used in Headless mode to handle CTRL+C.
 	/// </summary>
 	void RegisterSIGINTCallback();
+#endif /*TRAP_HEADLESS_MODE*/
 }
 
 #endif /*TRAP_UTILS_H*/

--- a/TRAP/src/Utils/Utils.h
+++ b/TRAP/src/Utils/Utils.h
@@ -87,13 +87,15 @@ namespace TRAP::Utils
 
 	/// <summary>
 	/// Get the window manager used by Linux based systems.
+	///
+	/// On Linux if no known window manager is found then the engine will be terminated.
 	/// </summary>
 	/// <returns>
 	/// TRAP::Application::LinuxWindowManager::X11, TRAP::Application::LinuxWindowManager::Wayland or
 	/// TRAP::Application::LinuxWindowManager::Unknown(If window manager is unknown or system OS
-	/// is not Linux based Windows).
+	/// is not Linux based).
 	/// </returns>
-	[[nodiscard]] LinuxWindowManager GetLinuxWindowManager();
+	LinuxWindowManager GetLinuxWindowManager();
 
 	//-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Window/Monitor.cpp
+++ b/TRAP/src/Window/Monitor.cpp
@@ -1,6 +1,8 @@
 #include "TRAPPCH.h"
 #include "Monitor.h"
 
+#ifndef TRAP_HEADLESS_MODE
+
 TRAP::Monitor::Monitor(const uint32_t monitor)
 {
 	ZoneNamedC(__tracy, tracy::Color::DarkOrange, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Window);
@@ -180,3 +182,5 @@ TRAP::Monitor::Monitor(const uint32_t monitor)
 
 	return Monitor(0);
 }
+
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Window/Monitor.h
+++ b/TRAP/src/Window/Monitor.h
@@ -1,7 +1,7 @@
 #ifndef TRAP_MONITOR_H
 #define TRAP_MONITOR_H
 
-// #include "Window.h"
+#ifndef TRAP_HEADLESS_MODE
 
 #include <cstdint>
 #include <string>
@@ -197,5 +197,7 @@ constexpr TRAP::Monitor::VideoMode::VideoMode(const int32_t width, const int32_t
 {
 	return m_handle;
 }
+
+#endif /*TRAP_HEADLESS_MODE*/
 
 #endif /*TRAP_MONITOR_H*/

--- a/TRAP/src/Window/Window.cpp
+++ b/TRAP/src/Window/Window.cpp
@@ -66,7 +66,13 @@ TRAP::Window::~Window()
 	ZoneNamedC(__tracy, tracy::Color::DarkOrange, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Window);
 
 	if(TRAP::Graphics::RendererAPI::GetRenderAPI() != TRAP::Graphics::RenderAPI::NONE)
+	{
+#ifndef TRAP_HEADLESS_MODE
 		TRAP::Graphics::RendererAPI::GetRenderer()->RemovePerViewportData(this);
+#else
+		TRAP::Graphics::RendererAPI::GetRenderer()->RemovePerViewportData();
+#endif /*TRAP_HEADLESS_MODE*/
+	}
 
 	--s_windows;
 
@@ -1107,7 +1113,7 @@ void TRAP::Window::Init(const WindowProps& props)
 
 #ifdef TRAP_HEADLESS_MODE
 	if(TRAP::Graphics::RendererAPI::GetRenderAPI() != Graphics::RenderAPI::NONE)
-		TRAP::Graphics::RendererAPI::GetRenderer()->InitPerViewportData(this);
+		TRAP::Graphics::RendererAPI::GetRenderer()->InitPerViewportData();
 #else
 	TRAP::Graphics::RendererAPI::GetRenderer()->InitPerViewportData(this);
 #endif

--- a/TRAP/src/Window/Window.cpp
+++ b/TRAP/src/Window/Window.cpp
@@ -268,6 +268,8 @@ void TRAP::Window::SetTitle(const std::string& title)
 		                   "[INDEV]" + Log::WindowVersion + Graphics::RendererAPI::GetRenderer()->GetTitle();
 #ifdef TRAP_PLATFORM_LINUX
 		newTitle += "[" + Utils::String::ConvertToString(Utils::GetLinuxWindowManager()) + "]";
+#elif defined(TRAP_PLATFORM_WINDOWS)
+		newTitle += "[Win32]";
 #endif
 
 #if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer) || defined(TRAP_ASAN)
@@ -1050,14 +1052,11 @@ void TRAP::Window::Init(const WindowProps& props)
 	#ifndef TRAP_RELEASE
 		newTitle += Graphics::RendererAPI::GetRenderer()->GetTitle();
 	#ifdef TRAP_PLATFORM_LINUX
-		if (Utils::GetLinuxWindowManager() == Utils::LinuxWindowManager::Wayland)
-			newTitle += "[Wayland]";
-		else if (Utils::GetLinuxWindowManager() == Utils::LinuxWindowManager::X11)
-			newTitle += "[X11]";
-		else
-			newTitle += "[Unknown]";
+		newTitle += "[" + Utils::String::ConvertToString(Utils::GetLinuxWindowManager()) + "]";
+	#elif defined(TRAP_PLATFORM_WINDOWS)
+		newTitle += "[Win32]";
 	#endif
-	#endif
+	#endif /*TRAP_RELEASE*/
 		INTERNAL::WindowingAPI::SetWindowTitle(*m_window, newTitle);
 	}
 

--- a/TRAP/src/Window/Window.cpp
+++ b/TRAP/src/Window/Window.cpp
@@ -68,13 +68,7 @@ TRAP::Window::~Window()
 	ZoneNamedC(__tracy, tracy::Color::DarkOrange, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Window);
 
 	if(TRAP::Graphics::RendererAPI::GetRenderAPI() != TRAP::Graphics::RenderAPI::NONE)
-	{
-#ifndef TRAP_HEADLESS_MODE
 		TRAP::Graphics::RendererAPI::GetRenderer()->RemovePerViewportData(this);
-#else
-		TRAP::Graphics::RendererAPI::GetRenderer()->RemovePerViewportData();
-#endif /*TRAP_HEADLESS_MODE*/
-	}
 
 	--s_windows;
 
@@ -229,14 +223,12 @@ void TRAP::Window::OnUpdate()
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-#ifndef TRAP_HEADLESS_MODE
 [[nodiscard]] bool TRAP::Window::GetVSync() const noexcept
 {
 	ZoneNamedC(__tracy, tracy::Color::DarkOrange, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Window) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
 
 	return m_data.VSync;
 }
-#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -566,9 +558,7 @@ void TRAP::Window::SetCursorType(const CursorType& cursor) const
 
 	INTERNAL::WindowingAPI::InternalCursor* internalCursor = INTERNAL::WindowingAPI::CreateStandardCursor(cursor);
 	INTERNAL::WindowingAPI::SetCursor(*m_window, internalCursor);
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::ImGuiWindowing::SetCustomCursor(internalCursor); //Make ImGui the owner of the cursor
-#endif /*TRAP_HEADLESS_MODE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -582,9 +572,7 @@ void TRAP::Window::SetCursorIcon(const Image* const image, const int32_t xHotspo
 			*image, xHotspot, yHotspot
 		);
 	INTERNAL::WindowingAPI::SetCursor(*m_window, cursor);
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::ImGuiWindowing::SetCustomCursor(cursor); //Make ImGui the owner of the cursor
-#endif /*TRAP_HEADLESS_MODE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -799,7 +787,6 @@ void TRAP::Window::SetDragAndDrop(const bool enabled) const
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-#ifndef TRAP_HEADLESS_MODE
 void TRAP::Window::SetVSync(const bool enabled)
 {
 	ZoneNamedC(__tracy, tracy::Color::DarkOrange, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Window);
@@ -807,7 +794,6 @@ void TRAP::Window::SetVSync(const bool enabled)
 	m_data.VSync = enabled;
 	TRAP::Graphics::RendererAPI::GetRenderer()->SetVSync(enabled, this);
 }
-#endif /*TRAP_HEADLESS_MODE*/
 
 //-------------------------------------------------------------------------------------------------------------------//
 
@@ -1113,12 +1099,7 @@ void TRAP::Window::Init(const WindowProps& props)
 
 	SetupEventCallbacks();
 
-#ifdef TRAP_HEADLESS_MODE
-	if(TRAP::Graphics::RendererAPI::GetRenderAPI() != Graphics::RenderAPI::NONE)
-		TRAP::Graphics::RendererAPI::GetRenderer()->InitPerViewportData();
-#else
 	TRAP::Graphics::RendererAPI::GetRenderer()->InitPerViewportData(this);
-#endif
 }
 
 //-------------------------------------------------------------------------------------------------------------------//
@@ -1153,17 +1134,14 @@ void TRAP::Window::SetupEventCallbacks()
 			data->Width = w;
 			data->Height = h;
 
-#ifndef TRAP_HEADLESS_MODE
 			if (!data->EventCallback)
 				return;
 
 			Events::WindowResizeEvent event(w, h, data->Win);
 			data->EventCallback(event);
-#endif /*TRAP_HEADLESS_MODE*/
 		}
 	);
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetWindowMinimizeCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, bool restored)
 		{
@@ -1184,9 +1162,7 @@ void TRAP::Window::SetupEventCallbacks()
 			}
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetWindowMaximizeCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, bool restored)
 		{
@@ -1207,7 +1183,6 @@ void TRAP::Window::SetupEventCallbacks()
 			}
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
 	INTERNAL::WindowingAPI::SetWindowPosCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, const int32_t x, const int32_t y)
@@ -1222,17 +1197,14 @@ void TRAP::Window::SetupEventCallbacks()
 				data->windowModeParams.YPos = y;
 			}
 
-#ifndef TRAP_HEADLESS_MODE
 			if (!data->EventCallback)
 				return;
 
 			Events::WindowMoveEvent event(x, y, data->Win);
 			data->EventCallback(event);
-#endif /*TRAP_HEADLESS_MODE*/
 		}
 	);
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetWindowFocusCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, const bool focused)
 		{
@@ -1253,9 +1225,7 @@ void TRAP::Window::SetupEventCallbacks()
 			}
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetWindowCloseCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window)
 		{
@@ -1268,7 +1238,6 @@ void TRAP::Window::SetupEventCallbacks()
 			data->EventCallback(event);
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
 	INTERNAL::WindowingAPI::SetKeyCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, const Input::Key key, const Input::KeyState state)
@@ -1284,44 +1253,37 @@ void TRAP::Window::SetupEventCallbacks()
 				{
 					data->KeyRepeatCounts[static_cast<uint16_t>(key)] = 0;
 
-#ifndef TRAP_HEADLESS_MODE
 					if (!data->EventCallback)
 						return;
 
 					Events::KeyPressEvent event(static_cast<Input::Key>(key), 0, data->Win);
 					data->EventCallback(event);
-#endif /*TRAP_HEADLESS_MODE*/
 				}
 				else
 				{
 					data->KeyRepeatCounts[static_cast<uint16_t>(key)]++;
 
-#ifndef TRAP_HEADLESS_MODE
 					if (!data->EventCallback)
 						return;
 
 					Events::KeyPressEvent event(static_cast<Input::Key>(key),
 					                            data->KeyRepeatCounts[static_cast<uint16_t>(key)], data->Win);
 					data->EventCallback(event);
-#endif /*TRAP_HEADLESS_MODE*/
 				}
 			}
 			else
 			{
 				data->KeyRepeatCounts.erase(static_cast<uint16_t>(key));
 
-#ifndef TRAP_HEADLESS_MODE
 				if (!data->EventCallback)
 					return;
 
 				Events::KeyReleaseEvent event(static_cast<Input::Key>(key), data->Win);
 				data->EventCallback(event);
-#endif /*TRAP_HEADLESS_MODE*/
 			}
 		}
 	);
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetCharCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, const uint32_t codePoint)
 		{
@@ -1334,9 +1296,7 @@ void TRAP::Window::SetupEventCallbacks()
 			data->EventCallback(event);
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetMouseButtonCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window,
 		   const Input::MouseButton button,
@@ -1359,9 +1319,7 @@ void TRAP::Window::SetupEventCallbacks()
 			}
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetScrollCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window,
 		   const double xOffset, const double yOffset)
@@ -1375,9 +1333,7 @@ void TRAP::Window::SetupEventCallbacks()
 			data->EventCallback(event);
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetCursorPosCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, double xPos, double yPos)
 		{
@@ -1397,7 +1353,6 @@ void TRAP::Window::SetupEventCallbacks()
 			data->EventCallback(event);
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
 	INTERNAL::WindowingAPI::SetFrameBufferSizeCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, const int32_t w, const int32_t h)
@@ -1409,17 +1364,14 @@ void TRAP::Window::SetupEventCallbacks()
 			data->Width = w;
 			data->Height = h;
 
-#ifndef TRAP_HEADLESS_MODE
 			if (!data->EventCallback || w == 0 || h == 0)
 				return;
 
 			Events::FrameBufferResizeEvent event(w, h, data->Win);
 			data->EventCallback(event);
-#endif /*TRAP_HEADLESS_MODE*/
 		}
 	);
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetCursorEnterCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, const bool entered)
 		{
@@ -1440,9 +1392,7 @@ void TRAP::Window::SetupEventCallbacks()
 			}
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetDropCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, std::vector<std::string> paths)
 		{
@@ -1455,9 +1405,7 @@ void TRAP::Window::SetupEventCallbacks()
 			data->EventCallback(event);
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
-#ifndef TRAP_HEADLESS_MODE
 	INTERNAL::WindowingAPI::SetContentScaleCallback(*m_window,
 		[](const INTERNAL::WindowingAPI::InternalWindow& window, const float xScale, const float yScale)
 		{
@@ -1470,7 +1418,6 @@ void TRAP::Window::SetupEventCallbacks()
 			data->EventCallback(event);
 		}
 	);
-#endif /*TRAP_HEADLESS_MODE*/
 
 	INTERNAL::WindowingAPI::SetMonitorCallback([](const INTERNAL::WindowingAPI::InternalMonitor& mon,
 	                                              const bool connected)
@@ -1515,7 +1462,6 @@ void TRAP::Window::SetupEventCallbacks()
 			break;
 		}
 
-#ifndef TRAP_HEADLESS_MODE
 		if (!data->EventCallback)
 			return;
 
@@ -1537,7 +1483,6 @@ void TRAP::Window::SetupEventCallbacks()
 
 			return;
 		}
-#endif /*TRAP_HEADLESS_MODE*/
 	});
 }
 

--- a/TRAP/src/Window/Window.cpp
+++ b/TRAP/src/Window/Window.cpp
@@ -1,7 +1,9 @@
 #include "TRAPPCH.h"
-#include "Utils/String/String.h"
 #include "Window.h"
 
+#ifndef TRAP_HEADLESS_MODE
+
+#include "Utils/String/String.h"
 #include "Core/PlatformDetection.h"
 #include "Utils/Dialogs/Dialogs.h"
 #include "Events/KeyEvent.h"
@@ -1582,3 +1584,5 @@ TRAP::WindowProps::AdvancedProps::AdvancedProps(const bool resizable,
 {
 	ZoneNamedC(__tracy, tracy::Color::DarkOrange, TRAP_PROFILE_SYSTEMS() & ProfileSystems::Window);
 }
+
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Window/Window.h
+++ b/TRAP/src/Window/Window.h
@@ -1,6 +1,8 @@
 #ifndef TRAP_WINDOW_H
 #define TRAP_WINDOW_H
 
+#ifndef TRAP_HEADLESS_MODE
+
 #include "Window/Monitor.h"
 #include "WindowingAPI.h"
 
@@ -497,5 +499,7 @@ namespace TRAP
 		                     uint32_t monitor = 0) noexcept;
 	};
 }
+
+#endif /*TRAP_HEADLESS_MODE*/
 
 #endif /*TRAP_WINDOW_H*/

--- a/TRAP/src/Window/Window.h
+++ b/TRAP/src/Window/Window.h
@@ -152,13 +152,11 @@ namespace TRAP
 		/// </summary>
 		/// <returns>Opacity of the window on success, empty optional otherwise.</returns>
 		[[nodiscard]] std::optional<float> GetOpacity() const;
-#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Get whether VSync is enabled or disabled.
 		/// </summary>
 		/// <returns>True if VSync is enabled, false otherwise.</returns>
 		[[nodiscard]] bool GetVSync() const noexcept;
-#endif /*TRAP_HEADLESS_MODE*/
 		/// <summary>
 		/// Get the aspect ratio of the window.
 		/// </summary>
@@ -297,13 +295,11 @@ namespace TRAP
 		/// </summary>
 		/// <param name="enabled">True to enable, false otherwise.</param>
 		void SetDragAndDrop(bool enabled) const;
-#ifndef TRAP_HEADLESS_MODE
 		/// <summary>
 		/// Enable or disable VSync for the window.
 		/// </summary>
 		/// <param name="enabled">Whether to enable VSync or not.</param>
 		void SetVSync(bool enabled);
-#endif /*TRAP_HEADLESS_MODE*/
 
 		/// <summary>
 		/// Query whether the window is maximized or not.

--- a/TRAP/src/Window/WindowingAPI.cpp
+++ b/TRAP/src/Window/WindowingAPI.cpp
@@ -2358,7 +2358,6 @@ void TRAP::INTERNAL::WindowingAPI::InputKeyboardLayout()
 {
 	ZoneNamedC(__tracy, tracy::Color::DarkOrange, (TRAP_PROFILE_SYSTEMS() & ProfileSystems::WindowingAPI) && (TRAP_PROFILE_SYSTEMS() & ProfileSystems::Verbose));
 
-#ifndef TRAP_HEADLESS_MODE
 	if(!TRAP::Input::GetEventCallback())
 		return;
 
@@ -2371,7 +2370,6 @@ void TRAP::INTERNAL::WindowingAPI::InputKeyboardLayout()
 		TRAP::Events::KeyLayoutEvent event(*layout);
 		TRAP::Input::GetEventCallback()(event);
 	}
-#endif /*TRAP_HEADLESS_MODE*/
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/TRAP/src/Window/WindowingAPI.cpp
+++ b/TRAP/src/Window/WindowingAPI.cpp
@@ -27,11 +27,11 @@ Modified by: Jan "GamesTrap" Schuerkamp
 
 #include "TRAPPCH.h"
 
-#include <limits>
-#include <thread>
-
 #include "Core/PlatformDetection.h"
 #include "WindowingAPI.h"
+
+#ifndef TRAP_HEADLESS_MODE
+
 #include "Window.h"
 #include "Events/KeyEvent.h"
 #include "Layers/ImGui/ImGuiWindowing.h"
@@ -2601,3 +2601,5 @@ void TRAP::INTERNAL::WindowingAPI::InputWindowContentScale(const InternalWindow&
 	if (window.Callbacks.Scale != nullptr)
 		window.Callbacks.Scale(window, xScale, yScale);
 }
+
+#endif /*TRAP_HEADLESS_MODE*/

--- a/TRAP/src/Window/WindowingAPI.h
+++ b/TRAP/src/Window/WindowingAPI.h
@@ -28,6 +28,8 @@ Modified by: Jan "GamesTrap" Schuerkamp
 #ifndef TRAP_WINDOWINGAPI_H
 #define TRAP_WINDOWINGAPI_H
 
+#ifndef TRAP_HEADLESS_MODE
+
 #include "Core/PlatformDetection.h"
 
 #include <forward_list>
@@ -6750,5 +6752,7 @@ inline constexpr void TRAP::INTERNAL::WindowingAPI::PlatformSetRawMouseMotionWay
 }
 
 #endif
+
+#endif /*TRAP_HEADLESS_MODE*/
 
 #endif /*TRAP_WINDOWINGAPI_H*/

--- a/TRAP/src/Window/WindowingAPILinux.cpp
+++ b/TRAP/src/Window/WindowingAPILinux.cpp
@@ -722,8 +722,6 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetRawMouseMotion(const InternalWindo
 
 void TRAP::INTERNAL::WindowingAPI::SetProgressIndicator(const ProgressState state, const double progress)
 {
-    TRAP_ASSERT(Utils::GetLinuxWindowManager() != Utils::LinuxWindowManager::Unknown, "Unsupported window manager");
-
 	ZoneNamedC(__tracy, tracy::Color::DarkOrange, TRAP_PROFILE_SYSTEMS() & ProfileSystems::WindowingAPI);
 
     if((s_Data.DBUS.Handle == nullptr) || (s_Data.DBUS.Connection == nullptr))
@@ -788,8 +786,6 @@ void TRAP::INTERNAL::WindowingAPI::SetProgressIndicator(const ProgressState stat
 void TRAP::INTERNAL::WindowingAPI::PlatformSetWindowProgressIndicator([[maybe_unused]] const InternalWindow& window,
                                                                       const ProgressState state, const double progress)
 {
-    TRAP_ASSERT(Utils::GetLinuxWindowManager() != Utils::LinuxWindowManager::Unknown, "Unsupported window manager");
-
 	ZoneNamedC(__tracy, tracy::Color::DarkOrange, TRAP_PROFILE_SYSTEMS() & ProfileSystems::WindowingAPI);
 
     SetProgressIndicator(state, progress);

--- a/TRAP/src/Window/WindowingAPILinux.cpp
+++ b/TRAP/src/Window/WindowingAPILinux.cpp
@@ -32,6 +32,9 @@ Modified by: Jan "GamesTrap" Schuerkamp
 #ifdef TRAP_PLATFORM_LINUX
 
 #include "WindowingAPI.h"
+
+#ifndef TRAP_HEADLESS_MODE
+
 #include "Application.h"
 #include "Utils/Utils.h"
 #include "Utils/Time/TimeStep.h"
@@ -1101,4 +1104,6 @@ bool TRAP::INTERNAL::WindowingAPI::PollPOSIX(pollfd* const fds, const nfds_t cou
 	}
 }
 
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
+
+#endif /*TRAP_PLATFORM_LINUX*/

--- a/TRAP/src/Window/WindowingAPILinuxWayland.cpp
+++ b/TRAP/src/Window/WindowingAPILinuxWayland.cpp
@@ -25,9 +25,6 @@ freely, subject to the following restrictions:
 Modified by: Jan "GamesTrap" Schuerkamp
 */
 
-#include <cstddef>
-
-#include "Input/Input.h"
 #include "TRAPPCH.h"
 
 #include "Core/PlatformDetection.h"
@@ -35,6 +32,9 @@ Modified by: Jan "GamesTrap" Schuerkamp
 #ifdef TRAP_PLATFORM_LINUX
 
 #include "WindowingAPI.h"
+
+#ifndef TRAP_HEADLESS_MODE
+
 #include "Application.h"
 #include "Utils/Utils.h"
 #include "Utils/DynamicLoading/DynamicLoading.h"
@@ -4015,4 +4015,6 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetDragAndDropWayland([[maybe_unused]
     InputError(Error::Feature_Unavailable, "[Wayland] Platform does not support toggling drag and drop. Drag and drop is enabled by default.");
 }
 
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
+
+#endif /*TRAP_PLATFORM_LINUX*/

--- a/TRAP/src/Window/WindowingAPILinuxX11.cpp
+++ b/TRAP/src/Window/WindowingAPILinuxX11.cpp
@@ -25,16 +25,17 @@ freely, subject to the following restrictions:
 Modified by: Jan "GamesTrap" Schuerkamp
 */
 
-#include <cstddef>
-
 #include "TRAPPCH.h"
 
 #include "Core/PlatformDetection.h"
-#include "Utils/String/String.h"
 
 #ifdef TRAP_PLATFORM_LINUX
 
 #include "WindowingAPI.h"
+
+#ifndef TRAP_HEADLESS_MODE
+
+#include "Utils/String/String.h"
 #include "Application.h"
 #include "Utils/Utils.h"
 #include "Utils/DynamicLoading/DynamicLoading.h"
@@ -5014,4 +5015,6 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetDragAndDropX11(InternalWindow& win
 		s_Data.X11.XLIB.DeleteProperty(s_Data.X11.display, window.X11.Handle, s_Data.X11.XDNDAware);
 }
 
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
+
+#endif /*TRAP_PLATFORM_LINUX*/

--- a/TRAP/src/Window/WindowingAPIWin32.cpp
+++ b/TRAP/src/Window/WindowingAPIWin32.cpp
@@ -29,6 +29,9 @@ Modified by: Jan "GamesTrap" Schuerkamp
 
 #include "Core/PlatformDetection.h"
 #include "WindowingAPI.h"
+
+#ifndef TRAP_HEADLESS_MODE
+
 #include "Utils/Dialogs/Dialogs.h"
 #include "Utils/DynamicLoading/DynamicLoading.h"
 #include "Application.h"
@@ -3573,4 +3576,6 @@ void TRAP::INTERNAL::WindowingAPI::PlatformSetDragAndDrop(InternalWindow& window
 	DragAcceptFiles(window.Handle, value);
 }
 
-#endif
+#endif /*TRAP_HEADLESS_MODE*/
+
+#endif /*TRAP_PLATFORM_WINDOWS*/


### PR DESCRIPTION
# General

This PR decouples the Headless mode from specific classes/structs/namespaces which are usable in normal mode.

## What changed

- Removed usage of `TRAP::Window` in Headless mode.
- Removed support for the following APIs in Headless mode:
  - `TRAP::Window`
  - `TRAP::Monitor`
  - `TRAP::Graphics::SwapChain`
  - `TRAP::Graphics::API::VulkanSwapChain`
  - `TRAP::Graphics::API::VulkanSurface`
  - `TRAP::Input`
  - `TRAP::INTERNAL::WindowingAPI`
- Removed unnecessary `TRAP_HEADLESS_MODE` checks
- Removed unnecessary `TRAP::Utils::GetLinuxWindowManager()` checks

## New features

- Added saving and loading of Viewport size to/from engine.cfg
- Added `RendererAPI::GetResolution()` function to query the current viewport size.