### PR TITLE
Switch from GitHub artifacts to homebrew made ones

### DIFF
--- a/.github/composite/artifact-upload/action.yml
+++ b/.github/composite/artifact-upload/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
           7z a -t7z -m0=LZMA2 -mmt=$(nproc) -mx9 -md=64m -mfb=64 -ms=16g -mqs=on -sccUTF-8 -bb0 -bse0 -bsp2 -w -mtc=on -mta=on '${{inputs.target-filename}}.7z' ${{inputs.folder-to-upload}}
     - name: Upload artifact (Windows)
-      shell: pwsh
+      shell: powershell
       if: runner.os == 'Windows'
       run: |
           New-PSDrive -Name "X" -PSProvider FileSystem -Root "\\${{inputs.server-hostname}}\${{inputs.server-share}}" -Persist -Credential (New-Object System.Management.Automation.PSCredential (${{inputs.server-username}}, (ConvertTo-SecureString ${{inputs.server-password}} -AsPlainText -Force)))

--- a/.github/composite/artifact-upload/action.yml
+++ b/.github/composite/artifact-upload/action.yml
@@ -38,7 +38,6 @@ runs:
           7z a -t7z -m0=LZMA2 -mmt=$(nproc) -mx9 -md=64m -mfb=64 -ms=16g -mqs=on -sccUTF-8 -bb0 -bse0 -bsp2 -w -mtc=on -mta=on '${{inputs.target-filename}}.7z' '${{inputs.folder-to-upload}}/.'
     - name: Upload artifact (Windows)
       shell: pwsh
-      id: upload-artifact
       if: runner.os == 'Windows'
       run: |
           New-PSDrive -Name "X" -PSProvider FileSystem -Root "\\${{inputs.server-hostname}}\artifacts" -Persist -Credential (New-Object System.Management.Automation.PSCredential (${{inputs.server-username}}, (ConvertTo-SecureString ${{inputs.server-password}} -AsPlainText -Force)))
@@ -46,7 +45,6 @@ runs:
           Remove-PSDrive -Name "X"
     - name: Upload artifact (Linux)
       shell: bash
-      id: upload-artifact
       if: runner.os == 'Linux'
       run: |
           sudo apt install -y smbclient

--- a/.github/composite/artifact-upload/action.yml
+++ b/.github/composite/artifact-upload/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
       id: archive-artifact
       run: |
-          7z a -t7z -m0=LZMA2 -mmt=$(nproc) -mx9 -md=64m -mfb=64 -ms=16g -mqs=on -sccUTF-8 -bb0 -bse0 -bsp2 -w -mtc=on -mta=on '${{inputs.target-filename}}.7z' '${{inputs.folder-to-upload}}/.'
+          7z a -t7z -m0=LZMA2 -mmt=$(nproc) -mx9 -md=64m -mfb=64 -ms=16g -mqs=on -sccUTF-8 -bb0 -bse0 -bsp2 -w -mtc=on -mta=on '${{inputs.target-filename}}.7z' ${{inputs.folder-to-upload}}
     - name: Upload artifact (Windows)
       shell: pwsh
       if: runner.os == 'Windows'

--- a/.github/composite/artifact-upload/action.yml
+++ b/.github/composite/artifact-upload/action.yml
@@ -28,7 +28,7 @@ runs:
             echo "TARGET_PATH=${{ github.event.repository.name }}/branch/${{ github.ref_name }}/${{github.run_number}}_${{github.run_attempt}}_${{github.sha}}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == 'pull_request' ]]; then
             echo "TARGET_PATH=${{ github.event.repository.name }}/pull_request/${{github.event.pull_request.number}}/${{github.run_number}}_${{github.run_attempt}}_${{github.sha}}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event.name }}" == 'workflow_dispatch' ]]; then
+          elif [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
             echo "TARGET_PATH=${{ github.event.repository.name }}/workflow_dispatch/${{github.run_number}}_${{github.run_attempt}}_${{github.sha}}" >> "$GITHUB_OUTPUT"
           fi
     - name: Archive artifact (7z)
@@ -48,7 +48,7 @@ runs:
       if: runner.os == 'Linux'
       run: |
           sudo apt install -y smbclient
-          smbclient //${{inputs.server-hostname}}/artifacts -U ${{inputs.server-username}}%${{inputs.server-password}} -c 'prompt; recurse; mkdir "${{steps.build-dest-path.outputs.TARGET_PATH}}"; put "${{inputs.target-filename}}.7z" "$${{steps.build-dest-path.outputs.TARGET_PATH}}/${{inputs.target-filename}}.7z"'
+          smbclient //${{inputs.server-hostname}}/artifacts -U ${{inputs.server-username}}%${{inputs.server-password}} -c 'prompt; recurse; mkdir "${{steps.build-dest-path.outputs.TARGET_PATH}}"; put "${{inputs.target-filename}}.7z" "${{steps.build-dest-path.outputs.TARGET_PATH}}/${{inputs.target-filename}}.7z"'
     - name: Cleanup artifact
       shell: bash
       id: cleanup-artifact

--- a/.github/composite/artifact-upload/action.yml
+++ b/.github/composite/artifact-upload/action.yml
@@ -43,8 +43,8 @@ runs:
       shell: powershell
       if: runner.os == 'Windows'
       run: |
-          New-PSDrive -Name "X" -PSProvider FileSystem -Root "\\${{inputs.server-hostname}}\${{inputs.server-share}}" -Persist -Credential (New-Object System.Management.Automation.PSCredential (${{inputs.server-username}}, (ConvertTo-SecureString ${{inputs.server-password}} -AsPlainText -Force)))
-          Copy-Item -Path ${{inputs.target-filename}}.7z -Destination (New-Item -type directory -force "X:\${{steps.build-dest-path.outputs.TARGET_PATH}}") -force -ea 0
+          New-PSDrive -Name "X" -PSProvider FileSystem -Root "\\${{inputs.server-hostname}}\${{inputs.server-share}}" -Persist -Credential (New-Object System.Management.Automation.PSCredential ("${{inputs.server-username}}", (ConvertTo-SecureString "${{inputs.server-password}}" -AsPlainText -Force)))
+          Copy-Item -Path "${{inputs.target-filename}}.7z" -Destination (New-Item -type directory -force "X:\${{steps.build-dest-path.outputs.TARGET_PATH}}") -force -ea 0
           Remove-PSDrive -Name "X"
     - name: Upload artifact (Linux)
       shell: bash

--- a/.github/composite/artifact-upload/action.yml
+++ b/.github/composite/artifact-upload/action.yml
@@ -1,0 +1,58 @@
+name: "Artifact upload"
+author: Jan Schürkamp <gamestrap@trappedgames.de>
+description: ""
+inputs:
+  folder-to-upload:
+    description: ""
+    required: true
+  target-filename:
+    description: ""
+    required: true
+  server-hostname:
+    description: ""
+    required: true
+  server-username:
+    description: ""
+    required: true
+  server-password:
+    description: ""
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Build destination path
+      shell: bash
+      id: build-dest-path
+      run: |
+          if [[ "${{ github.event_name }}" == 'push' ]]; then
+            echo "TARGET_PATH=${{ github.event.repository.name }}/branch/${{ github.ref_name }}/${{github.run_number}}_${{github.run_attempt}}_${{github.sha}}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+            echo "TARGET_PATH=${{ github.event.repository.name }}/pull_request/${{github.event.pull_request.number}}/${{github.run_number}}_${{github.run_attempt}}_${{github.sha}}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event.name }}" == 'workflow_dispatch' ]]; then
+            echo "TARGET_PATH=${{ github.event.repository.name }}/workflow_dispatch/${{github.run_number}}_${{github.run_attempt}}_${{github.sha}}" >> "$GITHUB_OUTPUT"
+          fi
+    - name: Archive artifact (7z)
+      shell: bash
+      id: archive-artifact
+      run: |
+          7z a -t7z -m0=LZMA2 -mmt=$(nproc) -mx9 -md=64m -mfb=64 -ms=16g -mqs=on -sccUTF-8 -bb0 -bse0 -bsp2 -w -mtc=on -mta=on '${{inputs.target-filename}}.7z' '${{inputs.folder-to-upload}}/.'
+    - name: Upload artifact (Windows)
+      shell: pwsh
+      id: upload-artifact
+      if: runner.os == 'Windows'
+      run: |
+          New-PSDrive -Name "X" -PSProvider FileSystem -Root "\\${{inputs.server-hostname}}\artifacts" -Persist -Credential (New-Object System.Management.Automation.PSCredential (${{inputs.server-username}}, (ConvertTo-SecureString ${{inputs.server-password}} -AsPlainText -Force)))
+          Copy-Item -Path ${{inputs.target-filename}}.7z -Destination (New-Item -type directory -force "X:\${{steps.build-dest-path.outputs.TARGET_PATH}}") -force -ea 0
+          Remove-PSDrive -Name "X"
+    - name: Upload artifact (Linux)
+      shell: bash
+      id: upload-artifact
+      if: runner.os == 'Linux'
+      run: |
+          sudo apt install -y smbclient
+          smbclient //${{inputs.server-hostname}}/artifacts -U ${{inputs.server-username}}%${{inputs.server-password}} -c 'prompt; recurse; mkdir "${{steps.build-dest-path.outputs.TARGET_PATH}}"; put "${{inputs.target-filename}}.7z" "$${{steps.build-dest-path.outputs.TARGET_PATH}}/${{inputs.target-filename}}.7z"'
+    - name: Cleanup artifact
+      shell: bash
+      id: cleanup-artifact
+      run: |
+          rm '${{inputs.target-filename}}.7z'

--- a/.github/composite/artifact-upload/action.yml
+++ b/.github/composite/artifact-upload/action.yml
@@ -11,6 +11,9 @@ inputs:
   server-hostname:
     description: ""
     required: true
+  server-share:
+    description: ""
+    required: true
   server-username:
     description: ""
     required: true
@@ -40,7 +43,7 @@ runs:
       shell: pwsh
       if: runner.os == 'Windows'
       run: |
-          New-PSDrive -Name "X" -PSProvider FileSystem -Root "\\${{inputs.server-hostname}}\artifacts" -Persist -Credential (New-Object System.Management.Automation.PSCredential (${{inputs.server-username}}, (ConvertTo-SecureString ${{inputs.server-password}} -AsPlainText -Force)))
+          New-PSDrive -Name "X" -PSProvider FileSystem -Root "\\${{inputs.server-hostname}}\${{inputs.server-share}}" -Persist -Credential (New-Object System.Management.Automation.PSCredential (${{inputs.server-username}}, (ConvertTo-SecureString ${{inputs.server-password}} -AsPlainText -Force)))
           Copy-Item -Path ${{inputs.target-filename}}.7z -Destination (New-Item -type directory -force "X:\${{steps.build-dest-path.outputs.TARGET_PATH}}") -force -ea 0
           Remove-PSDrive -Name "X"
     - name: Upload artifact (Linux)
@@ -48,7 +51,7 @@ runs:
       if: runner.os == 'Linux'
       run: |
           sudo apt install -y smbclient
-          smbclient //${{inputs.server-hostname}}/artifacts -U ${{inputs.server-username}}%${{inputs.server-password}} -c 'prompt; recurse; mkdir "${{steps.build-dest-path.outputs.TARGET_PATH}}"; put "${{inputs.target-filename}}.7z" "${{steps.build-dest-path.outputs.TARGET_PATH}}/${{inputs.target-filename}}.7z"'
+          smbclient //${{inputs.server-hostname}}/${{inputs.server-share}} -U ${{inputs.server-username}}%${{inputs.server-password}} -c 'prompt; recurse; mkdir "${{steps.build-dest-path.outputs.TARGET_PATH}}"; put "${{inputs.target-filename}}.7z" "${{steps.build-dest-path.outputs.TARGET_PATH}}/${{inputs.target-filename}}.7z"'
     - name: Cleanup artifact
       shell: bash
       id: cleanup-artifact

--- a/.github/runners/Ubuntu/Dockerfile.linux.base
+++ b/.github/runners/Ubuntu/Dockerfile.linux.base
@@ -45,6 +45,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
     git-lfs \
     nodejs \
     btop \
+    p7zip-full \
   && DPKG_ARCH="$(dpkg --print-architecture)" \
   && LSB_RELEASE_CODENAME="$(lsb_release --codename | cut -f2)" \
   && sed -e 's/Defaults.*env_reset/Defaults env_keep = "HTTP_PROXY HTTPS_PROXY NO_PROXY FTP_PROXY http_proxy https_proxy no_proxy ftp_proxy"/' -i /etc/sudoers \

--- a/.github/runners/Windows/install_software.ps1
+++ b/.github/runners/Windows/install_software.ps1
@@ -6,8 +6,10 @@ Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 refreshenv
 $GitBashPath = "C:\Program Files\git\bin"
 $CMakePath = "C:\Program Files\CMake\bin"
+$7zPath = "C:\Program Files\7-Zip"
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH + $GitBashPath, "Machine") #Add bash.exe to PATH
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH + $CMakePath, "Machine") #Add cmake.exe to PATH
+[Environment]::SetEnvironmentVariable("PATH", $env:PATH + $7zPath, "Machine") #Add 7z.exe to PATH
 
 #Create alias for node12
 if (!(Test-Path $PROFILE))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,10 +333,21 @@ jobs:
     runs-on: [self-hosted, windows, X64, cpu]
     needs: [build-windows-msvc-2022]
     steps:
+      - name: Cleanup workspace
+        if: ${{ always() }}
+        uses: gamestrap/gha-workspace-cleanup@v1.2.4
       # - name: Download artifact
       #   uses: actions/download-artifact@v3
       #   with:
       #     name: Windows MSVC 2022 Release Executables
+      - name: Download artifact (TrappedGames)
+        uses: gamestrap/gha-download-artifact@v1.0.1
+        with:
+          server-hostname: ${{ secrets.ARTIFACT_HOST }}
+          server-share: "artifacts"
+          server-username: ${{ secrets.ARTIFACT_USERNAME }}
+          server-password: ${{ secrets.ARTIFACT_PASSWORD }}
+          artifact-name: "Windows MSVC Release Executables"
       - name: Run Tests
         run: |
           cd UnitTests
@@ -346,10 +357,21 @@ jobs:
     runs-on: [self-hosted, Linux, X64, ubuntu, "23.10", cpu]
     needs: [build-linux-clang-17]
     steps:
+      - name: Cleanup workspace
+        if: ${{ always() }}
+        uses: gamestrap/gha-workspace-cleanup@v1.2.4
       # - name: Download artifact
       #   uses: actions/download-artifact@v3
       #   with:
       #     name: Linux Clang Release Executables
+      - name: Download artifact (TrappedGames)
+        uses: gamestrap/gha-download-artifact@v1.0.1
+        with:
+          server-hostname: ${{ secrets.ARTIFACT_HOST }}
+          server-share: "artifacts"
+          server-username: ${{ secrets.ARTIFACT_USERNAME }}
+          server-password: ${{ secrets.ARTIFACT_PASSWORD }}
+          artifact-name: "Linux Clang Release Executables"
       - name: Run Tests
         run: |
           cd UnitTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,7 +350,7 @@ jobs:
       #   with:
       #     name: Windows MSVC 2022 Release Executables
       - name: Download artifact (TrappedGames)
-        uses: gamestrap/gha-download-artifact@v1.0.2
+        uses: gamestrap/gha-download-artifact@v1.0.3
         with:
           server-hostname: ${{ secrets.ARTIFACT_HOST }}
           server-share: "artifacts"
@@ -374,7 +374,7 @@ jobs:
       #   with:
       #     name: Linux Clang Release Executables
       - name: Download artifact (TrappedGames)
-        uses: gamestrap/gha-download-artifact@v1.0.2
+        uses: gamestrap/gha-download-artifact@v1.0.3
         with:
           server-hostname: ${{ secrets.ARTIFACT_HOST }}
           server-share: "artifacts"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,7 @@ jobs:
         cp -r Games/TRAP-Editor/Assets bin/Release-linux-x86_64/Games/TRAP-Editor/
         cp -r Games/TRAP-Editor/Resources bin/Release-linux-x86_64/Games/TRAP-Editor/
         cp -r Utility/QOIConv bin/Release-linux-x86_64/Utility/
+        cp -r Licenses bin/Release-linux-x86_64/Licenses
         rm bin/Release-linux-x86_64/Utility/QOIConv/QOIConv.exe
     - name: Upload artifacts (TrappedGames)
       uses: ./.github/composite/artifact-upload
@@ -112,6 +113,7 @@ jobs:
           bin/Release-linux-x86_64/./Games
           bin/Release-linux-x86_64/./Utility
           bin/Release-linux-x86_64/./UnitTests
+          bin/Release-linux-x86_64/./Licenses
     # - name: Upload artifacts
     #   uses: actions/upload-artifact@v3
     #   with:
@@ -120,6 +122,7 @@ jobs:
     #       bin/Release-linux-x86_64/Games
     #       bin/Release-linux-x86_64/Utility
     #       bin/Release-linux-x86_64/UnitTests
+    #       bin/Release-linux-x86_64/Licenses
   build-linux-clang-17:
     name: Build Linux Clang 17
     runs-on: [self-hosted, Linux, X64, ubuntu, "23.10", cpu]
@@ -206,6 +209,7 @@ jobs:
         cp -r Games/TRAP-Editor/Assets bin/Release-linux-x86_64/Games/TRAP-Editor/
         cp -r Games/TRAP-Editor/Resources bin/Release-linux-x86_64/Games/TRAP-Editor/
         cp -r Utility/QOIConv bin/Release-linux-x86_64/Utility/
+        cp -r Licenses bin/Release-linux-x86_64/Licenses
         rm bin/Release-linux-x86_64/Utility/QOIConv/QOIConv.exe
     - name: Upload artifacts (TrappedGames)
       uses: ./.github/composite/artifact-upload
@@ -219,6 +223,7 @@ jobs:
           bin/Release-linux-x86_64/./Games
           bin/Release-linux-x86_64/./Utility
           bin/Release-linux-x86_64/./UnitTests
+          bin/Release-linux-x86_64/./Licenses
     # - name: Upload artifacts
     #   uses: actions/upload-artifact@v3
     #   with:
@@ -227,6 +232,7 @@ jobs:
     #       bin/Release-linux-x86_64/Games
     #       bin/Release-linux-x86_64/Utility
     #       bin/Release-linux-x86_64/UnitTests
+    #       bin/Release-linux-x86_64/Licenses
   build-windows-msvc-2022:
     name: Build Windows MSVC 2022
     runs-on: [self-hosted, windows, X64, cpu]
@@ -301,6 +307,7 @@ jobs:
         Xcopy Games\Tests3D\Assets bin\Release-windows-x86_64\Games\Tests3D\Assets /I /H /E /C
         Xcopy Games\TRAP-Editor\Assets bin\Release-windows-x86_64\Games\TRAP-Editor\Assets /I /H /E /C
         Xcopy Games\TRAP-Editor\Resources bin\Release-windows-x86_64\Games\TRAP-Editor\Resources /I /H /E /C
+        Xcopy Licenses bin\Release-windows-x86_64\Licenses /I /H /E /C
         Xcopy Utility\QOIConv bin\Release-windows-x86_64\Utility\QOIConv /I /H /E /C
         Xcopy Redists bin\Release-windows-x86_64\Redists /I /H /E /C
         Get-ChildItem -Path "bin" -Filter "*.pdb" -Recurse | Remove-Item -Force
@@ -317,6 +324,7 @@ jobs:
           bin/Release-windows-x86_64/./Games
           bin/Release-windows-x86_64/./Utility
           bin/Release-windows-x86_64/./UnitTests
+          bin/Release-windows-x86_64/./Licenses
           bin/Release-windows-x86_64/./Redists
     # - name: Upload artifacts
     #   uses: actions/upload-artifact@v3
@@ -325,8 +333,9 @@ jobs:
     #     path: |
     #       bin/Release-windows-x86_64/Games
     #       bin/Release-windows-x86_64/Utility
-    #       bin/Release-windows-x86_64/Redists
     #       bin/Release-windows-x86_64/UnitTests
+    #       bin/Release-windows-x86_64/Licenses
+    #       bin/Release-windows-x86_64/Redists
 
   test-windows:
     name: Unit-Test Windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,21 +105,21 @@ jobs:
       with:
         target-filename: Linux GCC Release Executables
         server-hostname: ${{ secrets.ARTIFACT_HOST }}
-        server-share: ${{ secrets.ARTIFACT_SHARE }}
+        server-share: "artifacts"
         server-username: ${{ secrets.ARTIFACT_USERNAME }}
         server-password: ${{ secrets.ARTIFACT_PASSWORD }}
         folder-to-upload: >
           bin/Release-linux-x86_64/./Games
           bin/Release-linux-x86_64/./Utility
           bin/Release-linux-x86_64/./UnitTests
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: Linux GCC Release Executables
-        path: |
-          bin/Release-linux-x86_64/Games
-          bin/Release-linux-x86_64/Utility
-          bin/Release-linux-x86_64/UnitTests
+    # - name: Upload artifacts
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: Linux GCC Release Executables
+    #     path: |
+    #       bin/Release-linux-x86_64/Games
+    #       bin/Release-linux-x86_64/Utility
+    #       bin/Release-linux-x86_64/UnitTests
   build-linux-clang-17:
     name: Build Linux Clang 17
     runs-on: [self-hosted, Linux, X64, ubuntu, "23.10", cpu]
@@ -212,21 +212,21 @@ jobs:
       with:
         target-filename: Linux Clang Release Executables
         server-hostname: ${{ secrets.ARTIFACT_HOST }}
-        server-share: ${{ secrets.ARTIFACT_SHARE }}
+        server-share: "artifacts"
         server-username: ${{ secrets.ARTIFACT_USERNAME }}
         server-password: ${{ secrets.ARTIFACT_PASSWORD }}
         folder-to-upload: >
           bin/Release-linux-x86_64/./Games
           bin/Release-linux-x86_64/./Utility
           bin/Release-linux-x86_64/./UnitTests
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: Linux Clang Release Executables
-        path: |
-          bin/Release-linux-x86_64/Games
-          bin/Release-linux-x86_64/Utility
-          bin/Release-linux-x86_64/UnitTests
+    # - name: Upload artifacts
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: Linux Clang Release Executables
+    #     path: |
+    #       bin/Release-linux-x86_64/Games
+    #       bin/Release-linux-x86_64/Utility
+    #       bin/Release-linux-x86_64/UnitTests
   build-windows-msvc-2022:
     name: Build Windows MSVC 2022
     runs-on: [self-hosted, windows, X64, cpu]
@@ -310,7 +310,7 @@ jobs:
       with:
         target-filename: Windows MSVC Release Executables
         server-hostname: ${{ secrets.ARTIFACT_HOST }}
-        server-share: ${{ secrets.ARTIFACT_SHARE }}
+        server-share: "artifacts"
         server-username: ${{ secrets.ARTIFACT_USERNAME }}
         server-password: ${{ secrets.ARTIFACT_PASSWORD }}
         folder-to-upload: >
@@ -318,15 +318,15 @@ jobs:
           bin/Release-windows-x86_64/./Utility
           bin/Release-windows-x86_64/./UnitTests
           bin/Release-windows-x86_64/./Redists
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: Windows MSVC 2022 Release Executables
-        path: |
-          bin/Release-windows-x86_64/Games
-          bin/Release-windows-x86_64/Utility
-          bin/Release-windows-x86_64/Redists
-          bin/Release-windows-x86_64/UnitTests
+    # - name: Upload artifacts
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: Windows MSVC 2022 Release Executables
+    #     path: |
+    #       bin/Release-windows-x86_64/Games
+    #       bin/Release-windows-x86_64/Utility
+    #       bin/Release-windows-x86_64/Redists
+    #       bin/Release-windows-x86_64/UnitTests
 
   test-windows:
     name: Unit-Test Windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,17 @@ jobs:
         cp -r Games/TRAP-Editor/Resources bin/Release-linux-x86_64/Games/TRAP-Editor/
         cp -r Utility/QOIConv bin/Release-linux-x86_64/Utility/
         rm bin/Release-linux-x86_64/Utility/QOIConv/QOIConv.exe
+    - name: Upload artifacts (TrappedGames)
+      uses: ./.github/composite/artifact-upload
+      with:
+        target-filename: Linux GCC Release Executables
+        server-hostname: ${{ secrets.ARTIFACT_HOST }}
+        server-username: ${{ secrets.ARTIFACT_USERNAME }}
+        server-password: ${{ secrets.ARTIFACT_PASSWORD }}
+        folder-to-upload: |
+          bin/Release-linux-x86_64/./Games
+          bin/Release-linux-x86_64/./Utility
+          bin/Release-linux-x86_64/./UnitTests
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,10 +333,10 @@ jobs:
     runs-on: [self-hosted, windows, X64, cpu]
     needs: [build-windows-msvc-2022]
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: Windows MSVC 2022 Release Executables
+      # - name: Download artifact
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: Windows MSVC 2022 Release Executables
       - name: Run Tests
         run: |
           cd UnitTests
@@ -346,10 +346,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64, ubuntu, "23.10", cpu]
     needs: [build-linux-clang-17]
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: Linux Clang Release Executables
+      # - name: Download artifact
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: Linux Clang Release Executables
       - name: Run Tests
         run: |
           cd UnitTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,6 +206,17 @@ jobs:
         cp -r Games/TRAP-Editor/Resources bin/Release-linux-x86_64/Games/TRAP-Editor/
         cp -r Utility/QOIConv bin/Release-linux-x86_64/Utility/
         rm bin/Release-linux-x86_64/Utility/QOIConv/QOIConv.exe
+    - name: Upload artifacts (TrappedGames)
+      uses: ./.github/composite/artifact-upload
+      with:
+        target-filename: Linux Clang Release Executables
+        server-hostname: ${{ secrets.ARTIFACT_HOST }}
+        server-username: ${{ secrets.ARTIFACT_USERNAME }}
+        server-password: ${{ secrets.ARTIFACT_PASSWORD }}
+        folder-to-upload: >
+          bin/Release-linux-x86_64/./Games
+          bin/Release-linux-x86_64/./Utility
+          bin/Release-linux-x86_64/./UnitTests
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -292,6 +303,18 @@ jobs:
         Xcopy Redists bin\Release-windows-x86_64\Redists /I /H /E /C
         Get-ChildItem -Path "bin" -Filter "*.pdb" -Recurse | Remove-Item -Force
         Remove-Item bin\Release-windows-x86_64\Utility\QOIConv\QOIConv
+    - name: Upload artifacts (TrappedGames)
+      uses: ./.github/composite/artifact-upload
+      with:
+        target-filename: Windows MSVC Release Executables
+        server-hostname: ${{ secrets.ARTIFACT_HOST }}
+        server-username: ${{ secrets.ARTIFACT_USERNAME }}
+        server-password: ${{ secrets.ARTIFACT_PASSWORD }}
+        folder-to-upload: >
+          bin/Release-windows-x86_64/./Games
+          bin/Release-windows-x86_64/./Utility
+          bin/Release-windows-x86_64/./UnitTests
+          bin/Release-windows-x86_64/./Redists
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
         server-hostname: ${{ secrets.ARTIFACT_HOST }}
         server-username: ${{ secrets.ARTIFACT_USERNAME }}
         server-password: ${{ secrets.ARTIFACT_PASSWORD }}
-        folder-to-upload: |
+        folder-to-upload: >
           bin/Release-linux-x86_64/./Games
           bin/Release-linux-x86_64/./Utility
           bin/Release-linux-x86_64/./UnitTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,7 @@ jobs:
       with:
         target-filename: Linux GCC Release Executables
         server-hostname: ${{ secrets.ARTIFACT_HOST }}
+        server-share: ${{ secrets.ARTIFACT_SHARE }}
         server-username: ${{ secrets.ARTIFACT_USERNAME }}
         server-password: ${{ secrets.ARTIFACT_PASSWORD }}
         folder-to-upload: >
@@ -211,6 +212,7 @@ jobs:
       with:
         target-filename: Linux Clang Release Executables
         server-hostname: ${{ secrets.ARTIFACT_HOST }}
+        server-share: ${{ secrets.ARTIFACT_SHARE }}
         server-username: ${{ secrets.ARTIFACT_USERNAME }}
         server-password: ${{ secrets.ARTIFACT_PASSWORD }}
         folder-to-upload: >
@@ -308,6 +310,7 @@ jobs:
       with:
         target-filename: Windows MSVC Release Executables
         server-hostname: ${{ secrets.ARTIFACT_HOST }}
+        server-share: ${{ secrets.ARTIFACT_SHARE }}
         server-username: ${{ secrets.ARTIFACT_USERNAME }}
         server-password: ${{ secrets.ARTIFACT_PASSWORD }}
         folder-to-upload: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,9 @@ jobs:
         cp -r Licenses bin/Release-linux-x86_64/Licenses
         rm bin/Release-linux-x86_64/Utility/QOIConv/QOIConv.exe
     - name: Upload artifacts (TrappedGames)
+      env:
+        artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+      if: env.artifact_hostname != null
       uses: ./.github/composite/artifact-upload
       with:
         target-filename: Linux GCC Release Executables
@@ -114,15 +117,18 @@ jobs:
           bin/Release-linux-x86_64/./Utility
           bin/Release-linux-x86_64/./UnitTests
           bin/Release-linux-x86_64/./Licenses
-    # - name: Upload artifacts
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     name: Linux GCC Release Executables
-    #     path: |
-    #       bin/Release-linux-x86_64/Games
-    #       bin/Release-linux-x86_64/Utility
-    #       bin/Release-linux-x86_64/UnitTests
-    #       bin/Release-linux-x86_64/Licenses
+    - name: Upload artifacts (GitHub)
+      env:
+        artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+      if: env.artifact_hostname == null
+      uses: actions/upload-artifact@v3
+      with:
+        name: Linux GCC Release Executables
+        path: |
+          bin/Release-linux-x86_64/Games
+          bin/Release-linux-x86_64/Utility
+          bin/Release-linux-x86_64/UnitTests
+          bin/Release-linux-x86_64/Licenses
   build-linux-clang-17:
     name: Build Linux Clang 17
     runs-on: [self-hosted, Linux, X64, ubuntu, "23.10", cpu]
@@ -212,6 +218,9 @@ jobs:
         cp -r Licenses bin/Release-linux-x86_64/Licenses
         rm bin/Release-linux-x86_64/Utility/QOIConv/QOIConv.exe
     - name: Upload artifacts (TrappedGames)
+      env:
+        artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+      if: env.artifact_hostname != null
       uses: ./.github/composite/artifact-upload
       with:
         target-filename: Linux Clang Release Executables
@@ -224,15 +233,18 @@ jobs:
           bin/Release-linux-x86_64/./Utility
           bin/Release-linux-x86_64/./UnitTests
           bin/Release-linux-x86_64/./Licenses
-    # - name: Upload artifacts
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     name: Linux Clang Release Executables
-    #     path: |
-    #       bin/Release-linux-x86_64/Games
-    #       bin/Release-linux-x86_64/Utility
-    #       bin/Release-linux-x86_64/UnitTests
-    #       bin/Release-linux-x86_64/Licenses
+    - name: Upload artifacts (GitHub)
+      env:
+        artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+      if: env.artifact_hostname == null
+      uses: actions/upload-artifact@v3
+      with:
+        name: Linux Clang Release Executables
+        path: |
+          bin/Release-linux-x86_64/Games
+          bin/Release-linux-x86_64/Utility
+          bin/Release-linux-x86_64/UnitTests
+          bin/Release-linux-x86_64/Licenses
   build-windows-msvc-2022:
     name: Build Windows MSVC 2022
     runs-on: [self-hosted, windows, X64, cpu]
@@ -313,6 +325,9 @@ jobs:
         Get-ChildItem -Path "bin" -Filter "*.pdb" -Recurse | Remove-Item -Force
         Remove-Item bin\Release-windows-x86_64\Utility\QOIConv\QOIConv
     - name: Upload artifacts (TrappedGames)
+      env:
+        artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+      if: env.artifact_hostname != null
       uses: ./.github/composite/artifact-upload
       with:
         target-filename: Windows MSVC Release Executables
@@ -326,16 +341,19 @@ jobs:
           bin/Release-windows-x86_64/./UnitTests
           bin/Release-windows-x86_64/./Licenses
           bin/Release-windows-x86_64/./Redists
-    # - name: Upload artifacts
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     name: Windows MSVC 2022 Release Executables
-    #     path: |
-    #       bin/Release-windows-x86_64/Games
-    #       bin/Release-windows-x86_64/Utility
-    #       bin/Release-windows-x86_64/UnitTests
-    #       bin/Release-windows-x86_64/Licenses
-    #       bin/Release-windows-x86_64/Redists
+    - name: Upload artifacts (GitHub)
+      env:
+        artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+      if: env.artifact_hostname == null
+      uses: actions/upload-artifact@v3
+      with:
+        name: Windows MSVC 2022 Release Executables
+        path: |
+          bin/Release-windows-x86_64/Games
+          bin/Release-windows-x86_64/Utility
+          bin/Release-windows-x86_64/UnitTests
+          bin/Release-windows-x86_64/Licenses
+          bin/Release-windows-x86_64/Redists
 
   test-windows:
     name: Unit-Test Windows
@@ -345,11 +363,10 @@ jobs:
       - name: Cleanup workspace
         if: ${{ always() }}
         uses: gamestrap/gha-workspace-cleanup@v1.2.4
-      # - name: Download artifact
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: Windows MSVC 2022 Release Executables
       - name: Download artifact (TrappedGames)
+        env:
+          artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+        if: env.artifact_hostname != null
         uses: gamestrap/gha-download-artifact@v1.0.3
         with:
           server-hostname: ${{ secrets.ARTIFACT_HOST }}
@@ -357,6 +374,13 @@ jobs:
           server-username: ${{ secrets.ARTIFACT_USERNAME }}
           server-password: ${{ secrets.ARTIFACT_PASSWORD }}
           artifact-name: "Windows MSVC Release Executables"
+      - name: Download artifact (GitHub)
+        env:
+          artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+        if: env.artifact_hostname == null
+        uses: actions/download-artifact@v3
+        with:
+          name: Windows MSVC 2022 Release Executables
       - name: Run Tests
         run: |
           cd UnitTests
@@ -369,11 +393,10 @@ jobs:
       - name: Cleanup workspace
         if: ${{ always() }}
         uses: gamestrap/gha-workspace-cleanup@v1.2.4
-      # - name: Download artifact
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: Linux Clang Release Executables
       - name: Download artifact (TrappedGames)
+        env:
+          artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+        if: env.artifact_hostname != null
         uses: gamestrap/gha-download-artifact@v1.0.3
         with:
           server-hostname: ${{ secrets.ARTIFACT_HOST }}
@@ -381,6 +404,13 @@ jobs:
           server-username: ${{ secrets.ARTIFACT_USERNAME }}
           server-password: ${{ secrets.ARTIFACT_PASSWORD }}
           artifact-name: "Linux Clang Release Executables"
+      - name: Download artifact (GitHub)
+        env:
+          artifact_hostname: ${{secrets.ARTIFACT_HOST}}
+        if: env.artifact_hostname == null
+        uses: actions/download-artifact@v3
+        with:
+          name: Linux Clang Release Executables
       - name: Run Tests
         run: |
           cd UnitTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,7 +350,7 @@ jobs:
       #   with:
       #     name: Windows MSVC 2022 Release Executables
       - name: Download artifact (TrappedGames)
-        uses: gamestrap/gha-download-artifact@v1.0.1
+        uses: gamestrap/gha-download-artifact@v1.0.2
         with:
           server-hostname: ${{ secrets.ARTIFACT_HOST }}
           server-share: "artifacts"
@@ -374,7 +374,7 @@ jobs:
       #   with:
       #     name: Linux Clang Release Executables
       - name: Download artifact (TrappedGames)
-        uses: gamestrap/gha-download-artifact@v1.0.1
+        uses: gamestrap/gha-download-artifact@v1.0.2
         with:
           server-hostname: ${{ secrets.ARTIFACT_HOST }}
           server-share: "artifacts"

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -4574,3 +4574,13 @@ SITREP 10/21/2023|23w42b2
     - Changed TRAP Engine version to 23w42b2(0.9.120)
     - Utils GetCPUInfo() Linux Replaced inline assembly with cpuid compiler intrinsic ~<5 mins
     - WindowingAPILinuxWayland Fixed glitching when windows change between fractional and non-fractional scaling code paths ~<5 mins
+
+SITREP 10/22/2023|23w42b3
+    - Changed TRAP Engine version to 23w42b3(0.9.121)
+    - Added new artifact-upload composite action (allows storing build artifacts on a custom Samba share) ~<30 mins
+    - GitHub Action Windows Runner Added 7z to PATH ~<5 mins
+    - GitHub Action Linux Runner Added p7zip-full package ~<5 mins
+    - Build-CI Replaced GitHub upload-artifact action with our own ~<10 mins
+    - Build-CI Replaced GitHub download-artifact action with our own (gamestrap/gha-download-artifact) ~<5 mins
+    - Build-CI Use GitHub artifact actions when ARTIFACT_HOST secret is not set ~<5 mins
+    - Build-CI Added Licenses folder to artifacts ~<5 mins

--- a/TRAP/src/Core/Base.h
+++ b/TRAP/src/Core/Base.h
@@ -183,7 +183,7 @@ template<uint32_t major, uint32_t minor, uint32_t patch>
 /// <summary>
 /// TRAP version number created with TRAP_MAKE_VERSION
 /// </summary>
-inline constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION<0, 9, 119>();
+inline constexpr uint32_t TRAP_VERSION = TRAP_MAKE_VERSION<0, 9, 121>();
 
 //-------------------------------------------------------------------------------------------------------------------//
 

--- a/TRAP/src/Log/Log.h
+++ b/TRAP/src/Log/Log.h
@@ -147,7 +147,7 @@ namespace TRAP
 		/// </summary>
 		constexpr void Clear() noexcept;
 
-		inline static constexpr auto WindowVersion =                        "[23w42b1]";
+		inline static constexpr auto WindowVersion =                        "[23w42b3]";
 		inline static constexpr auto WindowPrefix =                         "[Window] ";
 		inline static constexpr auto WindowIconPrefix =                     "[Window][Icon] ";
 		inline static constexpr auto ConfigPrefix =                         "[Config] ";


### PR DESCRIPTION
This replaces the GitHub artifact actions with custom made ones which allow storing artifacts as a compressed 7z files onto a configurable Samba share.

The upload-artifact action can be found in `.github/composite/artifact-upload`.
The download-artifact action can be found  [here](https://github.com/GamesTrap/gha-download-artifact).

This PR should also fix the slow upload/download speeds of the artifacts.