### PR TITLE
TRAP-Editor Entity changes while in play mode

### DIFF
--- a/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
+++ b/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
@@ -302,7 +302,8 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 	},
 	[](const TRAP::Entity& ent, const TransformComponent& transComp)
 	{
-		if(const auto* const rigid2DComp = ent.TryGetComponent<Rigidbody2DComponent>())
+		if(const auto* const rigid2DComp = ent.TryGetComponent<Rigidbody2DComponent>();
+		   rigid2DComp != nullptr && rigid2DComp->RuntimeBody != nullptr)
 		{
 			rigid2DComp->SetPosition(TRAP::Math::Vec2{transComp.Position});
 			rigid2DComp->SetAngle(transComp.Rotation.z());

--- a/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
+++ b/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
@@ -6,11 +6,15 @@
 
 namespace
 {
-	void DrawVec3Control(const std::string& label,
+	/// @brief Draws a Vec3 control.
+	/// @return True if a value has changed, false if values are unchanged.
+	bool DrawVec3Control(const std::string& label,
 						 TRAP::Math::Vec3& values,
 						 const f32 resetValues = 0.0f,
 						 const f32 columnWidth = 100.0f)
 	{
+		bool changed = false;
+
 		ImGuiIO& io = ImGui::GetIO();
 		auto* const boldFont = io.Fonts->Fonts[0u];
 
@@ -32,12 +36,16 @@ namespace
 		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.8f, 0.1f, 0.15f, 1.0f));
 		ImGui::PushFont(boldFont);
 		if (ImGui::Button("X", buttonSize))
+		{
 			values.x() = resetValues;
+			changed = true;
+		}
 		ImGui::PopFont();
 		ImGui::PopStyleColor(3);
 
 		ImGui::SameLine();
-		ImGui::DragFloat("##X", &values.x(), 0.1f, 0.0f, 0.0f, "%.2f");
+		if(ImGui::DragFloat("##X", &values.x(), 0.1f, 0.0f, 0.0f, "%.2f"))
+			changed = true;
 		ImGui::PopItemWidth();
 		ImGui::SameLine();
 
@@ -46,12 +54,16 @@ namespace
 		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.2f, 0.7f, 0.2f, 1.0f));
 		ImGui::PushFont(boldFont);
 		if (ImGui::Button("Y", buttonSize))
+		{
 			values.y() = resetValues;
+			changed = true;
+		}
 		ImGui::PopFont();
 		ImGui::PopStyleColor(3);
 
 		ImGui::SameLine();
-		ImGui::DragFloat("##Y", &values.y(), 0.1f, 0.0f, 0.0f, "%.2f");
+		if(ImGui::DragFloat("##Y", &values.y(), 0.1f, 0.0f, 0.0f, "%.2f"))
+			changed = true;
 		ImGui::PopItemWidth();
 		ImGui::SameLine();
 
@@ -60,12 +72,16 @@ namespace
 		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.18f, 0.25f, 0.8f, 1.0f));
 		ImGui::PushFont(boldFont);
 		if (ImGui::Button("Z", buttonSize))
+		{
 			values.z() = resetValues;
+			changed = true;
+		}
 		ImGui::PopFont();
 		ImGui::PopStyleColor(3);
 
 		ImGui::SameLine();
-		ImGui::DragFloat("##Z", &values.z(), 0.1f, 0.0f, 0.0f, "%.2f");
+		if(ImGui::DragFloat("##Z", &values.z(), 0.1f, 0.0f, 0.0f, "%.2f"))
+			changed = true;
 		ImGui::PopItemWidth();
 
 		ImGui::PopStyleVar();
@@ -73,6 +89,77 @@ namespace
 		ImGui::Columns(1);
 
 		ImGui::PopID();
+
+		return changed;
+	}
+
+	//-------------------------------------------------------------------------------------------------------------------//
+
+	/// @brief Draw component UI for an entity.
+	/// @tparam T Component type.
+	/// @param name Name of the component to display.
+	/// @param entity Entity associated with the component.
+	/// @param displayFunc Function which draws the component specific properties.
+	/// @param updateFunc Function to call when a value of the component has changed through the UI.
+	template <typename T, typename UIFunction, typename UpdateFunction>
+	requires TRAP::IsComponent<T> && std::is_invocable_r_v<bool, UIFunction, T&> && std::is_invocable_r_v<void, UpdateFunction, TRAP::Entity&, const T&>
+	void DrawComponent(const std::string& name, TRAP::Entity& entity, UIFunction displayFunc, UpdateFunction updateFunc)
+	{
+		static constexpr ImGuiTreeNodeFlags treeNodeFlags = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_AllowOverlap |
+															ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_Framed |
+															ImGuiTreeNodeFlags_FramePadding;
+
+		if (!entity.HasComponent<T>())
+			return;
+
+		auto& component = entity.GetComponent<T>();
+		const ImVec2 contentRegionAvailable = ImGui::GetContentRegionAvail();
+
+		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2{ 4.0f, 4.0f });
+		const f32 lineHeight = GImGui->Font->FontSize + (GImGui->Style.FramePadding.y * 2.0f);
+		ImGui::Separator();
+		const bool open = ImGui::TreeNodeEx(reinterpret_cast<void*>(typeid(T).hash_code()), treeNodeFlags, "%s", name.c_str());
+		ImGui::PopStyleVar();
+		bool removeComponent = false;
+		if(!std::same_as<T, TRAP::TransformComponent>)
+		{
+			ImGui::SameLine(contentRegionAvailable.x - (lineHeight * 0.5f));
+			if (ImGui::Button(":", ImVec2{ lineHeight, lineHeight }))
+				ImGui::OpenPopup("ComponentSettings");
+
+			if (ImGui::BeginPopup("ComponentSettings"))
+			{
+				if (ImGui::MenuItem("Remove Component"))
+					removeComponent = true;
+
+				ImGui::EndPopup();
+			}
+
+		}
+
+		if (open)
+		{
+			if(displayFunc(component))
+				updateFunc(entity, component);
+			ImGui::TreePop();
+		}
+		if(!std::same_as<T, TRAP::TransformComponent>)
+		{
+			if (removeComponent)
+				entity.RemoveComponent<T>();
+		}
+	}
+
+	/// @brief Draw component UI for an entity.
+	/// @tparam T Component type.
+	/// @param name Name of the component to display.
+	/// @param entity Entity associated with the component.
+	/// @param displayFunc Function which draws the component specific properties.
+	template <typename T, typename UIFunction>
+	requires TRAP::IsComponent<T> && std::is_invocable_r_v<bool, UIFunction, T&>
+	void DrawComponent(const std::string& name, TRAP::Entity& entity, UIFunction displayFunc)
+	{
+		return DrawComponent<T, UIFunction>(name, entity, displayFunc, [](TRAP::Entity&, const T&){});
 	}
 }
 
@@ -159,56 +246,6 @@ void TRAP::SceneGraphPanel::DrawEntityNode(const Entity& entity)
 
 //-------------------------------------------------------------------------------------------------------------------//
 
-template <typename T, typename UIFunction>
-requires TRAP::IsComponent<T> && std::is_invocable_r_v<void, UIFunction, T&>
-void DrawComponent(const std::string& name, TRAP::Entity& entity, UIFunction func)
-{
-	static constexpr ImGuiTreeNodeFlags treeNodeFlags = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_AllowOverlap |
-		                                                ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_Framed |
-														ImGuiTreeNodeFlags_FramePadding;
-
-	if (!entity.HasComponent<T>())
-		return;
-
-	auto& component = entity.GetComponent<T>();
-	const ImVec2 contentRegionAvailable = ImGui::GetContentRegionAvail();
-
-	ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2{ 4.0f, 4.0f });
-	const f32 lineHeight = GImGui->Font->FontSize + (GImGui->Style.FramePadding.y * 2.0f);
-	ImGui::Separator();
-	const bool open = ImGui::TreeNodeEx(reinterpret_cast<void*>(typeid(T).hash_code()), treeNodeFlags, "%s", name.c_str());
-	ImGui::PopStyleVar();
-	bool removeComponent = false;
-	if(!std::same_as<T, TRAP::TransformComponent>)
-	{
-		ImGui::SameLine(contentRegionAvailable.x - (lineHeight * 0.5f));
-		if (ImGui::Button(":", ImVec2{ lineHeight, lineHeight }))
-			ImGui::OpenPopup("ComponentSettings");
-
-		if (ImGui::BeginPopup("ComponentSettings"))
-		{
-			if (ImGui::MenuItem("Remove Component"))
-				removeComponent = true;
-
-			ImGui::EndPopup();
-		}
-
-	}
-
-	if (open)
-	{
-		func(component);
-		ImGui::TreePop();
-	}
-	if(!std::same_as<T, TRAP::TransformComponent>)
-	{
-		if (removeComponent)
-			entity.RemoveComponent<T>();
-	}
-}
-
-//-------------------------------------------------------------------------------------------------------------------//
-
 void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 {
 	if (entity.HasComponent<TagComponent>() && entity.HasComponent<UIDComponent>())
@@ -249,11 +286,29 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 
 	DrawComponent<TransformComponent>("Transform", entity, [](auto& component)
 	{
-		DrawVec3Control("Position", component.Position);
+		bool changed = false;
+
+		changed |= DrawVec3Control("Position", component.Position);
+
 		Math::Vec3 rotation = Math::Degrees(component.Rotation);
-		DrawVec3Control("Rotation", rotation);
-		component.Rotation = Math::Radians(rotation);
-		DrawVec3Control("Scale", component.Scale, 1.0f);
+		if(DrawVec3Control("Rotation", rotation))
+		{
+			component.Rotation = Math::Radians(rotation);
+			changed = true;
+		}
+		changed |= DrawVec3Control("Scale", component.Scale, 1.0f);
+
+		return changed;
+	},
+	[](const TRAP::Entity& ent, const TransformComponent& transComp)
+	{
+		if(!ent.HasComponent<Rigidbody2DComponent>())
+			return;
+
+		const auto& rigidComp = ent.GetComponent<Rigidbody2DComponent>();
+
+		rigidComp.SetPosition(TRAP::Math::Vec2{transComp.Position});
+		rigidComp.SetAngle(transComp.Rotation.z());
 	});
 
 	DrawComponent<CameraComponent>("Camera", entity, [](auto& component)
@@ -309,11 +364,15 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 
 			ImGui::Checkbox("Fixed Aspect Ratio", &component.FixedAspectRatio);
 		}
+
+		return false;
 	});
 
 	DrawComponent<SpriteRendererComponent>("Sprite Renderer", entity, [](auto& component)
 	{
 		ImGui::ColorEdit4("Color", &std::get<0u>(component.Color));
+
+		return false;
 	});
 
 	DrawComponent<CircleRendererComponent>("Circle Renderer", entity, [](auto& component)
@@ -321,6 +380,8 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 		ImGui::ColorEdit4("Color", &std::get<0u>(component.Color));
 		ImGui::DragFloat("Thickness", &component.Thickness, 0.025f, 0.0f, 1.0f);
 		ImGui::DragFloat("Fade", &component.Fade, 0.00025f, 0.0f, 1.0f);
+
+		return false;
 	});
 
 	DrawComponent<Rigidbody2DComponent>("Rigidbody 2D", entity, [](auto& component)
@@ -346,6 +407,8 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 		}
 
 		ImGui::Checkbox("Fixed Rotation", &component.FixedRotation);
+
+		return false;
 	});
 
 	DrawComponent<BoxCollider2DComponent>("Box Collider 2D", entity, [](auto& component)
@@ -356,6 +419,8 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 		ImGui::DragFloat("Friction", &component.Friction, 0.01f, 0.0f, 1.0f);
 		ImGui::DragFloat("Restitution", &component.Restitution, 0.01f, 0.0f, 1.0f);
 		ImGui::DragFloat("RestitutionThreshold", &component.RestitutionThreshold, 0.01f, 0.0f);
+
+		return false;
 	});
 
 	DrawComponent<CircleCollider2DComponent>("Circle Collider 2D", entity, [](auto& component)
@@ -366,6 +431,8 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 		ImGui::DragFloat("Friction", &component.Friction, 0.01f, 0.0f, 1.0f);
 		ImGui::DragFloat("Restitution", &component.Restitution, 0.01f, 0.0f, 1.0f);
 		ImGui::DragFloat("RestitutionThreshold", &component.RestitutionThreshold, 0.01f, 0.0f);
+
+		return false;
 	});
 }
 

--- a/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
+++ b/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
@@ -396,6 +396,8 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 
 	DrawComponent<Rigidbody2DComponent>("Rigidbody 2D", entity, [](auto& component)
 	{
+		bool changed = false;
+
 		static const std::array<std::string, 3u> bodyTypeStrings{"Static", "Dynamic", "Kinematic"};
 		const char* currentBodyTypeString = bodyTypeStrings[std::to_underlying(component.Type)].c_str();
 		if(ImGui::BeginCombo("Body Type", currentBodyTypeString))
@@ -407,6 +409,7 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 				{
 					currentBodyTypeString = bodyTypeStrings[i].c_str();
 					component.Type = static_cast<Rigidbody2DComponent::BodyType>(i);
+					changed = true;
 				}
 
 				if(isSelected)
@@ -416,9 +419,17 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 			ImGui::EndCombo();
 		}
 
-		ImGui::Checkbox("Fixed Rotation", &component.FixedRotation);
+		changed |= ImGui::Checkbox("Fixed Rotation", &component.FixedRotation);
 
-		return false;
+		return changed;
+	},
+	[]([[maybe_unused]] const TRAP::Entity& ent, const Rigidbody2DComponent& rigidBody2DComp)
+	{
+		if(rigidBody2DComp.RuntimeBody != nullptr)
+		{
+			rigidBody2DComp.RuntimeBody->SetType(Rigidbody2DComponent::Rigidbody2DTypeToBox2DBody(rigidBody2DComp.Type));
+			rigidBody2DComp.RuntimeBody->SetFixedRotation(rigidBody2DComp.FixedRotation);
+		}
 	});
 
 	DrawComponent<BoxCollider2DComponent>("Box Collider 2D", entity, [](auto& component)
@@ -430,7 +441,7 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 		ImGui::DragFloat("Restitution", &component.Restitution, 0.01f, 0.0f, 1.0f);
 		ImGui::DragFloat("RestitutionThreshold", &component.RestitutionThreshold, 0.01f, 0.0f);
 
-		return false;
+		return false; //TODO Apply changes in play mode
 	});
 
 	DrawComponent<CircleCollider2DComponent>("Circle Collider 2D", entity, [](auto& component)
@@ -442,7 +453,7 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 		ImGui::DragFloat("Restitution", &component.Restitution, 0.01f, 0.0f, 1.0f);
 		ImGui::DragFloat("RestitutionThreshold", &component.RestitutionThreshold, 0.01f, 0.0f);
 
-		return false;
+		return false; //TODO Apply changes in play mode
 	});
 }
 

--- a/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
+++ b/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
@@ -302,14 +302,22 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 	},
 	[](const TRAP::Entity& ent, const TransformComponent& transComp)
 	{
-		if(!ent.HasComponent<Rigidbody2DComponent>())
-			return;
+		if(const auto* const rigid2DComp = ent.TryGetComponent<Rigidbody2DComponent>())
+		{
+			rigid2DComp->SetPosition(TRAP::Math::Vec2{transComp.Position});
+			rigid2DComp->SetAngle(transComp.Rotation.z());
 
-		const auto& rigid2DComp = ent.GetComponent<Rigidbody2DComponent>();
-
-		rigid2DComp.SetPosition(TRAP::Math::Vec2{transComp.Position});
-		rigid2DComp.SetAngle(transComp.Rotation.z());
-		//TODO Scale collider
+			if(auto* const boxCollider2DComp = ent.TryGetComponent<BoxCollider2DComponent>()) //Recreate Fixture (applies scaling)
+			{
+				rigid2DComp->DestroyColliderFixture(*boxCollider2DComp);
+				boxCollider2DComp->CreateFixture(*rigid2DComp, TRAP::Math::Vec2{transComp.Scale});
+			}
+			if(auto* const circleCollider2DComp = ent.TryGetComponent<CircleCollider2DComponent>()) //Recreate Fixture (applies scaling)
+			{
+				rigid2DComp->DestroyColliderFixture(*circleCollider2DComp);
+				circleCollider2DComp->CreateFixture(*rigid2DComp, TRAP::Math::Vec2{transComp.Scale});
+			}
+		}
 	});
 
 	DrawComponent<CameraComponent>("Camera", entity, [](auto& component)

--- a/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
+++ b/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
@@ -305,10 +305,11 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 		if(!ent.HasComponent<Rigidbody2DComponent>())
 			return;
 
-		const auto& rigidComp = ent.GetComponent<Rigidbody2DComponent>();
+		const auto& rigid2DComp = ent.GetComponent<Rigidbody2DComponent>();
 
-		rigidComp.SetPosition(TRAP::Math::Vec2{transComp.Position});
-		rigidComp.SetAngle(transComp.Rotation.z());
+		rigid2DComp.SetPosition(TRAP::Math::Vec2{transComp.Position});
+		rigid2DComp.SetAngle(transComp.Rotation.z());
+		//TODO Scale collider
 	});
 
 	DrawComponent<CameraComponent>("Camera", entity, [](auto& component)

--- a/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
+++ b/Games/TRAP-Editor/src/Panels/SceneGraphPanel.cpp
@@ -102,7 +102,7 @@ namespace
 	/// @param displayFunc Function which draws the component specific properties.
 	/// @param updateFunc Function to call when a value of the component has changed through the UI.
 	template <typename T, typename UIFunction, typename UpdateFunction>
-	requires TRAP::IsComponent<T> && std::is_invocable_r_v<bool, UIFunction, T&> && std::is_invocable_r_v<void, UpdateFunction, TRAP::Entity&, const T&>
+	requires TRAP::IsComponent<T> && std::is_invocable_r_v<bool, UIFunction, T&> && std::is_invocable_r_v<void, UpdateFunction, TRAP::Entity&, T&>
 	void DrawComponent(const std::string& name, TRAP::Entity& entity, UIFunction displayFunc, UpdateFunction updateFunc)
 	{
 		static constexpr ImGuiTreeNodeFlags treeNodeFlags = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_AllowOverlap |
@@ -434,26 +434,62 @@ void TRAP::SceneGraphPanel::DrawComponents(Entity& entity)
 
 	DrawComponent<BoxCollider2DComponent>("Box Collider 2D", entity, [](auto& component)
 	{
-		ImGui::DragFloat2("Offset", &std::get<0u>(component.Offset), 0.1f);
-		ImGui::DragFloat2("Size", &std::get<0u>(component.Size), 0.1f);
-		ImGui::DragFloat("Density", &component.Density, 0.01f, 0.0f, 1.0f);
-		ImGui::DragFloat("Friction", &component.Friction, 0.01f, 0.0f, 1.0f);
-		ImGui::DragFloat("Restitution", &component.Restitution, 0.01f, 0.0f, 1.0f);
-		ImGui::DragFloat("RestitutionThreshold", &component.RestitutionThreshold, 0.01f, 0.0f);
+		bool changed = false;
 
-		return false; //TODO Apply changes in play mode
+		changed |= ImGui::DragFloat2("Offset", &std::get<0u>(component.Offset), 0.1f);
+		changed |= ImGui::DragFloat2("Size", &std::get<0u>(component.Size), 0.1f);
+		changed |= ImGui::DragFloat("Density", &component.Density, 0.01f, 0.0f, 1.0f);
+		changed |= ImGui::DragFloat("Friction", &component.Friction, 0.01f, 0.0f, 1.0f);
+		changed |= ImGui::DragFloat("Restitution", &component.Restitution, 0.01f, 0.0f, 1.0f);
+		changed |= ImGui::DragFloat("RestitutionThreshold", &component.RestitutionThreshold, 0.01f, 0.0f);
+
+		return changed;
+	},
+	[]([[maybe_unused]] const TRAP::Entity& ent, BoxCollider2DComponent& boxCollider2DComp)
+	{
+		if(boxCollider2DComp.RuntimeFixture == nullptr)
+			return;
+
+		const auto* const transformComp = ent.TryGetComponent<TransformComponent>();
+		if(transformComp == nullptr)
+			return;
+
+		const auto* const rigidBody2DComp = ent.TryGetComponent<Rigidbody2DComponent>();
+		if(rigidBody2DComp == nullptr || rigidBody2DComp->RuntimeBody == nullptr)
+			return;
+
+		rigidBody2DComp->DestroyColliderFixture(boxCollider2DComp);
+		boxCollider2DComp.CreateFixture(*rigidBody2DComp, TRAP::Math::Vec2{transformComp->Scale});
 	});
 
 	DrawComponent<CircleCollider2DComponent>("Circle Collider 2D", entity, [](auto& component)
 	{
-		ImGui::DragFloat2("Offset", &std::get<0u>(component.Offset), 0.1f);
-		ImGui::DragFloat("Radius", &component.Radius, 0.1f);
-		ImGui::DragFloat("Density", &component.Density, 0.01f, 0.0f, 1.0f);
-		ImGui::DragFloat("Friction", &component.Friction, 0.01f, 0.0f, 1.0f);
-		ImGui::DragFloat("Restitution", &component.Restitution, 0.01f, 0.0f, 1.0f);
-		ImGui::DragFloat("RestitutionThreshold", &component.RestitutionThreshold, 0.01f, 0.0f);
+		bool changed = false;
 
-		return false; //TODO Apply changes in play mode
+		changed |= ImGui::DragFloat2("Offset", &std::get<0u>(component.Offset), 0.1f);
+		changed |= ImGui::DragFloat("Radius", &component.Radius, 0.1f);
+		changed |= ImGui::DragFloat("Density", &component.Density, 0.01f, 0.0f, 1.0f);
+		changed |= ImGui::DragFloat("Friction", &component.Friction, 0.01f, 0.0f, 1.0f);
+		changed |= ImGui::DragFloat("Restitution", &component.Restitution, 0.01f, 0.0f, 1.0f);
+		changed |= ImGui::DragFloat("RestitutionThreshold", &component.RestitutionThreshold, 0.01f, 0.0f);
+
+		return changed;
+	},
+	[]([[maybe_unused]] const TRAP::Entity& ent, TRAP::CircleCollider2DComponent& circleCollider2DComp)
+	{
+		if(circleCollider2DComp.RuntimeFixture == nullptr)
+			return;
+
+		const auto* const transformComp = ent.TryGetComponent<TransformComponent>();
+		if(transformComp == nullptr)
+			return;
+
+		const auto* const rigidBody2DComp = ent.TryGetComponent<Rigidbody2DComponent>();
+		if(rigidBody2DComp == nullptr || rigidBody2DComp->RuntimeBody == nullptr)
+			return;
+
+		rigidBody2DComp->DestroyColliderFixture(circleCollider2DComp);
+		circleCollider2DComp.CreateFixture(*rigidBody2DComp, TRAP::Math::Vec2{transformComp->Scale});
 	});
 }
 

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
@@ -1006,12 +1006,14 @@ void TRAPEditorLayer::OnOverlayRender()
 			{
 				auto [transform, circleCollider] = view.get<TRAP::TransformComponent, TRAP::CircleCollider2DComponent>(entity);
 
-				const TRAP::Math::Vec3 position = transform.Position + TRAP::Math::Vec3(circleCollider.Offset, -colliderProjectionZ);
 				const f32 rotation = transform.Rotation.z();
 				const f32 maxScale = TRAP::Math::Max(transform.Scale.x(), transform.Scale.y());
 				const TRAP::Math::Vec3 scale = TRAP::Math::Vec3{maxScale, maxScale, transform.Scale.z()} * TRAP::Math::Vec3(circleCollider.Radius * 2.0f);
 
-				const TRAP::Math::Mat4 trans = TRAP::Math::Translate(position) * TRAP::Math::Rotate(rotation, {0.0f, 0.0f, 1.0f}) * TRAP::Math::Scale(scale);
+				const TRAP::Math::Mat4 trans = TRAP::Math::Translate(transform.Position) *
+				                               TRAP::Math::Rotate(rotation, {0.0f, 0.0f, 1.0f}) *
+				                               TRAP::Math::Translate(TRAP::Math::Vec3(circleCollider.Offset, -colliderProjectionZ)) *
+											   TRAP::Math::Scale(scale);
 
 				TRAP::Graphics::Renderer2D::DrawCircle(trans, TRAP::Math::Vec4(0.0f, 1.0f, 0.0f, 1.0f), 0.01f);
 			}

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
@@ -508,13 +508,21 @@ void TRAPEditorLayer::OnImGuizmoRender()
 			tc.Rotation += deltaRotation;
 			tc.Scale = scale;
 
-			if(selectedEntity.HasComponent<TRAP::Rigidbody2DComponent>())
+			if(const auto* const rigid2DComp = selectedEntity.TryGetComponent<TRAP::Rigidbody2DComponent>())
 			{
-				const auto& rigid2DComp = selectedEntity.GetComponent<TRAP::Rigidbody2DComponent>();
+				rigid2DComp->SetPosition(TRAP::Math::Vec2{tc.Position});
+				rigid2DComp->SetAngle(tc.Rotation.z());
 
-				rigid2DComp.SetPosition(TRAP::Math::Vec2{tc.Position});
-				rigid2DComp.SetAngle(tc.Rotation.z());
-				//TODO Scale collider
+				if(auto* const boxCollider2DComp = selectedEntity.TryGetComponent<TRAP::BoxCollider2DComponent>()) //Recreate Fixture (applies scaling)
+				{
+					rigid2DComp->DestroyColliderFixture(*boxCollider2DComp);
+					boxCollider2DComp->CreateFixture(*rigid2DComp, TRAP::Math::Vec2{tc.Scale});
+				}
+				if(auto* const circleCollider2DComp = selectedEntity.TryGetComponent<TRAP::CircleCollider2DComponent>()) //Recreate Fixture (applies scaling)
+				{
+					rigid2DComp->DestroyColliderFixture(*circleCollider2DComp);
+					circleCollider2DComp->CreateFixture(*rigid2DComp, TRAP::Math::Vec2{tc.Scale});
+				}
 			}
 		}
 	}

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
@@ -987,13 +987,13 @@ void TRAPEditorLayer::OnOverlayRender()
 			{
 				auto [transform, boxCollider] = view.get<TRAP::TransformComponent, TRAP::BoxCollider2DComponent>(entity);
 
-				const TRAP::Math::Vec3 position = transform.Position + TRAP::Math::Vec3(boxCollider.Offset, -colliderProjectionZ);
 				const f32 rotation = transform.Rotation.z();
 				const TRAP::Math::Vec3 scale = transform.Scale * TRAP::Math::Vec3(boxCollider.Size * 2.0f, 1.0f);
 
-				const TRAP::Math::Mat4 trans = TRAP::Math::Translate(position) *
+				const TRAP::Math::Mat4 trans = TRAP::Math::Translate(transform.Position) *
 											   TRAP::Math::Rotate(rotation, {0.0f, 0.0f, 1.0f}) *
-											    TRAP::Math::Scale(scale);
+											   TRAP::Math::Translate(TRAP::Math::Vec3(boxCollider.Offset, -colliderProjectionZ)) *
+											   TRAP::Math::Scale(scale);
 
 				TRAP::Graphics::Renderer2D::DrawRect(trans, TRAP::Math::Vec4(0.0f, 1.0f, 0.0f, 1.0f));
 			}

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
@@ -433,68 +433,7 @@ void TRAPEditorLayer::OnImGuiRender()
 	m_allowViewportCameraEvents = (ImGui::IsMouseHoveringRect(ImVec2(std::get<0u>(m_viewportBounds).x(), std::get<0u>(m_viewportBounds).y()),
 	                                                          ImVec2(std::get<1u>(m_viewportBounds).x(), std::get<1u>(m_viewportBounds).y())) && m_viewportFocused) || m_startedCameraMovement;
 
-	//Gizmos
-	TRAP::Entity selectedEntity = m_sceneGraphPanel.GetSelectedEntity();
-	if(selectedEntity && m_enableGizmo)
-	{
-		//Camera
-		auto cameraEntity = m_activeScene->GetPrimaryCameraEntity(); //Run time camera
-		TRAP::Math::Mat4 cameraProj{};
-		TRAP::Math::Mat4 cameraView{};
-		if(m_sceneState == SceneState::Edit || !cameraEntity)
-		{
-			cameraProj = m_editorCamera.GetProjectionMatrix();
-			cameraView = m_editorCamera.GetViewMatrix();
-		}
-		else if(m_sceneState == SceneState::Play)
-		{
-			const auto& camera = cameraEntity.GetComponent<TRAP::CameraComponent>().Camera;
-			cameraProj = camera.GetProjectionMatrix();
-			cameraView = TRAP::Math::Inverse(cameraEntity.GetComponent<TRAP::TransformComponent>().GetTransform());
-		}
-
-		//Entity transform
-		auto& tc = selectedEntity.GetComponent<TRAP::TransformComponent>();
-		TRAP::Math::Mat4 transform = tc.GetTransform();
-
-		// ImGuizmo::SetOrthographic(camera.GetProjectionType() == TRAP::SceneCamera::ProjectionType::Orthographic); //TODO 2D mode
-		ImGuizmo::SetOrthographic(false);
-		ImGuizmo::SetDrawlist();
-
-		ImGuizmo::SetRect(std::get<0u>(m_viewportBounds).x(), std::get<0u>(m_viewportBounds).y(),
-						  std::get<1u>(m_viewportBounds).x(), std::get<1u>(m_viewportBounds).y());
-
-		//Snapping
-		const bool snap = TRAP::Input::IsKeyPressed(TRAP::Input::Key::Left_Control) ||
-						  TRAP::Input::IsKeyPressed(TRAP::Input::Key::Right_Control);
-		f32 snapValue = 0.5f;
-		if(m_gizmoType == ImGuizmo::OPERATION::ROTATE)
-			snapValue = 45.0f;
-
-		const std::array<f32, 3u> snapValues = {snapValue, snapValue, snapValue};
-
-		//Disable gizmo while entity was just changed and the left mouse button is still pressed
-		ImGuizmo::Enable(!m_entityChanged || m_leftMouseBtnRepeatCount == 0u);
-
-		const bool manipulated = ImGuizmo::Manipulate(&std::get<0u>(cameraView).x(), &std::get<0u>(cameraProj).x(),
-														static_cast<ImGuizmo::OPERATION>(m_gizmoType),
-														ImGuizmo::LOCAL, &std::get<0u>(transform).x(),
-														nullptr, snap ? snapValues.data() : nullptr);
-
-		if (manipulated &&
-			!TRAP::Input::IsMouseButtonPressed(TRAP::Input::MouseButton::Right) &&
-			!TRAP::Input::IsMouseButtonPressed(TRAP::Input::MouseButton::Middle))
-		{
-			TRAP::Math::Vec3 position{}, rotation{}, scale{};
-			if(TRAP::Math::Decompose(transform, position, rotation, scale))
-			{
-				const TRAP::Math::Vec3 deltaRotation = rotation - tc.Rotation;
-				tc.Position = position;
-				tc.Rotation += deltaRotation;
-				tc.Scale = scale;
-			}
-		}
-	}
+	OnImGuizmoRender();
 
 	ImGui::End();
 	ImGui::PopStyleVar();
@@ -502,6 +441,83 @@ void TRAPEditorLayer::OnImGuiRender()
 	UIToolbar();
 
 	ImGui::End();
+}
+
+//-------------------------------------------------------------------------------------------------------------------//
+
+void TRAPEditorLayer::OnImGuizmoRender()
+{
+	//Gizmos
+	TRAP::Entity selectedEntity = m_sceneGraphPanel.GetSelectedEntity();
+	if(!selectedEntity || !m_enableGizmo)
+		return;
+
+	//Camera
+	auto cameraEntity = m_activeScene->GetPrimaryCameraEntity(); //Run time camera
+	TRAP::Math::Mat4 cameraProj{};
+	TRAP::Math::Mat4 cameraView{};
+	if(m_sceneState == SceneState::Edit || !cameraEntity)
+	{
+		cameraProj = m_editorCamera.GetProjectionMatrix();
+		cameraView = m_editorCamera.GetViewMatrix();
+	}
+	else if(m_sceneState == SceneState::Play)
+	{
+		const auto& camera = cameraEntity.GetComponent<TRAP::CameraComponent>().Camera;
+		cameraProj = camera.GetProjectionMatrix();
+		cameraView = TRAP::Math::Inverse(cameraEntity.GetComponent<TRAP::TransformComponent>().GetTransform());
+	}
+
+	//Entity transform
+	auto& tc = selectedEntity.GetComponent<TRAP::TransformComponent>();
+	TRAP::Math::Mat4 transform = tc.GetTransform();
+
+	// ImGuizmo::SetOrthographic(camera.GetProjectionType() == TRAP::SceneCamera::ProjectionType::Orthographic); //TODO 2D mode
+	ImGuizmo::SetOrthographic(false);
+	ImGuizmo::SetDrawlist();
+
+	ImGuizmo::SetRect(std::get<0u>(m_viewportBounds).x(), std::get<0u>(m_viewportBounds).y(),
+						std::get<1u>(m_viewportBounds).x(), std::get<1u>(m_viewportBounds).y());
+
+	//Snapping
+	const bool snap = TRAP::Input::IsKeyPressed(TRAP::Input::Key::Left_Control) ||
+						TRAP::Input::IsKeyPressed(TRAP::Input::Key::Right_Control);
+	f32 snapValue = 0.5f;
+	if(m_gizmoType == ImGuizmo::OPERATION::ROTATE)
+		snapValue = 45.0f;
+
+	const std::array<f32, 3u> snapValues = {snapValue, snapValue, snapValue};
+
+	//Disable gizmo while entity was just changed and the left mouse button is still pressed
+	ImGuizmo::Enable(!m_entityChanged || m_leftMouseBtnRepeatCount == 0u);
+
+	const bool manipulated = ImGuizmo::Manipulate(&std::get<0u>(cameraView).x(), &std::get<0u>(cameraProj).x(),
+													static_cast<ImGuizmo::OPERATION>(m_gizmoType),
+													ImGuizmo::LOCAL, &std::get<0u>(transform).x(),
+													nullptr, snap ? snapValues.data() : nullptr);
+
+	if (manipulated &&
+		!TRAP::Input::IsMouseButtonPressed(TRAP::Input::MouseButton::Right) &&
+		!TRAP::Input::IsMouseButtonPressed(TRAP::Input::MouseButton::Middle))
+	{
+		TRAP::Math::Vec3 position{}, rotation{}, scale{};
+		if(TRAP::Math::Decompose(transform, position, rotation, scale))
+		{
+			const TRAP::Math::Vec3 deltaRotation = rotation - tc.Rotation;
+			tc.Position = position;
+			tc.Rotation += deltaRotation;
+			tc.Scale = scale;
+
+			if(selectedEntity.HasComponent<TRAP::Rigidbody2DComponent>())
+			{
+				const auto& rigid2DComp = selectedEntity.GetComponent<TRAP::Rigidbody2DComponent>();
+
+				rigid2DComp.SetPosition(TRAP::Math::Vec2{tc.Position});
+				rigid2DComp.SetAngle(tc.Rotation.z());
+				//TODO Scale collider
+			}
+		}
+	}
 }
 
 //-------------------------------------------------------------------------------------------------------------------//

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
@@ -508,7 +508,8 @@ void TRAPEditorLayer::OnImGuizmoRender()
 			tc.Rotation += deltaRotation;
 			tc.Scale = scale;
 
-			if(const auto* const rigid2DComp = selectedEntity.TryGetComponent<TRAP::Rigidbody2DComponent>())
+			if(const auto* const rigid2DComp = selectedEntity.TryGetComponent<TRAP::Rigidbody2DComponent>();
+			   rigid2DComp != nullptr && rigid2DComp->RuntimeBody != nullptr)
 			{
 				rigid2DComp->SetPosition(TRAP::Math::Vec2{tc.Position});
 				rigid2DComp->SetAngle(tc.Rotation.z());

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
@@ -1008,7 +1008,8 @@ void TRAPEditorLayer::OnOverlayRender()
 
 				const TRAP::Math::Vec3 position = transform.Position + TRAP::Math::Vec3(circleCollider.Offset, -colliderProjectionZ);
 				const f32 rotation = transform.Rotation.z();
-				const TRAP::Math::Vec3 scale = transform.Scale * TRAP::Math::Vec3(circleCollider.Radius * 2.0f);
+				const f32 maxScale = TRAP::Math::Max(transform.Scale.x(), transform.Scale.y());
+				const TRAP::Math::Vec3 scale = TRAP::Math::Vec3{maxScale, maxScale, transform.Scale.z()} * TRAP::Math::Vec3(circleCollider.Radius * 2.0f);
 
 				const TRAP::Math::Mat4 trans = TRAP::Math::Translate(position) * TRAP::Math::Rotate(rotation, {0.0f, 0.0f, 1.0f}) * TRAP::Math::Scale(scale);
 

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.cpp
@@ -982,9 +982,10 @@ void TRAPEditorLayer::OnOverlayRender()
 				auto [transform, circleCollider] = view.get<TRAP::TransformComponent, TRAP::CircleCollider2DComponent>(entity);
 
 				const TRAP::Math::Vec3 position = transform.Position + TRAP::Math::Vec3(circleCollider.Offset, -colliderProjectionZ);
+				const f32 rotation = transform.Rotation.z();
 				const TRAP::Math::Vec3 scale = transform.Scale * TRAP::Math::Vec3(circleCollider.Radius * 2.0f);
 
-				const TRAP::Math::Mat4 trans = TRAP::Math::Translate(position) * TRAP::Math::Scale(scale);
+				const TRAP::Math::Mat4 trans = TRAP::Math::Translate(position) * TRAP::Math::Rotate(rotation, {0.0f, 0.0f, 1.0f}) * TRAP::Math::Scale(scale);
 
 				TRAP::Graphics::Renderer2D::DrawCircle(trans, TRAP::Math::Vec4(0.0f, 1.0f, 0.0f, 1.0f), 0.01f);
 			}

--- a/Games/TRAP-Editor/src/TRAPEditorLayer.h
+++ b/Games/TRAP-Editor/src/TRAPEditorLayer.h
@@ -37,6 +37,8 @@ private:
 	// void OnScenePause();
 	// void OnSceneSimulate();
 
+	void OnImGuizmoRender();
+
 	//UI Panels
 	void UIToolbar();
 

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5532,3 +5532,4 @@ SITREP 01/04/2025|25w01b1
     - TRAP-Editor Added support for changing entity position and rotation while in play mode through Gizmo ~<10 mins
     - Entity Added TryGetComponent() function ~<5 mins
     - TRAP-Editor Added support for changing entity scale while in play mode through Gizmo and component UI ~<20 mins
+    - TRAP-Editor Added support for changing Rigidbody2DComponent while in play mode through component UI ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5536,3 +5536,4 @@ SITREP 01/04/2025|25w01b1
     - TRAP-Editor Added support for changing BoxCollider2DComponent while in play mode through component UI ~<10 mins
     - TRAP-Editor Added support for changing CircleCollider2DComponent while in play mode through component UI ~<10 mins
     - TRAP-Editor Fixed CircleCollider2DComponent wrong scale when drawing colliders ~<5 mins
+    - TRAP-Editor Fixed BoxCollider2DComponent Offset property being wrongly displayed when drawing colliders ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5530,3 +5530,4 @@ SITREP 01/04/2025|25w01b1
     - TRAP-Editor Added support for changing entity position and rotation while in play mode through component UI ~<30 mins
     - TRAP-Editor Fixed CircleCollider2DComponent not taking rotation into account when drawing colliders ~<5 mins
     - TRAP-Editor Added support for changing entity position and rotation while in play mode through Gizmo ~<10 mins
+    - Entity Added TryGetComponent() function ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5533,3 +5533,5 @@ SITREP 01/04/2025|25w01b1
     - Entity Added TryGetComponent() function ~<5 mins
     - TRAP-Editor Added support for changing entity scale while in play mode through Gizmo and component UI ~<20 mins
     - TRAP-Editor Added support for changing Rigidbody2DComponent while in play mode through component UI ~<10 mins
+    - TRAP-Editor Added support for changing BoxCollider2DComponent while in play mode through component UI ~<10 mins
+    - TRAP-Editor Added support for changing CircleCollider2DComponent while in play mode through component UI ~<10 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5535,3 +5535,4 @@ SITREP 01/04/2025|25w01b1
     - TRAP-Editor Added support for changing Rigidbody2DComponent while in play mode through component UI ~<10 mins
     - TRAP-Editor Added support for changing BoxCollider2DComponent while in play mode through component UI ~<10 mins
     - TRAP-Editor Added support for changing CircleCollider2DComponent while in play mode through component UI ~<10 mins
+    - TRAP-Editor Fixed CircleCollider2DComponent wrong scale when drawing colliders ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5528,3 +5528,4 @@ SITREP 01/04/2025|25w01b1
     - ImGuiLayer Added TextFmt() function to use fmt::format with ImGui ~<5 mins
     - Replaced ImGui::Text() calls with ImGui::TextFmt() ~<10 mins
     - TRAP-Editor Added support for changing entity position and rotation while in play mode through component UI ~<30 mins
+    - TRAP-Editor Fixed CircleCollider2DComponent not taking rotation into account when drawing colliders ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5537,3 +5537,4 @@ SITREP 01/04/2025|25w01b1
     - TRAP-Editor Added support for changing CircleCollider2DComponent while in play mode through component UI ~<10 mins
     - TRAP-Editor Fixed CircleCollider2DComponent wrong scale when drawing colliders ~<5 mins
     - TRAP-Editor Fixed BoxCollider2DComponent Offset property being wrongly displayed when drawing colliders ~<5 mins
+    - TRAP-Editor Fixed CircleCollider2DComponent Offset property being wrongly displayed when drawing colliders ~<5 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5527,3 +5527,4 @@ SITREP 01/04/2025|25w01b1
     - ImGuiVulkanBackend Changed caching of textures ~<30 mins
     - ImGuiLayer Added TextFmt() function to use fmt::format with ImGui ~<5 mins
     - Replaced ImGui::Text() calls with ImGui::TextFmt() ~<10 mins
+    - TRAP-Editor Added support for changing entity position and rotation while in play mode through component UI ~<30 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5531,3 +5531,4 @@ SITREP 01/04/2025|25w01b1
     - TRAP-Editor Fixed CircleCollider2DComponent not taking rotation into account when drawing colliders ~<5 mins
     - TRAP-Editor Added support for changing entity position and rotation while in play mode through Gizmo ~<10 mins
     - Entity Added TryGetComponent() function ~<5 mins
+    - TRAP-Editor Added support for changing entity scale while in play mode through Gizmo and component UI ~<20 mins

--- a/SITREPS.txt
+++ b/SITREPS.txt
@@ -5529,3 +5529,4 @@ SITREP 01/04/2025|25w01b1
     - Replaced ImGui::Text() calls with ImGui::TextFmt() ~<10 mins
     - TRAP-Editor Added support for changing entity position and rotation while in play mode through component UI ~<30 mins
     - TRAP-Editor Fixed CircleCollider2DComponent not taking rotation into account when drawing colliders ~<5 mins
+    - TRAP-Editor Added support for changing entity position and rotation while in play mode through Gizmo ~<10 mins

--- a/TRAP/src/Scene/Components.h
+++ b/TRAP/src/Scene/Components.h
@@ -208,6 +208,24 @@ namespace TRAP
 				collider2DComp.RuntimeFixture = nullptr;
 			}
 		}
+
+		[[nodiscard]] static constexpr b2BodyType Rigidbody2DTypeToBox2DBody(const TRAP::Rigidbody2DComponent::BodyType bodyType)
+		{
+			switch(bodyType)
+			{
+			case TRAP::Rigidbody2DComponent::BodyType::Static:
+				return b2_staticBody;
+
+			case TRAP::Rigidbody2DComponent::BodyType::Dynamic:
+				return b2_dynamicBody;
+
+			case TRAP::Rigidbody2DComponent::BodyType::Kinematic:
+				return b2_kinematicBody;
+			}
+
+			TRAP_ASSERT(false, "TRAPRigidbody2DTypeToBox2DBody(): Unknown body type!");
+			return b2_staticBody;
+		}
 	};
 
 	struct BoxCollider2DComponent

--- a/TRAP/src/Scene/Components.h
+++ b/TRAP/src/Scene/Components.h
@@ -254,7 +254,7 @@ namespace TRAP
 			}
 
 			b2PolygonShape boxShape{};
-			boxShape.SetAsBox(Size.x() * scale.x(), Size.y() * scale.y());
+			boxShape.SetAsBox(Size.x() * scale.x(), Size.y() * scale.y(), b2Vec2(Offset.x(), Offset.y()), 0.0f);
 
 			b2FixtureDef fixtureDef{};
 			fixtureDef.shape = &boxShape;

--- a/TRAP/src/Scene/Components.h
+++ b/TRAP/src/Scene/Components.h
@@ -6,6 +6,8 @@
 #endif /*_MSC_VER*/
 #include <box2d/b2_body.h>
 #include <box2d/b2_fixture.h>
+#include <box2d/b2_polygon_shape.h>
+#include <box2d/b2_circle_shape.h>
 #ifdef _MSC_VER
 	#pragma warning(pop)
 #endif /*_MSC_VER*/
@@ -153,6 +155,9 @@ namespace TRAP
 	//Physics------------------------------------------------------------------------------------------------------------//
 	//-------------------------------------------------------------------------------------------------------------------//
 
+	struct BoxCollider2DComponent;
+	struct CircleCollider2DComponent;
+
 	struct Rigidbody2DComponent
 	{
 		enum class BodyType : u8 {Static, Dynamic, Kinematic};
@@ -192,6 +197,17 @@ namespace TRAP
 
 			RuntimeBody->SetType(originalBodyType);
 		}
+
+		template<typename T>
+		requires std::same_as<T, BoxCollider2DComponent> || std::same_as<T, CircleCollider2DComponent>
+		void DestroyColliderFixture(T& collider2DComp) const
+		{
+			if((RuntimeBody != nullptr) && (collider2DComp.RuntimeFixture != nullptr))
+			{
+				RuntimeBody->DestroyFixture(collider2DComp.RuntimeFixture);
+				collider2DComp.RuntimeFixture = nullptr;
+			}
+		}
 	};
 
 	struct BoxCollider2DComponent
@@ -210,6 +226,26 @@ namespace TRAP
 
 		/// @brief Constructor.
 		constexpr BoxCollider2DComponent() noexcept = default;
+
+		void CreateFixture(const Rigidbody2DComponent& rigidBody2DComp, const TRAP::Math::Vec2& scale)
+		{
+			if(rigidBody2DComp.RuntimeBody == nullptr)
+			{
+				TRAP_ASSERT(false, "CreateBoxColliderFixture(): rigidBody2DComp.RuntimeBody is nullptr!");
+				return;
+			}
+
+			b2PolygonShape boxShape{};
+			boxShape.SetAsBox(Size.x() * scale.x(), Size.y() * scale.y());
+
+			b2FixtureDef fixtureDef{};
+			fixtureDef.shape = &boxShape;
+			fixtureDef.density = Density;
+			fixtureDef.friction = Friction;
+			fixtureDef.restitution = Restitution;
+			fixtureDef.restitutionThreshold = RestitutionThreshold;
+			RuntimeFixture = rigidBody2DComp.RuntimeBody->CreateFixture(&fixtureDef);
+		}
 	};
 
 	struct CircleCollider2DComponent
@@ -228,6 +264,27 @@ namespace TRAP
 
 		/// @brief Constructor.
 		constexpr CircleCollider2DComponent() noexcept = default;
+
+		void CreateFixture(const Rigidbody2DComponent& rigidBody2DComp, const TRAP::Math::Vec2& scale)
+		{
+			if(rigidBody2DComp.RuntimeBody == nullptr)
+			{
+				TRAP_ASSERT(false, "CreateCircleColliderFixture(): rigidBody2DComp.RuntimeBody is nullptr!");
+				return;
+			}
+
+			b2CircleShape circleShape{};
+			circleShape.m_p.Set(Offset.x(), Offset.y());
+			circleShape.m_radius = TRAP::Math::Max(scale.x(), scale.y()) * Radius;
+
+			b2FixtureDef fixtureDef{};
+			fixtureDef.shape = &circleShape;
+			fixtureDef.density = Density;
+			fixtureDef.friction = Friction;
+			fixtureDef.restitution = Restitution;
+			fixtureDef.restitutionThreshold = RestitutionThreshold;
+			RuntimeFixture = rigidBody2DComp.RuntimeBody->CreateFixture(&fixtureDef);
+		}
 	};
 
 	template<typename... Component>

--- a/TRAP/src/Scene/Components.h
+++ b/TRAP/src/Scene/Components.h
@@ -164,6 +164,34 @@ namespace TRAP
 
 		/// @brief Constructor.
 		constexpr Rigidbody2DComponent() noexcept = default;
+
+		void SetPosition(const TRAP::Math::Vec2& pos) const
+		{
+			if(RuntimeBody == nullptr)
+				return;
+
+			//Temporarily set the rigidbody to static for manual update
+			const b2BodyType originalBodyType = RuntimeBody->GetType();
+			RuntimeBody->SetType(b2BodyType::b2_staticBody);
+
+			RuntimeBody->SetTransform(b2Vec2(pos.x(), pos.y()), RuntimeBody->GetAngle());
+
+			RuntimeBody->SetType(originalBodyType);
+		}
+
+		void SetAngle(const f32 angle) const
+		{
+			if(RuntimeBody == nullptr)
+				return;
+
+			//Temporarily set the rigidbody to static for manual update
+			const b2BodyType originalBodyType = RuntimeBody->GetType();
+			RuntimeBody->SetType(b2BodyType::b2_staticBody);
+
+			RuntimeBody->SetTransform(RuntimeBody->GetPosition(), angle);
+
+			RuntimeBody->SetType(originalBodyType);
+		}
 	};
 
 	struct BoxCollider2DComponent

--- a/TRAP/src/Scene/Entity.h
+++ b/TRAP/src/Scene/Entity.h
@@ -90,6 +90,17 @@ namespace TRAP
 			return m_scene->m_registry.get<T>(m_entityHandle);
 		}
 
+		/// @brief Try to retrieve component T from entity.
+		/// @tparam T Type of component.
+		/// @return Component if exists on entity, nullptr otherwise.
+		template<typename T>
+		[[nodiscard]] T* TryGetComponent() const
+		{
+			ZoneNamedC(__tracy, tracy::Color::Turquoise, (GetTRAPProfileSystems() & ProfileSystems::Scene) != ProfileSystems::None);
+
+			return m_scene->m_registry.try_get<T>(m_entityHandle);
+		}
+
 		/// @brief Query if entity contains the component T.
 		/// @tparam T Type of component.
 		/// @return True if entity contains component T, false otherwise.

--- a/TRAP/src/Scene/Scene.cpp
+++ b/TRAP/src/Scene/Scene.cpp
@@ -22,26 +22,7 @@
 #endif /*_MSC_VER*/
 
 namespace
-{
-	[[nodiscard]] constexpr b2BodyType TRAPRigidbody2DTypeToBox2DBody(const TRAP::Rigidbody2DComponent::BodyType bodyType)
-	{
-		switch(bodyType)
-		{
-		case TRAP::Rigidbody2DComponent::BodyType::Static:
-			return b2_staticBody;
-
-		case TRAP::Rigidbody2DComponent::BodyType::Dynamic:
-			return b2_dynamicBody;
-
-		case TRAP::Rigidbody2DComponent::BodyType::Kinematic:
-			return b2_kinematicBody;
-		}
-
-		TRAP_ASSERT(false, "TRAPRigidbody2DTypeToBox2DBody(): Unknown body type!");
-		return b2_staticBody;
-	}
-
-	//-------------------------------------------------------------------------------------------------------------------//
+{	//-------------------------------------------------------------------------------------------------------------------//
 
 	template<typename... Component>
 	void CopyComponent(entt::registry& dst, const entt::registry& src, const std::unordered_map<entt::entity, entt::entity>& enttMap)
@@ -167,7 +148,7 @@ void TRAP::Scene::OnRuntimeStart()
 		auto& rigidbody2D = entity.GetComponent<Rigidbody2DComponent>();
 
 		b2BodyDef bodyDef{};
-		bodyDef.type = TRAPRigidbody2DTypeToBox2DBody(rigidbody2D.Type);
+		bodyDef.type = Rigidbody2DComponent::Rigidbody2DTypeToBox2DBody(rigidbody2D.Type);
 		bodyDef.position.Set(transform.Position.x(), transform.Position.y());
 		bodyDef.angle = transform.Rotation.z();
 

--- a/TRAP/src/Scene/Scene.cpp
+++ b/TRAP/src/Scene/Scene.cpp
@@ -176,37 +176,10 @@ void TRAP::Scene::OnRuntimeStart()
 		rigidbody2D.RuntimeBody = body;
 
 		if(entity.HasComponent<BoxCollider2DComponent>())
-		{
-			auto& boxCollider2D = entity.GetComponent<BoxCollider2DComponent>();
-
-			b2PolygonShape boxShape{};
-			boxShape.SetAsBox(boxCollider2D.Size.x() * transform.Scale.x(), boxCollider2D.Size.y() * transform.Scale.y());
-
-			b2FixtureDef fixtureDef{};
-			fixtureDef.shape = &boxShape;
-			fixtureDef.density = boxCollider2D.Density;
-			fixtureDef.friction = boxCollider2D.Friction;
-			fixtureDef.restitution = boxCollider2D.Restitution;
-			fixtureDef.restitutionThreshold = boxCollider2D.RestitutionThreshold;
-			boxCollider2D.RuntimeFixture = body->CreateFixture(&fixtureDef);
-		}
+			entity.GetComponent<BoxCollider2DComponent>().CreateFixture(rigidbody2D, TRAP::Math::Vec2{transform.Scale});
 
 		if(entity.HasComponent<CircleCollider2DComponent>())
-		{
-			auto& circleCollider2D = entity.GetComponent<CircleCollider2DComponent>();
-
-			b2CircleShape circleShape{};
-			circleShape.m_p.Set(circleCollider2D.Offset.x(), circleCollider2D.Offset.y());
-			circleShape.m_radius = transform.Scale.x() * circleCollider2D.Radius;
-
-			b2FixtureDef fixtureDef{};
-			fixtureDef.shape = &circleShape;
-			fixtureDef.density = circleCollider2D.Density;
-			fixtureDef.friction = circleCollider2D.Friction;
-			fixtureDef.restitution = circleCollider2D.Restitution;
-			fixtureDef.restitutionThreshold = circleCollider2D.RestitutionThreshold;
-			circleCollider2D.RuntimeFixture = body->CreateFixture(&fixtureDef);
-		}
+			entity.GetComponent<CircleCollider2DComponent>().CreateFixture(rigidbody2D, TRAP::Math::Vec2{transform.Scale});
 	}
 }
 
@@ -225,23 +198,13 @@ void TRAP::Scene::OnRuntimeStop()
 		if(entity.HasComponent<BoxCollider2DComponent>())
 		{
 			auto& boxCollider2D = entity.GetComponent<BoxCollider2DComponent>();
-
-			if((rigidbody2D.RuntimeBody != nullptr) && (boxCollider2D.RuntimeFixture != nullptr))
-			{
-				rigidbody2D.RuntimeBody->DestroyFixture(boxCollider2D.RuntimeFixture);
-				boxCollider2D.RuntimeFixture = nullptr;
-			}
+			rigidbody2D.DestroyColliderFixture(boxCollider2D);
 		}
 
 		if(entity.HasComponent<CircleCollider2DComponent>())
 		{
 			auto& circleCollider2D = entity.GetComponent<CircleCollider2DComponent>();
-
-			if((rigidbody2D.RuntimeBody != nullptr) && (circleCollider2D.RuntimeFixture != nullptr))
-			{
-				rigidbody2D.RuntimeBody->DestroyFixture(circleCollider2D.RuntimeFixture);
-				circleCollider2D.RuntimeFixture = nullptr;
-			}
+			rigidbody2D.DestroyColliderFixture(circleCollider2D);
 		}
 
 		if(rigidbody2D.RuntimeBody != nullptr)


### PR DESCRIPTION
This PR adds support for changing entity component properties while in play mode.
Various Box and Circle collider visualization fixes.