### PR TITLE
WindowingAPI Wayland arbitrary (emulated) video mode support (resolves #103)

### DIFF
--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -4574,3 +4574,7 @@ SITREP 10/21/2023|23w42b2
     - Changed TRAP Engine version to 23w42b2(0.9.120)
     - Utils GetCPUInfo() Linux Replaced inline assembly with cpuid compiler intrinsic ~<5 mins
     - WindowingAPILinuxWayland Fixed glitching when windows change between fractional and non-fractional scaling code paths ~<5 mins
+    - WindowingAPILinuxWayland Only add emulated video modes if wp_viewporter protocol is supported ~<5 mins
+    - WindowingAPILinuxWayland Fixed PointerHandleMotion() using wrong cursor position for InputCursorPos() call ~<5 mins
+    - WindowingAPILinuxWayland Added support for arbitrary (emulated) video modes ~<30 mins
+    - WindowingAPILinuxWayland Added support for using arbitrary video mode and fractional scaling at the same time ~<30 mins

--- a/TRAP/src/Window/WindowingAPI.h
+++ b/TRAP/src/Window/WindowingAPI.h
@@ -1723,6 +1723,7 @@ namespace TRAP::INTERNAL
 				bool Visible;
 				bool Activated;
 				bool Fullscreen;
+				bool EmulatedVideoModeActive = false;
 				bool Hovered;
 				wl_surface* Surface;
 				wl_callback* Callback;

--- a/TRAP/src/Window/WindowingAPILinuxWayland.cpp
+++ b/TRAP/src/Window/WindowingAPILinuxWayland.cpp
@@ -1190,7 +1190,7 @@ void TRAP::INTERNAL::WindowingAPI::PointerHandleMotion([[maybe_unused]] void* co
     {
     case TRAPDecorationSideWayland::MainWindow:
         s_Data.Wayland.CursorPreviousName = "";
-        InputCursorPos(*window, x, y);
+        InputCursorPos(*window, window->Wayland.CursorPosX, window->Wayland.CursorPosY);
         break;
 
     case TRAPDecorationSideWayland::TopDecoration:


### PR DESCRIPTION
This PR implements support for emulated (arbitrary) video modes. Resolves #103.
This allows use to expose more exclusive fullscreen resolutions other than the currently set monitor resolution on Wayland.

Currently Wayland only gives us the current monitor video mode like:
2560x1440@144Hz

Using the video mode emulation we now have access to all the usually selectable resolutions.

For example:
(16:9)
2560x1440@144Hz
1920x1080@144Hz
1280x720@144Hz
(4:3)
1920x1440@144Hz
1024x768@144Hz
800x600@144Hz
...

Note: We can only change the resolution but not the refresh rate!

Partially based on **stale** upstream PR in [GLFW](https://github.com/glfw/glfw):

- https://github.com/glfw/glfw/pull/1273

and on SDL:

- https://github.com/libsdl-org/SDL/commit/4d76c9cb46491064b1817bd69f78d59783546ee5